### PR TITLE
Pass priority and TTL to transport

### DIFF
--- a/cmd/really/really.cpp
+++ b/cmd/really/really.cpp
@@ -149,6 +149,7 @@ public:
                                quicr::bytes&& /* e2e_token */)
   {
     // TODO: Authenticate token
+    logger.log(qtransport::LogLevel::info, "Publish intent namespace: " + quicr_namespace.to_hex());
     quicr::PublishIntentResult result{ quicr::messages::Response::Ok, {}, {} };
     server->publishIntentResponse(quicr_namespace, result);
   };
@@ -176,7 +177,7 @@ public:
         continue;
       }
 
-      server->sendNamedObject(dest.subscribe_id, false, datagram);
+      server->sendNamedObject(dest.subscribe_id, false, 1, 200, datagram);
     }
   }
 

--- a/cmd/really/reallyTest.cpp
+++ b/cmd/really/reallyTest.cpp
@@ -141,6 +141,7 @@ main(int argc, char* argv[])
 
   if (data.size() > 0) {
     auto nspace = quicr::Namespace(name, 96);
+    logger.log(qtransport::LogLevel::info, "Publish Intent for name: " + name.to_hex() + " == namespace: " + nspace.to_hex());
     client.publishIntent(pd, nspace, {}, {}, {});
     std::this_thread::sleep_for(std::chrono::seconds(1));
 

--- a/include/quicr/quicr_server.h
+++ b/include/quicr/quicr_server.h
@@ -109,11 +109,17 @@ public:
    * @param subscriber_id            : Subscriber ID to send the message to
    * @param use_reliable_transport   : Indicates the preference for the object's
    *                                   transport, if forwarded.
+   * @param priority                 : Identifies the relative priority of the
+   *                                   current object
+   * @param expiry_age_ms            : Time hint for the object to be in cache
+   *                                   before being purged after reception
    * @param datagram                 : QuicR Publish Datagram to send
    *
    */
   void sendNamedObject(const uint64_t& subscriber_id,
                        bool use_reliable_transport,
+                       uint8_t priority,
+                       uint16_t expiry_age_ms,
                        const messages::PublishDatagram& datagram);
 
 protected:

--- a/include/quicr/quicr_server_session.h
+++ b/include/quicr/quicr_server_session.h
@@ -97,11 +97,17 @@ public:
    * @param subscriber_id            : Subscriber ID to send the message to
    * @param use_reliable_transport   : Indicates the preference for the object's
    *                                   transport, if forwarded.
+   * @param priority                 : Identifies the relative priority of the
+   *                                   current object
+   * @param expiry_age_ms            : Time hint for the object to be in cache
+   *                                   before being purged after reception
    * @param datagram                 : QuicR Publish Datagram to send
    *
    */
   virtual void sendNamedObject(const uint64_t& subscriber_id,
                                bool use_reliable_transport,
+                               uint8_t priority,
+                               uint16_t expiry_age_ms,
                                const messages::PublishDatagram& datagram) = 0;
 };
 

--- a/src/quicr_client_raw_session.cpp
+++ b/src/quicr_client_raw_session.cpp
@@ -369,8 +369,8 @@ QuicRClientRawSession::unsubscribe(const quicr::Namespace& quicr_namespace,
 void
 QuicRClientRawSession::publishNamedObject(
   const quicr::Name& quicr_name,
-  [[maybe_unused]] uint8_t priority,
-  [[maybe_unused]] uint16_t expiry_age_ms,
+  uint8_t priority,
+  uint16_t expiry_age_ms,
   [[maybe_unused]] bool use_reliable_transport,
   bytes&& data)
 {
@@ -413,7 +413,7 @@ QuicRClientRawSession::publishNamedObject(
     // TODO: Add metric for dropping packets due to queue full == qtransport::TransportError::QueueFull
     transport->enqueue(transport_context_id,
                        context.transport_stream_id,
-                       msg.get());
+                       msg.get(), priority, expiry_age_ms);
 
   } else {
     // Fragments required. At this point this only counts whole blocks
@@ -452,7 +452,8 @@ QuicRClientRawSession::publishNamedObject(
 
       if (transport->enqueue(transport_context_id,
                      context.transport_stream_id,
-                             msg.get()) != qtransport::TransportError::None) {
+                             msg.get(),
+                             priority, expiry_age_ms) != qtransport::TransportError::None) {
         std::this_thread::sleep_for(std::chrono::microseconds(100));
         // No point in finishing fragment if one is dropped
         return;
@@ -477,7 +478,8 @@ QuicRClientRawSession::publishNamedObject(
 
         if (transport->enqueue(transport_context_id,
                                context.transport_stream_id,
-                               msg.get()) != qtransport::TransportError::None) {
+                               msg.get(),
+                               priority, expiry_age_ms) != qtransport::TransportError::None) {
         std::this_thread::sleep_for(std::chrono::microseconds(100));
         }
       }

--- a/src/quicr_server.cpp
+++ b/src/quicr_server.cpp
@@ -80,11 +80,15 @@ QuicRServer::subscriptionEnded(const uint64_t& subscriber_id,
 void
 QuicRServer::sendNamedObject(const uint64_t& subscriber_id,
                              bool use_reliable_transport,
+                             uint8_t priority,
+                             uint16_t expiry_age_ms,
                              const messages::PublishDatagram& datagram)
 {
   server_session->sendNamedObject(subscriber_id,
-                             use_reliable_transport,
-                             datagram);
+                                  use_reliable_transport,
+                                  priority,
+                                  expiry_age_ms,
+                                  datagram);
 }
 
 } /* namespace end */

--- a/src/quicr_server_raw_session.cpp
+++ b/src/quicr_server_raw_session.cpp
@@ -186,6 +186,8 @@ void
 QuicRServerRawSession::sendNamedObject(
   const uint64_t& subscriber_id,
   [[maybe_unused]] bool use_reliable_transport,
+  uint8_t priority,
+  uint16_t expiry_age_ms,
   const messages::PublishDatagram& datagram)
 {
   // start populating message to encode
@@ -199,7 +201,8 @@ QuicRServerRawSession::sendNamedObject(
   msg << datagram;
 
   transport->enqueue(
-    context.transport_context_id, context.transport_stream_id, msg.get());
+    context.transport_context_id, context.transport_stream_id,
+    msg.get(), priority, expiry_age_ms);
 }
 
 ///

--- a/src/quicr_server_raw_session.h
+++ b/src/quicr_server_raw_session.h
@@ -120,11 +120,17 @@ public:
    * @param subscriber_id            : Subscriber ID to send the message to
    * @param use_reliable_transport   : Indicates the preference for the object's
    *                                   transport, if forwarded.
+   * @param priority                 : Identifies the relative priority of the
+   *                                   current object
+   * @param expiry_age_ms            : Time hint for the object to be in cache
+   *                                   before being purged after reception
    * @param datagram                 : QuicR Publish Datagram to send
    *
    */
   void sendNamedObject(const uint64_t& subscriber_id,
                        bool use_reliable_transport,
+                       uint8_t priority,
+                       uint16_t expiry_age_ms,
                        const messages::PublishDatagram& datagram) override;
 
 private:

--- a/test/fake_transport.h
+++ b/test/fake_transport.h
@@ -51,7 +51,9 @@ struct FakeTransport : public ITransport
 
   TransportError enqueue(const TransportContextId& /* tcid */,
                          const StreamId& /* sid */,
-                         std::vector<uint8_t>&& bytes)
+                         std::vector<uint8_t>&& bytes,
+                         const uint8_t,
+                         const uint32_t)
   {
     stored_data = std::move(bytes);
     return TransportError::None;


### PR DESCRIPTION
This appears to be working okay with WxQ/new-qmedia, but the TTL will need some adjusting in conf server/manifest. Right now the TTL is set to 50ms, which should be fine, but apparently it's not fine.  It needs to be more like 100ms. The problem appears to be with picoquic taking too long a times that exceeds 50ms.  That's a bit crazy, so we need to dig into that. Regardless, that's unrelated to the pq/time-queue changes here. 