### PR TITLE
Improving speed of MessageBuffer writes.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -44,7 +44,7 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
 
     - name: Benchmark
       run: ${{github.workspace}}/build/benchmark/quicr_benchmark

--- a/benchmark/message_buffer.cpp
+++ b/benchmark/message_buffer.cpp
@@ -71,12 +71,24 @@ MessageBuffer_PushBackNamespace(benchmark::State& state)
 }
 
 void
-MessageBuffer_PushBackVector(benchmark::State& state)
+MessageBuffer_PushBackVector_Copy(benchmark::State& state)
 {
   std::vector<uint8_t> buf(1280);
   std::generate(buf.begin(), buf.end(), std::rand);
 
-  quicr::messages::MessageBuffer buffer(1280 * 1000);
+  quicr::messages::MessageBuffer buffer;
+  for (auto _ : state) {
+    buffer.push(buf);
+  }
+}
+
+void
+MessageBuffer_PushBackVector_Reserved(benchmark::State& state)
+{
+  std::vector<uint8_t> buf(1280);
+  std::generate(buf.begin(), buf.end(), std::rand);
+
+  quicr::messages::MessageBuffer buffer(100000 * buf.size());
   for (auto _ : state) {
     buffer.push(buf);
   }
@@ -89,4 +101,5 @@ BENCHMARK(MessageBuffer_PushBack32);
 BENCHMARK(MessageBuffer_PushBack64);
 BENCHMARK(MessageBuffer_PushBackName);
 BENCHMARK(MessageBuffer_PushBackNamespace);
-BENCHMARK(MessageBuffer_PushBackVector);
+BENCHMARK(MessageBuffer_PushBackVector_Copy);
+BENCHMARK(MessageBuffer_PushBackVector_Reserved);

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -38,16 +38,6 @@ struct Unsubscribe
   quicr::Namespace quicr_namespace;
 };
 
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Unsubscribe& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Unsubscribe& msg);
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Subscribe& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Subscribe& msg);
-
 struct SubscribeResponse
 {
   quicr::Namespace quicr_namespace;
@@ -63,21 +53,11 @@ struct SubscribeResponse
    */
 };
 
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const SubscribeResponse& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, SubscribeResponse& msg);
-
 struct SubscribeEnd
 {
   quicr::Namespace quicr_namespace;
   SubscribeResult::SubscribeStatus reason;
 };
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const SubscribeEnd& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, SubscribeEnd& msg);
 
 /*===========================================================================*/
 // Publish Message Types
@@ -97,13 +77,6 @@ struct PublishIntent
   uintVar_t datagram_capable;
 };
 
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishIntent& msg);
-MessageBuffer&
-operator<<(MessageBuffer& buffer, PublishIntent&& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, PublishIntent& msg);
-
 struct PublishIntentResponse
 {
   MessageType message_type;
@@ -115,11 +88,6 @@ struct PublishIntentResponse
   // *  [Reason Phrase (..)],
 };
 
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishIntentResponse& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, PublishIntentResponse& msg);
-
 struct Header
 {
   uintVar_t media_id;
@@ -130,11 +98,6 @@ struct Header
   uint8_t flags;
 };
 
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Header& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Header& msg);
-
 struct PublishDatagram
 {
   Header header;
@@ -143,25 +106,11 @@ struct PublishDatagram
   std::vector<uint8_t> media_data;
 };
 
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishDatagram& msg);
-MessageBuffer&
-operator<<(MessageBuffer& buffer, PublishDatagram&& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, PublishDatagram& msg);
-
 struct PublishStream
 {
   uintVar_t media_data_length;
   std::vector<uint8_t> media_data;
 };
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishStream& msg);
-MessageBuffer&
-operator<<(MessageBuffer& buffer, PublishStream&& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, PublishStream& msg);
 
 struct PublishIntentEnd
 {
@@ -171,19 +120,6 @@ struct PublishIntentEnd
   //  * relay_token(…),
   std::vector<uint8_t> payload;
 };
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishIntentEnd& msg);
-MessageBuffer&
-operator<<(MessageBuffer& buffer, PublishIntentEnd&& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, PublishIntentEnd& msg);
-
-MessageBuffer&
-operator<<(MessageBuffer& msg, const Namespace& ns);
-MessageBuffer&
-operator>>(MessageBuffer& msg, Namespace& ns);
-
 
 /*===========================================================================*/
 // Fetch Message Types
@@ -196,9 +132,36 @@ struct Fetch
   // TODO - Add authz
 };
 
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Fetch& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Fetch& msg);
+/*===========================================================================*/
+// MessageBuffer operator overloads.
+// TODO: These should ideally be removed eventually.
+/*===========================================================================*/
 
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishIntent& msg);
+MessageBuffer&
+operator<<(MessageBuffer& buffer, PublishIntent&& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, PublishIntent& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishDatagram& msg);
+MessageBuffer&
+operator<<(MessageBuffer& buffer, PublishDatagram&& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, PublishDatagram& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishStream& msg);
+MessageBuffer&
+operator<<(MessageBuffer& buffer, PublishStream&& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, PublishStream& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishIntentEnd& msg);
+MessageBuffer&
+operator<<(MessageBuffer& buffer, PublishIntentEnd&& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, PublishIntentEnd& msg);
 }

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -2,6 +2,7 @@
 
 #include <quicr/message_buffer.h>
 #include <quicr/message_types.h>
+#include <quicr/namespace.h>
 
 #include <string>
 #include <vector>
@@ -14,6 +15,12 @@ namespace quicr::messages {
 /*===========================================================================*/
 // Common
 /*===========================================================================*/
+
+struct MessageTypeException : public MessageBuffer::ReadException
+{
+  MessageTypeException(uint8_t type, MessageType expected_type);
+  MessageTypeException(MessageType type, MessageType expected_type);
+};
 
 uint64_t
 create_transaction_id();

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -21,33 +21,22 @@ uint64_t
 create_transaction_id();
 
 MessageBuffer&
-operator<<(MessageBuffer& msg, const uintVar_t& val);
+operator<<(MessageBuffer& msg, const quicr::uintVar_t& val);
 MessageBuffer&
-operator>>(MessageBuffer& msg, uintVar_t& val);
+operator>>(MessageBuffer& msg, quicr::uintVar_t& val);
+
+MessageBuffer&
+operator<<(MessageBuffer& msg, const std::vector<uint8_t>& val);
+MessageBuffer&
+operator<<(MessageBuffer& msg, std::vector<uint8_t>&& val);
+MessageBuffer&
+operator>>(MessageBuffer& msg, std::vector<uint8_t>& val);
 
 /*===========================================================================*/
 // MessageBuffer operator overloads.
+//
+// Note: These are overloads for message types that contain vectors.
 /*===========================================================================*/
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Unsubscribe& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Unsubscribe& msg);
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Subscribe& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Subscribe& msg);
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const SubscribeResponse& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, SubscribeResponse& msg);
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const SubscribeEnd& msg);
-MessageBuffer&
-operator>>(MessageBuffer& buffer, SubscribeEnd& msg);
 
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishIntent& msg);

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -38,7 +38,7 @@ MessageBuffer&
 operator>>(MessageBuffer& msg, quicr::uintVar_t& val);
 
 MessageBuffer&
-operator<<(MessageBuffer& msg, const std::span<const uint8_t> val);
+operator<<(MessageBuffer& msg, std::span<const uint8_t> val);
 MessageBuffer&
 operator<<(MessageBuffer& msg, std::vector<uint8_t>&& val);
 MessageBuffer&

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -19,6 +19,11 @@ uint64_t
 create_transaction_id();
 
 MessageBuffer&
+operator<<(MessageBuffer& msg, quicr::Namespace value);
+MessageBuffer&
+operator>>(MessageBuffer& msg, quicr::Namespace& value);
+
+MessageBuffer&
 operator<<(MessageBuffer& msg, const quicr::uintVar_t& val);
 MessageBuffer&
 operator>>(MessageBuffer& msg, quicr::uintVar_t& val);

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -4,6 +4,8 @@
 #include <quicr/message_types.h>
 #include <quicr/namespace.h>
 
+#include <ostream>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -16,14 +18,14 @@ namespace quicr::messages {
 // Common
 /*===========================================================================*/
 
-struct MessageTypeException : public MessageBuffer::ReadException
-{
-  MessageTypeException(uint8_t type, MessageType expected_type);
-  MessageTypeException(MessageType type, MessageType expected_type);
-};
-
 uint64_t
 create_transaction_id();
+
+struct MessageTypeException : public MessageBuffer::ReadException
+{
+  MessageTypeException(MessageType type, MessageType expected_type);
+  MessageTypeException(uint8_t type, MessageType expected_type);
+};
 
 MessageBuffer&
 operator<<(MessageBuffer& msg, quicr::Namespace value);
@@ -36,14 +38,14 @@ MessageBuffer&
 operator>>(MessageBuffer& msg, quicr::uintVar_t& val);
 
 MessageBuffer&
-operator<<(MessageBuffer& msg, const std::vector<uint8_t>& val);
+operator<<(MessageBuffer& msg, const std::span<const uint8_t> val);
 MessageBuffer&
 operator<<(MessageBuffer& msg, std::vector<uint8_t>&& val);
 MessageBuffer&
 operator>>(MessageBuffer& msg, std::vector<uint8_t>& val);
 
 /*===========================================================================*/
-// MessageBuffer operator overloads.
+// Subscription message MessageBuffer operator overloads.
 /*===========================================================================*/
 
 MessageBuffer&
@@ -65,6 +67,10 @@ MessageBuffer&
 operator<<(MessageBuffer& buffer, const SubscribeEnd& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, SubscribeEnd& msg);
+
+/*===========================================================================*/
+// Publication message MessageBuffer operator overloads.
+/*===========================================================================*/
 
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishIntent& msg);
@@ -98,6 +104,10 @@ MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishIntentEnd&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishIntentEnd& msg);
+
+/*===========================================================================*/
+// Fetch message MessageBuffer operator overloads.
+/*===========================================================================*/
 
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const Fetch& msg);

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <quicr/message_buffer.h>
+#include <quicr/message_types.h>
 #include <quicr/quicr_common.h>
 #include <quicr_name>
 
-#include <random>
 #include <string>
 #include <vector>
 
@@ -20,122 +20,34 @@ namespace quicr::messages {
 uint64_t
 create_transaction_id();
 
-/*===========================================================================*/
-// Subscribe Message Types
-/*===========================================================================*/
-
-struct Subscribe
-{
-  uint8_t version;
-  uint64_t transaction_id;
-  quicr::Namespace quicr_namespace;
-  SubscribeIntent intent;
-};
-
-struct Unsubscribe
-{
-  uint8_t version;
-  quicr::Namespace quicr_namespace;
-};
-
-struct SubscribeResponse
-{
-  quicr::Namespace quicr_namespace;
-  SubscribeResult::SubscribeStatus response;
-  uint64_t transaction_id;
-  /* TODO:
-   *
-   * signature(32)
-   * [Reason Phrase Length (i)],
-   * [Reason Phrase (..)],
-   * [redirect_relay_url_length(i)],
-   * [redirect_relay_url(…)..]
-   */
-};
-
-struct SubscribeEnd
-{
-  quicr::Namespace quicr_namespace;
-  SubscribeResult::SubscribeStatus reason;
-};
-
-/*===========================================================================*/
-// Publish Message Types
-/*===========================================================================*/
-
-struct PublishIntent
-{
-  MessageType message_type;
-  //  *     origin_url_length(i),
-  //  *     origin_url(…)…,
-  uint64_t transaction_id;
-  quicr::Namespace quicr_namespace;
-  //  *     relay_auth_token_length(i),
-  //  *     relay_token(…),
-  std::vector<uint8_t> payload;
-  uintVar_t media_id;
-  uintVar_t datagram_capable;
-};
-
-struct PublishIntentResponse
-{
-  MessageType message_type;
-  quicr::Namespace quicr_namespace;
-  Response response;
-  uint64_t transaction_id;
-  // *  signature(32)
-  // *  [Reason Phrase Length (i),
-  // *  [Reason Phrase (..)],
-};
-
-struct Header
-{
-  uintVar_t media_id;
-  quicr::Name name;
-  uintVar_t group_id;
-  uintVar_t object_id;
-  uintVar_t offset_and_fin;
-  uint8_t flags;
-};
-
-struct PublishDatagram
-{
-  Header header;
-  MediaType media_type;
-  uintVar_t media_data_length;
-  std::vector<uint8_t> media_data;
-};
-
-struct PublishStream
-{
-  uintVar_t media_data_length;
-  std::vector<uint8_t> media_data;
-};
-
-struct PublishIntentEnd
-{
-  MessageType message_type;
-  quicr::Namespace quicr_namespace;
-  //  * relay_auth_token_length(i),
-  //  * relay_token(…),
-  std::vector<uint8_t> payload;
-};
-
-/*===========================================================================*/
-// Fetch Message Types
-/*===========================================================================*/
-
-struct Fetch
-{
-  uint64_t transaction_id;
-  quicr::Name name; // resource to retrieve
-  // TODO - Add authz
-};
+MessageBuffer&
+operator<<(MessageBuffer& msg, const uintVar_t& val);
+MessageBuffer&
+operator>>(MessageBuffer& msg, uintVar_t& val);
 
 /*===========================================================================*/
 // MessageBuffer operator overloads.
-// TODO: These should ideally be removed eventually.
 /*===========================================================================*/
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Unsubscribe& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Unsubscribe& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Subscribe& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Subscribe& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const SubscribeResponse& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, SubscribeResponse& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const SubscribeEnd& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, SubscribeEnd& msg);
 
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishIntent& msg);

--- a/include/quicr/encode.h
+++ b/include/quicr/encode.h
@@ -2,8 +2,6 @@
 
 #include <quicr/message_buffer.h>
 #include <quicr/message_types.h>
-#include <quicr/quicr_common.h>
-#include <quicr_name>
 
 #include <string>
 #include <vector>
@@ -34,9 +32,27 @@ operator>>(MessageBuffer& msg, std::vector<uint8_t>& val);
 
 /*===========================================================================*/
 // MessageBuffer operator overloads.
-//
-// Note: These are overloads for message types that contain vectors.
 /*===========================================================================*/
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Subscribe& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Subscribe& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Unsubscribe& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Unsubscribe& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const SubscribeResponse& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, SubscribeResponse& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const SubscribeEnd& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, SubscribeEnd& msg);
 
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishIntent& msg);
@@ -44,6 +60,11 @@ MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishIntent&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishIntent& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishIntentResponse& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, PublishIntentResponse& msg);
 
 MessageBuffer&
 operator<<(MessageBuffer& buffer, const PublishDatagram& msg);
@@ -65,4 +86,10 @@ MessageBuffer&
 operator<<(MessageBuffer& buffer, PublishIntentEnd&& msg);
 MessageBuffer&
 operator>>(MessageBuffer& buffer, PublishIntentEnd& msg);
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Fetch& msg);
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Fetch& msg);
+
 }

--- a/include/quicr/message_buffer.h
+++ b/include/quicr/message_buffer.h
@@ -62,6 +62,76 @@ private:
 
 namespace quicr::messages {
 
+namespace {
+
+template<typename T>
+constexpr T
+swap_bytes(T value)
+{
+  if constexpr (std::endian::native == std::endian::big)
+    return value;
+
+  uint8_t* value_ptr = reinterpret_cast<uint8_t*>(&value);
+  for (size_t i = 0; i < sizeof(value) / 2; ++i) {
+    std::swap(value_ptr[i], value_ptr[sizeof(value) - 1 - i]);
+  }
+  return value;
+}
+
+template<>
+constexpr uint16_t
+swap_bytes(uint16_t value)
+{
+  if constexpr (std::endian::native == std::endian::big)
+    return value;
+
+  return ((value >> 8) & 0x00ff) | ((value << 8) & 0xff00);
+}
+
+// clang-format off
+template<>
+constexpr uint32_t
+swap_bytes(uint32_t value)
+{
+  if constexpr (std::endian::native == std::endian::big)
+    return value;
+
+  return ((value >> 24) & 0x000000ff) |
+         ((value >>  8) & 0x0000ff00) |
+         ((value <<  8) & 0x00ff0000) |
+         ((value << 24) & 0xff000000);
+}
+
+template<>
+constexpr uint64_t
+swap_bytes(uint64_t value)
+{
+  if constexpr (std::endian::native == std::endian::big)
+    return value;
+
+  return ((value >> 56) & 0x00000000000000ff) |
+         ((value >> 40) & 0x000000000000ff00) |
+         ((value >> 24) & 0x0000000000ff0000) |
+         ((value >>  8) & 0x00000000ff000000) |
+         ((value <<  8) & 0x000000ff00000000) |
+         ((value << 24) & 0x0000ff0000000000) |
+         ((value << 40) & 0x00ff000000000000) |
+         ((value << 56) & 0xff00000000000000);
+}
+
+template<>
+constexpr quicr::Name
+swap_bytes(quicr::Name value)
+{
+  if constexpr (std::endian::native == std::endian::big)
+    return value;
+
+  constexpr auto ones = ~0x0_name;
+  return ((ones & swap_bytes(uint64_t(value))) << 64) | swap_bytes(uint64_t(value >> 64));
+}
+}
+// clang-format on
+
 /**
  * @brief Defines a buffer that can be sent over transport. Cannot be copied.
  */
@@ -106,7 +176,7 @@ public:
   void push(const std::vector<uint8_t>& data);
   void push(std::vector<uint8_t>&& data);
   void pop(uint16_t len);
-  std::vector<uint8_t> front(uint16_t len);
+  std::vector<uint8_t> front(uint16_t len) const;
   std::vector<uint8_t> pop_front(uint16_t len);
 
   [[deprecated("quicr::message::MessageBuffer::get is deprecated, use take")]]
@@ -118,10 +188,61 @@ public:
   MessageBuffer& operator=(const MessageBuffer& other) = default;
   MessageBuffer& operator=(MessageBuffer&& other) = default;
 
-  template<typename Uint_t>
-  friend MessageBuffer& operator<<(MessageBuffer& msg, Uint_t val);
-  template<typename Uint_t>
-  friend MessageBuffer& operator>>(MessageBuffer& msg, Uint_t& val);
+  friend MessageBuffer& operator<<(MessageBuffer& msg, uint8_t val)
+  {
+    msg.push(val);
+    return msg;
+  }
+
+  template<typename T>
+  friend MessageBuffer& operator<<(MessageBuffer& msg, T val)
+  {
+    val = swap_bytes(val);
+    uint8_t* val_ptr = reinterpret_cast<uint8_t*>(&val);
+
+    const auto length = msg._buffer.size();
+    msg._buffer.resize(length + sizeof(T));
+    std::memcpy(msg._buffer.data() + length, val_ptr, sizeof(T));
+
+    return msg;
+  }
+
+  template<typename T>
+  friend MessageBuffer& operator>>(MessageBuffer& msg, T& val)
+  {
+    if (msg.empty()) {
+      throw MessageBuffer::ReadException(
+        "Cannot read from empty message buffer");
+    }
+
+    if (msg._buffer.size() < sizeof(T)) {
+      throw MessageBuffer::ReadException(
+        "Cannot read mismatched size buffer into size of type: Wanted " +
+        std::to_string(sizeof(T)) + " but buffer only contains " +
+        std::to_string(msg._buffer.size()));
+    }
+
+    auto val_ptr = reinterpret_cast<uint8_t*>(&val);
+    std::memcpy(val_ptr, msg._buffer.data(), sizeof(T));
+
+    msg._buffer.erase(msg._buffer.begin(),
+                      std::next(msg._buffer.begin(), sizeof(T)));
+    val = swap_bytes(val);
+
+    return msg;
+  }
+
+  friend MessageBuffer& operator>>(MessageBuffer& msg, uint8_t& val)
+  {
+    if (msg.empty()) {
+      throw MessageBuffer::ReadException(
+        "Cannot read from empty message buffer");
+    }
+
+    val = msg.front();
+    msg.pop();
+    return msg;
+  }
 
 private:
   std::vector<uint8_t> _buffer;
@@ -138,55 +259,4 @@ MessageBuffer&
 operator<<(MessageBuffer& msg, std::vector<uint8_t>&& val);
 MessageBuffer&
 operator>>(MessageBuffer& msg, std::vector<uint8_t>& val);
-
-namespace {
-// clang-format off
-constexpr uint16_t
-swap_bytes(uint16_t value)
-{
-  if constexpr (std::endian::native == std::endian::big)
-    return value;
-
-  return ((value >> 8) & 0x00ff) | ((value << 8) & 0xff00);
-}
-
-constexpr uint32_t
-swap_bytes(uint32_t value)
-{
-  if constexpr (std::endian::native == std::endian::big)
-    return value;
-
-  return ((value >> 24) & 0x000000ff) |
-         ((value >>  8) & 0x0000ff00) |
-         ((value <<  8) & 0x00ff0000) |
-         ((value << 24) & 0xff000000);
-}
-
-constexpr uint64_t
-swap_bytes(uint64_t value)
-{
-  if constexpr (std::endian::native == std::endian::big)
-    return value;
-
-  return ((value >> 56) & 0x00000000000000ff) |
-         ((value >> 40) & 0x000000000000ff00) |
-         ((value >> 24) & 0x0000000000ff0000) |
-         ((value >>  8) & 0x00000000ff000000) |
-         ((value <<  8) & 0x000000ff00000000) |
-         ((value << 24) & 0x0000ff0000000000) |
-         ((value << 40) & 0x00ff000000000000) |
-         ((value << 56) & 0xff00000000000000);
-}
-
-constexpr quicr::Name
-swap_bytes(quicr::Name value)
-{
-  if constexpr (std::endian::native == std::endian::big)
-    return value;
-
-  return ((~0x0_name & swap_bytes(uint64_t(value))) << 64) | swap_bytes(uint64_t(value >> 64));
-}
-}
-// clang-format on
-
 }

--- a/include/quicr/message_buffer.h
+++ b/include/quicr/message_buffer.h
@@ -110,7 +110,7 @@ private:
 public:
   using value_type = std::uint8_t;
   using buffer_type = std::vector<value_type>;
-  using const_span_type = const std::span<const value_type>;
+  using const_span_type = std::span<const value_type>;
 
   using iterator = buffer_type::iterator;
   using const_iterator = buffer_type::const_iterator;

--- a/include/quicr/message_types.h
+++ b/include/quicr/message_types.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <quicr/quicr_common.h>
+#include <quicr/uvarint.h>
+#include <quicr_name>
+
+#include <string>
+#include <vector>
+
+namespace quicr::messages {
+
+/*===========================================================================*/
+// Subscribe Message Types
+/*===========================================================================*/
+
+struct Subscribe
+{
+  uint8_t version;
+  uint64_t transaction_id;
+  quicr::Namespace quicr_namespace;
+  SubscribeIntent intent;
+};
+
+struct Unsubscribe
+{
+  uint8_t version;
+  quicr::Namespace quicr_namespace;
+};
+
+struct SubscribeResponse
+{
+  quicr::Namespace quicr_namespace;
+  SubscribeResult::SubscribeStatus response;
+  uint64_t transaction_id;
+  /* TODO:
+   *
+   * signature(32)
+   * [Reason Phrase Length (i)],
+   * [Reason Phrase (..)],
+   * [redirect_relay_url_length(i)],
+   * [redirect_relay_url(…)..]
+   */
+};
+
+struct SubscribeEnd
+{
+  quicr::Namespace quicr_namespace;
+  SubscribeResult::SubscribeStatus reason;
+};
+
+/*===========================================================================*/
+// Publish Message Types
+/*===========================================================================*/
+
+struct PublishIntent
+{
+  MessageType message_type;
+  //  *     origin_url_length(i),
+  //  *     origin_url(…)…,
+  uint64_t transaction_id;
+  quicr::Namespace quicr_namespace;
+  //  *     relay_auth_token_length(i),
+  //  *     relay_token(…),
+  std::vector<uint8_t> payload;
+  uintVar_t media_id;
+  uintVar_t datagram_capable;
+};
+
+struct PublishIntentResponse
+{
+  MessageType message_type;
+  quicr::Namespace quicr_namespace;
+  Response response;
+  uint64_t transaction_id;
+  // *  signature(32)
+  // *  [Reason Phrase Length (i),
+  // *  [Reason Phrase (..)],
+};
+
+struct Header
+{
+  uintVar_t media_id;
+  quicr::Name name;
+  uintVar_t group_id;
+  uintVar_t object_id;
+  uintVar_t offset_and_fin;
+  uint8_t flags;
+};
+
+struct PublishDatagram
+{
+  Header header;
+  MediaType media_type;
+  uintVar_t media_data_length;
+  std::vector<uint8_t> media_data;
+};
+
+struct PublishStream
+{
+  uintVar_t media_data_length;
+  std::vector<uint8_t> media_data;
+};
+
+struct PublishIntentEnd
+{
+  MessageType message_type;
+  quicr::Namespace quicr_namespace;
+  //  * relay_auth_token_length(i),
+  //  * relay_token(…),
+  std::vector<uint8_t> payload;
+};
+
+/*===========================================================================*/
+// Fetch Message Types
+/*===========================================================================*/
+
+struct Fetch
+{
+  uint64_t transaction_id;
+  quicr::Name name; // resource to retrieve
+  // TODO - Add authz
+};
+}

--- a/include/quicr/message_types.h
+++ b/include/quicr/message_types.h
@@ -9,6 +9,26 @@
 #include <vector>
 
 namespace quicr::messages {
+/*===========================================================================*/
+// Common
+/*===========================================================================*/
+
+/**
+ * Type of message being sent/received
+ */
+enum class MessageType : uint8_t
+{
+  Unknown,
+  Subscribe,
+  SubscribeResponse,
+  SubscribeEnd,
+  Unsubscribe,
+  Publish,
+  PublishIntent,
+  PublishIntentResponse,
+  PublishIntentEnd,
+  Fetch,
+};
 
 /*===========================================================================*/
 // Subscribe Message Types

--- a/include/quicr/message_types.h
+++ b/include/quicr/message_types.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <quicr/name.h>
+#include <quicr/namespace.h>
 #include <quicr/quicr_common.h>
 #include <quicr/uvarint.h>
-#include <quicr_name>
 
 #include <string>
 #include <vector>

--- a/include/quicr/quicr_common.h
+++ b/include/quicr/quicr_common.h
@@ -27,22 +27,6 @@ using bytes = std::vector<uint8_t>;
 using QUICRContext = uint64_t;
 
 namespace messages {
-/**
- * Type of message being sent/received
- */
-enum class MessageType : uint8_t
-{
-  Unknown,
-  Subscribe,
-  SubscribeResponse,
-  SubscribeEnd,
-  Unsubscribe,
-  Publish,
-  PublishIntent,
-  PublishIntentResponse,
-  PublishIntentEnd,
-  Fetch,
-};
 
 /**
  * Indicates the type of media being sent.
@@ -108,9 +92,9 @@ struct SubscribeResult
     FailedError, // Failed due to relay error, error will be indicated
     FailedAuthz, // Valid credentials, but not authorized
     TimeOut, // Timed out. This happens if failed auth or if there is a failure
-            // with the relay
-            //   Auth failures are timed out because providing status of failed
-            //   auth can be exploited
+             // with the relay
+             //   Auth failures are timed out because providing status of failed
+             //   auth can be exploited
     ConnectionClosed
 
   };

--- a/include/quicr/quicr_server_delegate.h
+++ b/include/quicr/quicr_server_delegate.h
@@ -15,13 +15,14 @@
 
 #pragma once
 
-#include <string>
 #include <cstdint>
+#include <string>
 
-#include "quicr/quicr_common.h"
 #include "quicr/encode.h"
 #include "quicr/message_buffer.h"
-#include "transport/transport.h"
+#include "quicr/quicr_common.h"
+
+#include <transport/transport.h>
 
 namespace quicr {
 

--- a/include/quicr/uvarint.h
+++ b/include/quicr/uvarint.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <exception>
+#include <istream>
+#include <ostream>
 #include <stdint.h>
 
 namespace quicr {
@@ -8,6 +11,8 @@ namespace quicr {
  */
 class uintVar_t
 {
+  static constexpr uint64_t _max_value = 0x1ull << 61;
+
 public:
   uintVar_t() = default;
   constexpr uintVar_t(const uintVar_t&) = default;
@@ -15,9 +20,9 @@ public:
   constexpr uintVar_t(uint64_t value)
     : _value{ value }
   {
-    if (value >= 0x1ull << 61)
-      throw std::runtime_error("Max value cannot be exceeded: " +
-                               std::to_string(0x1ull << 61));
+    if (value >= _max_value)
+      throw std::domain_error("Max value cannot be exceeded: " +
+                              std::to_string(_max_value));
   }
 
   constexpr operator uint64_t() const { return _value; }
@@ -25,9 +30,9 @@ public:
   constexpr uintVar_t& operator=(uintVar_t&&) = default;
   constexpr uintVar_t& operator=(uint64_t value)
   {
-    if (value >= 0x1ull << 61)
-      throw std::runtime_error("Max value cannot be exceeded: " +
-                               std::to_string(0x1ull << 61));
+    if (value >= _max_value)
+      throw std::domain_error("Max value cannot be exceeded: " +
+                              std::to_string(_max_value));
     _value = value;
     return *this;
   }

--- a/include/quicr/uvarint.h
+++ b/include/quicr/uvarint.h
@@ -59,7 +59,7 @@ private:
 };
 
 constexpr uintVar_t
-operator""_uV(uint64_t value)
+operator""_uV(unsigned long long int value)
 {
   return { value };
 }

--- a/include/quicr/uvarint.h
+++ b/include/quicr/uvarint.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace quicr {
+/**
+ * @brief Variable length integer
+ */
+class uintVar_t
+{
+public:
+  uintVar_t() = default;
+  constexpr uintVar_t(const uintVar_t&) = default;
+  constexpr uintVar_t(uintVar_t&&) = default;
+  constexpr uintVar_t(uint64_t value)
+    : _value{ value }
+  {
+    if (value >= 0x1ull << 61)
+      throw std::runtime_error("Max value cannot be exceeded: " +
+                               std::to_string(0x1ull << 61));
+  }
+
+  constexpr operator uint64_t() const { return _value; }
+  constexpr uintVar_t& operator=(const uintVar_t&) = default;
+  constexpr uintVar_t& operator=(uintVar_t&&) = default;
+  constexpr uintVar_t& operator=(uint64_t value)
+  {
+    if (value >= 0x1ull << 61)
+      throw std::runtime_error("Max value cannot be exceeded: " +
+                               std::to_string(0x1ull << 61));
+    _value = value;
+    return *this;
+  }
+
+  constexpr bool operator==(uintVar_t other) { return _value == other._value; }
+  constexpr bool operator!=(uintVar_t other) { return !(*this == other); }
+  constexpr bool operator>(uintVar_t other) { return _value > other._value; }
+  constexpr bool operator>=(uintVar_t other) { return _value >= other._value; }
+  constexpr bool operator<(uintVar_t other) { return _value < other._value; }
+  constexpr bool operator<=(uintVar_t other) { return _value <= other._value; }
+
+  friend std::ostream& operator<<(std::ostream& os, uintVar_t v)
+  {
+    return os << v._value;
+  }
+
+  friend std::istream& operator>>(std::istream& is, uintVar_t v)
+  {
+    return is >> v._value;
+  }
+
+private:
+  uint64_t _value;
+};
+}

--- a/include/quicr/uvarint.h
+++ b/include/quicr/uvarint.h
@@ -57,4 +57,10 @@ public:
 private:
   uint64_t _value;
 };
+
+constexpr uintVar_t
+operator""_uV(uint64_t value)
+{
+  return { value };
+}
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,13 @@ add_library(quicr
             quicr_server.cpp
             quicr_server_raw_session.cpp)
 
+# Suppress external lib warnings
+set_property(GLOBAL PROPERTY RULE_MESSAGES OFF)
+target_compile_options(picotls-core PRIVATE -w)     # TODO Should move to qtransport
+target_compile_options(picotls-openssl PRIVATE -w)  # TODO Should move to qtransport
+target_compile_options(picoquic-core PRIVATE -w)    # TODO Should move to qtransport
+target_compile_options(quicr-transport PRIVATE -w)
+
 target_compile_options(quicr
     PRIVATE
         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Wall>

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -1,13 +1,13 @@
 #include <array>
 #include <ctime>
+#include <random>
 #include <string>
 
 #include <quicr/encode.h>
 
+using quicr::bytes;
+
 namespace quicr::messages {
-/*===========================================================================*/
-// Subscribe Encode & Decode
-/*===========================================================================*/
 
 uint64_t
 create_transaction_id()
@@ -15,6 +15,214 @@ create_transaction_id()
   std::default_random_engine engine(time(0));
   std::uniform_int_distribution distribution(1, 9);
   return distribution(engine);
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& msg, const uintVar_t& v)
+{
+  uint64_t val = v;
+
+  if (val < ((uint64_t)1 << 7)) {
+    msg.push(uint8_t(((val >> 0) & 0x7F)) | 0x00);
+    return msg;
+  }
+
+  if (val < ((uint64_t)1 << 14)) {
+    msg.push(uint8_t(((val >> 8) & 0x3F) | 0x80));
+    msg.push(uint8_t((val >> 0) & 0xFF));
+    return msg;
+  }
+
+  if (val < ((uint64_t)1 << 29)) {
+    msg.push(uint8_t(((val >> 24) & 0x1F) | 0x80 | 0x40));
+    msg.push(uint8_t((val >> 16) & 0xFF));
+    msg.push(uint8_t((val >> 8) & 0xFF));
+    msg.push(uint8_t((val >> 0) & 0xFF));
+    return msg;
+  }
+
+  msg.push(uint8_t(((val >> 56) & 0x0F) | 0x80 | 0x40 | 0x20));
+  msg.push(uint8_t((val >> 48) & 0xFF));
+  msg.push(uint8_t((val >> 40) & 0xFF));
+  msg.push(uint8_t((val >> 32) & 0xFF));
+  msg.push(uint8_t((val >> 24) & 0xFF));
+  msg.push(uint8_t((val >> 16) & 0xFF));
+  msg.push(uint8_t((val >> 8) & 0xFF));
+  msg.push(uint8_t((val >> 0) & 0xFF));
+
+  return msg;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& msg, uintVar_t& v)
+{
+  uint8_t byte[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+  uint8_t first = msg.front();
+
+  if ((first & (0x80)) == 0) {
+    msg >> byte[0];
+    uint8_t val = ((byte[0] & 0x7F) << 0);
+    v = val;
+    return msg;
+  }
+
+  if ((first & (0x80 | 0x40)) == 0x80) {
+    msg >> byte[1];
+    msg >> byte[0];
+    uint16_t val = (((uint16_t)byte[1] & 0x3F) << 8) + ((uint16_t)byte[0] << 0);
+    v = val;
+    return msg;
+  }
+
+  if ((first & (0x80 | 0x40 | 0x20)) == (0x80 | 0x40)) {
+    msg >> byte[3];
+    msg >> byte[2];
+    msg >> byte[1];
+    msg >> byte[0];
+    uint32_t val = ((uint32_t)(byte[3] & 0x1F) << 24) +
+                   ((uint32_t)byte[2] << 16) + ((uint32_t)byte[1] << 8) +
+                   ((uint32_t)byte[0] << 0);
+    v = val;
+    return msg;
+  }
+
+  msg >> byte[7];
+  msg >> byte[6];
+  msg >> byte[5];
+  msg >> byte[4];
+  msg >> byte[3];
+  msg >> byte[2];
+  msg >> byte[1];
+  msg >> byte[0];
+  uint64_t val = ((uint64_t)(byte[7] & 0x0F) << 56) +
+                 ((uint64_t)(byte[6]) << 48) + ((uint64_t)(byte[5]) << 40) +
+                 ((uint64_t)(byte[4]) << 32) + ((uint64_t)(byte[3]) << 24) +
+                 ((uint64_t)(byte[2]) << 16) + ((uint64_t)(byte[1]) << 8) +
+                 ((uint64_t)(byte[0]) << 0);
+  v = val;
+  return msg;
+}
+
+/*===========================================================================*/
+// Subscribe Encode & Decode
+/*===========================================================================*/
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Subscribe& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::Subscribe);
+  buffer << msg.transaction_id;
+  buffer << msg.quicr_namespace;
+  buffer << static_cast<uint8_t>(msg.intent);
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Subscribe& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::Subscribe)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for Subscribe object must "
+      "be MessageType::Subscribe");
+  }
+
+  buffer >> msg.transaction_id;
+  buffer >> msg.quicr_namespace;
+  uint8_t intent = 0;
+  buffer >> intent;
+  msg.intent = static_cast<SubscribeIntent>(intent);
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Unsubscribe& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::Unsubscribe);
+  buffer << msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Unsubscribe& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::Unsubscribe)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for Unsubscribe object "
+      "must be MessageType::Unsubscribe");
+  }
+
+  buffer >> msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const SubscribeResponse& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::SubscribeResponse);
+  buffer << static_cast<uint8_t>(msg.response);
+  buffer << msg.transaction_id;
+  buffer << msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, SubscribeResponse& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::SubscribeResponse)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for SubscribeResponse object "
+      "must be MessageType::SubscribeResponse");
+  }
+
+  uint8_t response;
+  buffer >> response;
+  msg.response = static_cast<SubscribeResult::SubscribeStatus>(response);
+
+  buffer >> msg.transaction_id;
+  buffer >> msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const SubscribeEnd& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::SubscribeEnd);
+  buffer << static_cast<uint8_t>(msg.reason);
+  buffer << msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, SubscribeEnd& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::SubscribeEnd)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for SubscribeEnd object "
+      "must be MessageType::SubscribeEnd");
+  }
+
+  uint8_t reason;
+  buffer >> reason;
+  msg.reason = static_cast<SubscribeResult::SubscribeStatus>(reason);
+
+  buffer >> msg.quicr_namespace;
+
+  return buffer;
 }
 
 /*===========================================================================*/
@@ -57,6 +265,61 @@ operator>>(MessageBuffer& buffer, PublishIntent& msg)
   buffer >> msg.payload;
   buffer >> msg.media_id;
   buffer >> msg.datagram_capable;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishIntentResponse& msg)
+{
+  buffer << static_cast<uint8_t>(msg.message_type);
+  buffer << msg.quicr_namespace;
+  buffer << static_cast<uint8_t>(msg.response);
+  buffer << msg.transaction_id;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, PublishIntentResponse& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  msg.message_type = static_cast<MessageType>(msg_type);
+
+  buffer >> msg.quicr_namespace;
+
+  uint8_t response;
+  buffer >> response;
+  msg.response = static_cast<Response>(response);
+
+  buffer >> msg.transaction_id;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Header& msg)
+{
+  buffer << msg.name;
+  buffer << msg.media_id;
+  buffer << msg.group_id;
+  buffer << msg.object_id;
+  buffer << msg.offset_and_fin;
+  buffer << msg.flags;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Header& msg)
+{
+  buffer >> msg.name;
+  buffer >> msg.media_id;
+  buffer >> msg.group_id;
+  buffer >> msg.object_id;
+  buffer >> msg.offset_and_fin;
+  buffer >> msg.flags;
 
   return buffer;
 }
@@ -173,4 +436,34 @@ operator>>(MessageBuffer& buffer, PublishIntentEnd& msg)
 
   return buffer;
 }
+
+///
+/// Fetch
+///
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Fetch& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::Fetch);
+  buffer << msg.transaction_id;
+  buffer << msg.name;
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Fetch& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::Fetch)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for Fetch object must "
+      "be MessageType::Fetch");
+  }
+
+  buffer >> msg.transaction_id;
+  buffer >> msg.name;
+  return buffer;
+}
+
 }

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -28,14 +28,16 @@ std::map<MessageType, std::string> message_type_name = {
 };
 #undef ENUM_MAPPING_ENTRY
 #undef ENUM_STRINGIFY
+
+std::string to_string(MessageType type) { return message_type_name[type]; }
 }
 // clang-format on
 
 MessageTypeException::MessageTypeException(MessageType type,
                                            MessageType expected_type)
-  : MessageBuffer::ReadException(message_type_name[type] +
-                                 " does not match expected message type: " +
-                                 message_type_name[expected_type])
+  : MessageBuffer::ReadException(
+      to_string(type) +
+      " does not match expected message type: " + to_string(expected_type))
 {
 }
 
@@ -161,7 +163,7 @@ operator>>(MessageBuffer& msg, quicr::uintVar_t& v)
 }
 
 MessageBuffer&
-operator<<(MessageBuffer& msg, const std::vector<uint8_t>& val)
+operator<<(MessageBuffer& msg, const std::span<const uint8_t> val)
 {
   msg << static_cast<uintVar_t>(val.size());
   msg.push(val);

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -22,6 +22,23 @@ create_transaction_id()
 /*===========================================================================*/
 
 MessageBuffer&
+operator<<(MessageBuffer& msg, quicr::Namespace value)
+{
+  return msg << value.name() << value.length();
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& msg, quicr::Namespace& value)
+{
+  quicr::Name name;
+  uint8_t length;
+  msg >> name >> length;
+
+  value = { name, length };
+  return msg;
+}
+
+MessageBuffer&
 operator<<(MessageBuffer& msg, const quicr::uintVar_t& v)
 {
   uint64_t val = v;

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -17,8 +17,12 @@ create_transaction_id()
   return distribution(engine);
 }
 
+/*===========================================================================*/
+// Common Encode & Decode
+/*===========================================================================*/
+
 MessageBuffer&
-operator<<(MessageBuffer& msg, const uintVar_t& v)
+operator<<(MessageBuffer& msg, const quicr::uintVar_t& v)
 {
   uint64_t val = v;
 
@@ -54,7 +58,7 @@ operator<<(MessageBuffer& msg, const uintVar_t& v)
 }
 
 MessageBuffer&
-operator>>(MessageBuffer& msg, uintVar_t& v)
+operator>>(MessageBuffer& msg, quicr::uintVar_t& v)
 {
   uint8_t byte[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
   uint8_t first = msg.front();
@@ -103,126 +107,30 @@ operator>>(MessageBuffer& msg, uintVar_t& v)
   return msg;
 }
 
-/*===========================================================================*/
-// Subscribe Encode & Decode
-/*===========================================================================*/
-
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const Subscribe& msg)
+operator<<(MessageBuffer& msg, const std::vector<uint8_t>& val)
 {
-  buffer << static_cast<uint8_t>(MessageType::Subscribe);
-  buffer << msg.transaction_id;
-  buffer << msg.quicr_namespace;
-  buffer << static_cast<uint8_t>(msg.intent);
-
-  return buffer;
+  msg << static_cast<uintVar_t>(val.size());
+  msg.push(val);
+  return msg;
 }
 
 MessageBuffer&
-operator>>(MessageBuffer& buffer, Subscribe& msg)
+operator<<(MessageBuffer& msg, std::vector<uint8_t>&& val)
 {
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::Subscribe)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for Subscribe object must "
-      "be MessageType::Subscribe");
-  }
-
-  buffer >> msg.transaction_id;
-  buffer >> msg.quicr_namespace;
-  uint8_t intent = 0;
-  buffer >> intent;
-  msg.intent = static_cast<SubscribeIntent>(intent);
-
-  return buffer;
+  msg << static_cast<uintVar_t>(val.size());
+  msg.push(std::move(val));
+  return msg;
 }
 
 MessageBuffer&
-operator<<(MessageBuffer& buffer, const Unsubscribe& msg)
+operator>>(MessageBuffer& msg, std::vector<uint8_t>& val)
 {
-  buffer << static_cast<uint8_t>(MessageType::Unsubscribe);
-  buffer << msg.quicr_namespace;
+  uintVar_t vec_size = 0;
+  msg >> vec_size;
 
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Unsubscribe& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::Unsubscribe)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for Unsubscribe object "
-      "must be MessageType::Unsubscribe");
-  }
-
-  buffer >> msg.quicr_namespace;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const SubscribeResponse& msg)
-{
-  buffer << static_cast<uint8_t>(MessageType::SubscribeResponse);
-  buffer << static_cast<uint8_t>(msg.response);
-  buffer << msg.transaction_id;
-  buffer << msg.quicr_namespace;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, SubscribeResponse& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::SubscribeResponse)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for SubscribeResponse object "
-      "must be MessageType::SubscribeResponse");
-  }
-
-  uint8_t response;
-  buffer >> response;
-  msg.response = static_cast<SubscribeResult::SubscribeStatus>(response);
-
-  buffer >> msg.transaction_id;
-  buffer >> msg.quicr_namespace;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const SubscribeEnd& msg)
-{
-  buffer << static_cast<uint8_t>(MessageType::SubscribeEnd);
-  buffer << static_cast<uint8_t>(msg.reason);
-  buffer << msg.quicr_namespace;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, SubscribeEnd& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::SubscribeEnd)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for SubscribeEnd object "
-      "must be MessageType::SubscribeEnd");
-  }
-
-  uint8_t reason;
-  buffer >> reason;
-  msg.reason = static_cast<SubscribeResult::SubscribeStatus>(reason);
-
-  buffer >> msg.quicr_namespace;
-
-  return buffer;
+  val = msg.pop_front(vec_size);
+  return msg;
 }
 
 /*===========================================================================*/
@@ -265,61 +173,6 @@ operator>>(MessageBuffer& buffer, PublishIntent& msg)
   buffer >> msg.payload;
   buffer >> msg.media_id;
   buffer >> msg.datagram_capable;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishIntentResponse& msg)
-{
-  buffer << static_cast<uint8_t>(msg.message_type);
-  buffer << msg.quicr_namespace;
-  buffer << static_cast<uint8_t>(msg.response);
-  buffer << msg.transaction_id;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, PublishIntentResponse& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  msg.message_type = static_cast<MessageType>(msg_type);
-
-  buffer >> msg.quicr_namespace;
-
-  uint8_t response;
-  buffer >> response;
-  msg.response = static_cast<Response>(response);
-
-  buffer >> msg.transaction_id;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Header& msg)
-{
-  buffer << msg.name;
-  buffer << msg.media_id;
-  buffer << msg.group_id;
-  buffer << msg.object_id;
-  buffer << msg.offset_and_fin;
-  buffer << msg.flags;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Header& msg)
-{
-  buffer >> msg.name;
-  buffer >> msg.media_id;
-  buffer >> msg.group_id;
-  buffer >> msg.object_id;
-  buffer >> msg.offset_and_fin;
-  buffer >> msg.flags;
 
   return buffer;
 }
@@ -434,35 +287,6 @@ operator>>(MessageBuffer& buffer, PublishIntentEnd& msg)
   buffer >> msg.quicr_namespace;
   buffer >> msg.payload;
 
-  return buffer;
-}
-
-///
-/// Fetch
-///
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Fetch& msg)
-{
-  buffer << static_cast<uint8_t>(MessageType::Fetch);
-  buffer << msg.transaction_id;
-  buffer << msg.name;
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Fetch& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::Fetch)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for Fetch object must "
-      "be MessageType::Fetch");
-  }
-
-  buffer >> msg.transaction_id;
-  buffer >> msg.name;
   return buffer;
 }
 

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -134,6 +134,128 @@ operator>>(MessageBuffer& msg, std::vector<uint8_t>& val)
 }
 
 /*===========================================================================*/
+// Subscribe Encode & Decode
+/*===========================================================================*/
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Subscribe& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::Subscribe);
+  buffer << msg.transaction_id;
+  buffer << msg.quicr_namespace;
+  buffer << static_cast<uint8_t>(msg.intent);
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Subscribe& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::Subscribe)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for Subscribe object must "
+      "be MessageType::Subscribe");
+  }
+
+  buffer >> msg.transaction_id;
+  buffer >> msg.quicr_namespace;
+  uint8_t intent = 0;
+  buffer >> intent;
+  msg.intent = static_cast<SubscribeIntent>(intent);
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Unsubscribe& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::Unsubscribe);
+  buffer << msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Unsubscribe& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::Unsubscribe)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for Unsubscribe object "
+      "must be MessageType::Unsubscribe");
+  }
+
+  buffer >> msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const SubscribeResponse& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::SubscribeResponse);
+  buffer << static_cast<uint8_t>(msg.response);
+  buffer << msg.transaction_id;
+  buffer << msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, SubscribeResponse& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::SubscribeResponse)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for SubscribeResponse object "
+      "must be MessageType::SubscribeResponse");
+  }
+
+  uint8_t response;
+  buffer >> response;
+  msg.response = static_cast<SubscribeResult::SubscribeStatus>(response);
+
+  buffer >> msg.transaction_id;
+  buffer >> msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const SubscribeEnd& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::SubscribeEnd);
+  buffer << static_cast<uint8_t>(msg.reason);
+  buffer << msg.quicr_namespace;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, SubscribeEnd& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::SubscribeEnd)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for SubscribeEnd object "
+      "must be MessageType::SubscribeEnd");
+  }
+
+  uint8_t reason;
+  buffer >> reason;
+  msg.reason = static_cast<SubscribeResult::SubscribeStatus>(reason);
+
+  buffer >> msg.quicr_namespace;
+
+  return buffer;
+}
+
+/*===========================================================================*/
 // Publish Encode & Decode
 /*===========================================================================*/
 
@@ -173,6 +295,61 @@ operator>>(MessageBuffer& buffer, PublishIntent& msg)
   buffer >> msg.payload;
   buffer >> msg.media_id;
   buffer >> msg.datagram_capable;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const PublishIntentResponse& msg)
+{
+  buffer << static_cast<uint8_t>(msg.message_type);
+  buffer << msg.quicr_namespace;
+  buffer << static_cast<uint8_t>(msg.response);
+  buffer << msg.transaction_id;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, PublishIntentResponse& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  msg.message_type = static_cast<MessageType>(msg_type);
+
+  buffer >> msg.quicr_namespace;
+
+  uint8_t response;
+  buffer >> response;
+  msg.response = static_cast<Response>(response);
+
+  buffer >> msg.transaction_id;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Header& msg)
+{
+  buffer << msg.name;
+  buffer << msg.media_id;
+  buffer << msg.group_id;
+  buffer << msg.object_id;
+  buffer << msg.offset_and_fin;
+  buffer << msg.flags;
+
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Header& msg)
+{
+  buffer >> msg.name;
+  buffer >> msg.media_id;
+  buffer >> msg.group_id;
+  buffer >> msg.object_id;
+  buffer >> msg.offset_and_fin;
+  buffer >> msg.flags;
 
   return buffer;
 }
@@ -287,6 +464,35 @@ operator>>(MessageBuffer& buffer, PublishIntentEnd& msg)
   buffer >> msg.quicr_namespace;
   buffer >> msg.payload;
 
+  return buffer;
+}
+
+///
+/// Fetch
+///
+
+MessageBuffer&
+operator<<(MessageBuffer& buffer, const Fetch& msg)
+{
+  buffer << static_cast<uint8_t>(MessageType::Fetch);
+  buffer << msg.transaction_id;
+  buffer << msg.name;
+  return buffer;
+}
+
+MessageBuffer&
+operator>>(MessageBuffer& buffer, Fetch& msg)
+{
+  uint8_t msg_type;
+  buffer >> msg_type;
+  if (msg_type != static_cast<uint8_t>(MessageType::Fetch)) {
+    throw MessageBuffer::MessageTypeException(
+      "Message type for Fetch object must "
+      "be MessageType::Fetch");
+  }
+
+  buffer >> msg.transaction_id;
+  buffer >> msg.name;
   return buffer;
 }
 

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -4,8 +4,6 @@
 
 #include <quicr/encode.h>
 
-using quicr::bytes;
-
 namespace quicr::messages {
 /*===========================================================================*/
 // Subscribe Encode & Decode
@@ -17,124 +15,6 @@ create_transaction_id()
   std::default_random_engine engine(time(0));
   std::uniform_int_distribution distribution(1, 9);
   return distribution(engine);
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Subscribe& msg)
-{
-  buffer << static_cast<uint8_t>(MessageType::Subscribe);
-  buffer << msg.transaction_id;
-  buffer << msg.quicr_namespace;
-  buffer << static_cast<uint8_t>(msg.intent);
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Subscribe& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::Subscribe)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for Subscribe object must "
-      "be MessageType::Subscribe");
-  }
-
-  buffer >> msg.transaction_id;
-  buffer >> msg.quicr_namespace;
-  uint8_t intent = 0;
-  buffer >> intent;
-  msg.intent = static_cast<SubscribeIntent>(intent);
-
-  return buffer;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Unsubscribe& msg)
-{
-  buffer << static_cast<uint8_t>(MessageType::Unsubscribe);
-  buffer << msg.quicr_namespace;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Unsubscribe& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::Unsubscribe)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for Unsubscribe object "
-      "must be MessageType::Unsubscribe");
-  }
-
-  buffer >> msg.quicr_namespace;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const SubscribeResponse& msg)
-{
-  buffer << static_cast<uint8_t>(MessageType::SubscribeResponse);
-  buffer << static_cast<uint8_t>(msg.response);
-  buffer << msg.transaction_id;
-  buffer << msg.quicr_namespace;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, SubscribeResponse& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::SubscribeResponse)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for SubscribeResponse object "
-      "must be MessageType::SubscribeResponse");
-  }
-
-  uint8_t response;
-  buffer >> response;
-  msg.response = static_cast<SubscribeResult::SubscribeStatus>(response);
-
-  buffer >> msg.transaction_id;
-  buffer >> msg.quicr_namespace;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const SubscribeEnd& msg)
-{
-  buffer << static_cast<uint8_t>(MessageType::SubscribeEnd);
-  buffer << static_cast<uint8_t>(msg.reason);
-  buffer << msg.quicr_namespace;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, SubscribeEnd& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::SubscribeEnd)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for SubscribeEnd object "
-      "must be MessageType::SubscribeEnd");
-  }
-
-  uint8_t reason;
-  buffer >> reason;
-  msg.reason = static_cast<SubscribeResult::SubscribeStatus>(reason);
-
-  buffer >> msg.quicr_namespace;
-
-  return buffer;
 }
 
 /*===========================================================================*/
@@ -177,61 +57,6 @@ operator>>(MessageBuffer& buffer, PublishIntent& msg)
   buffer >> msg.payload;
   buffer >> msg.media_id;
   buffer >> msg.datagram_capable;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const PublishIntentResponse& msg)
-{
-  buffer << static_cast<uint8_t>(msg.message_type);
-  buffer << msg.quicr_namespace;
-  buffer << static_cast<uint8_t>(msg.response);
-  buffer << msg.transaction_id;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, PublishIntentResponse& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  msg.message_type = static_cast<MessageType>(msg_type);
-
-  buffer >> msg.quicr_namespace;
-
-  uint8_t response;
-  buffer >> response;
-  msg.response = static_cast<Response>(response);
-
-  buffer >> msg.transaction_id;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Header& msg)
-{
-  buffer << msg.name;
-  buffer << msg.media_id;
-  buffer << msg.group_id;
-  buffer << msg.object_id;
-  buffer << msg.offset_and_fin;
-  buffer << msg.flags;
-
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Header& msg)
-{
-  buffer >> msg.name;
-  buffer >> msg.media_id;
-  buffer >> msg.group_id;
-  buffer >> msg.object_id;
-  buffer >> msg.offset_and_fin;
-  buffer >> msg.flags;
 
   return buffer;
 }
@@ -348,53 +173,4 @@ operator>>(MessageBuffer& buffer, PublishIntentEnd& msg)
 
   return buffer;
 }
-
-messages::MessageBuffer&
-operator<<(messages::MessageBuffer& msg, const quicr::Namespace& val)
-{
-  msg << val.name() << val.length();
-  return msg;
 }
-
-messages::MessageBuffer&
-operator>>(messages::MessageBuffer& msg, quicr::Namespace& val)
-{
-  quicr::Name name_mask;
-  uint8_t sig_bits;
-  msg >> name_mask >> sig_bits;
-  val = Namespace{ name_mask, sig_bits };
-
-  return msg;
-}
-
-///
-/// Fetch
-///
-
-MessageBuffer&
-operator<<(MessageBuffer& buffer, const Fetch& msg)
-{
-  buffer << static_cast<uint8_t>(MessageType::Fetch);
-  buffer << msg.transaction_id;
-  buffer << msg.name;
-  return buffer;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& buffer, Fetch& msg)
-{
-  uint8_t msg_type;
-  buffer >> msg_type;
-  if (msg_type != static_cast<uint8_t>(MessageType::Fetch)) {
-    throw MessageBuffer::MessageTypeException(
-      "Message type for Fetch object must "
-      "be MessageType::Fetch");
-  }
-
-  buffer >> msg.transaction_id;
-  buffer >> msg.name;
-  return buffer;
-}
-
-}
-

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -163,7 +163,7 @@ operator>>(MessageBuffer& msg, quicr::uintVar_t& v)
 }
 
 MessageBuffer&
-operator<<(MessageBuffer& msg, const std::span<const uint8_t> val)
+operator<<(MessageBuffer& msg, std::span<const uint8_t> val)
 {
   msg << static_cast<uintVar_t>(val.size());
   msg.push(val);

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -118,29 +118,18 @@ MessageBuffer::to_hex() const
 }
 
 MessageBuffer&
-operator<<(MessageBuffer& msg, const std::vector<uint8_t>& val)
+operator<<(MessageBuffer& msg, quicr::Namespace val)
 {
-  msg << static_cast<uintVar_t>(val.size());
-  msg.push(val);
-  return msg;
+  return msg << val.length() << val.name();
 }
 
 MessageBuffer&
-operator<<(MessageBuffer& msg, std::vector<uint8_t>&& val)
+operator>>(MessageBuffer& msg, quicr::Namespace& val)
 {
-  msg << static_cast<uintVar_t>(val.size());
-  msg.push(std::move(val));
+  quicr::Name name;
+  uint8_t length;
+  msg >> length >> name;
+  val = { name, length };
   return msg;
 }
-
-MessageBuffer&
-operator>>(MessageBuffer& msg, std::vector<uint8_t>& val)
-{
-  uintVar_t vec_size = 0;
-  msg >> vec_size;
-
-  val = msg.pop_front(vec_size);
-  return msg;
-}
-
 } // namespace quicr::messages

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -1,4 +1,5 @@
 #include <quicr/message_buffer.h>
+#include <quicr/uvarint.h>
 
 #include <algorithm>
 #include <array>
@@ -139,92 +140,6 @@ operator>>(MessageBuffer& msg, std::vector<uint8_t>& val)
   msg >> vec_size;
 
   val = msg.pop_front(vec_size);
-  return msg;
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& msg, const uintVar_t& v)
-{
-  uint64_t val = v;
-
-  if (val < ((uint64_t)1 << 7)) {
-    msg.push(uint8_t(((val >> 0) & 0x7F)) | 0x00);
-    return msg;
-  }
-
-  if (val < ((uint64_t)1 << 14)) {
-    msg.push(uint8_t(((val >> 8) & 0x3F) | 0x80));
-    msg.push(uint8_t((val >> 0) & 0xFF));
-    return msg;
-  }
-
-  if (val < ((uint64_t)1 << 29)) {
-    msg.push(uint8_t(((val >> 24) & 0x1F) | 0x80 | 0x40));
-    msg.push(uint8_t((val >> 16) & 0xFF));
-    msg.push(uint8_t((val >> 8) & 0xFF));
-    msg.push(uint8_t((val >> 0) & 0xFF));
-    return msg;
-  }
-
-  msg.push(uint8_t(((val >> 56) & 0x0F) | 0x80 | 0x40 | 0x20));
-  msg.push(uint8_t((val >> 48) & 0xFF));
-  msg.push(uint8_t((val >> 40) & 0xFF));
-  msg.push(uint8_t((val >> 32) & 0xFF));
-  msg.push(uint8_t((val >> 24) & 0xFF));
-  msg.push(uint8_t((val >> 16) & 0xFF));
-  msg.push(uint8_t((val >> 8) & 0xFF));
-  msg.push(uint8_t((val >> 0) & 0xFF));
-
-  return msg;
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& msg, uintVar_t& v)
-{
-  uint8_t byte[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-  uint8_t first = msg.front();
-
-  if ((first & (0x80)) == 0) {
-    msg >> byte[0];
-    uint8_t val = ((byte[0] & 0x7F) << 0);
-    v = val;
-    return msg;
-  }
-
-  if ((first & (0x80 | 0x40)) == 0x80) {
-    msg >> byte[1];
-    msg >> byte[0];
-    uint16_t val = (((uint16_t)byte[1] & 0x3F) << 8) + ((uint16_t)byte[0] << 0);
-    v = val;
-    return msg;
-  }
-
-  if ((first & (0x80 | 0x40 | 0x20)) == (0x80 | 0x40)) {
-    msg >> byte[3];
-    msg >> byte[2];
-    msg >> byte[1];
-    msg >> byte[0];
-    uint32_t val = ((uint32_t)(byte[3] & 0x1F) << 24) +
-                   ((uint32_t)byte[2] << 16) + ((uint32_t)byte[1] << 8) +
-                   ((uint32_t)byte[0] << 0);
-    v = val;
-    return msg;
-  }
-
-  msg >> byte[7];
-  msg >> byte[6];
-  msg >> byte[5];
-  msg >> byte[4];
-  msg >> byte[3];
-  msg >> byte[2];
-  msg >> byte[1];
-  msg >> byte[0];
-  uint64_t val = ((uint64_t)(byte[7] & 0x0F) << 56) +
-                 ((uint64_t)(byte[6]) << 48) + ((uint64_t)(byte[5]) << 40) +
-                 ((uint64_t)(byte[4]) << 32) + ((uint64_t)(byte[3]) << 24) +
-                 ((uint64_t)(byte[2]) << 16) + ((uint64_t)(byte[1]) << 8) +
-                 ((uint64_t)(byte[0]) << 0);
-  v = val;
   return msg;
 }
 

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -110,26 +110,10 @@ std::string
 MessageBuffer::to_hex() const
 {
   std::ostringstream hex;
-  hex << std::hex << std::setfill('0');
+  hex << std::hex << std::setfill('0') << std::uppercase;
   for (const auto& byte : _buffer) {
     hex << std::setw(2) << int(byte);
   }
   return hex.str();
-}
-
-MessageBuffer&
-operator<<(MessageBuffer& msg, quicr::Namespace val)
-{
-  return msg << val.length() << val.name();
-}
-
-MessageBuffer&
-operator>>(MessageBuffer& msg, quicr::Namespace& val)
-{
-  quicr::Name name;
-  uint8_t length;
-  msg >> length >> name;
-  val = { name, length };
-  return msg;
 }
 } // namespace quicr::messages

--- a/src/message_buffer.cpp
+++ b/src/message_buffer.cpp
@@ -98,8 +98,7 @@ MessageBuffer::front(uint16_t length) const
   if (length == size())
     return _buffer;
 
-  const auto& it = begin();
-  return { it, length };
+  return { data(), length };
 }
 
 uint8_t

--- a/src/quicr_client_raw_session.cpp
+++ b/src/quicr_client_raw_session.cpp
@@ -123,9 +123,10 @@ public:
                                "Dropping malformed message: " +
                                  std::string(e.what()));
         return;
-      } catch (const std::exception& /* ex */) {
+      } catch (const std::exception& e) {
         client.log_handler.log(qtransport::LogLevel::info,
-                               "Dropping malformed message");
+                               "Dropping malformed message: " +
+                                 std::string(e.what()));
         return;
       } catch (...) {
         client.log_handler.log(

--- a/src/quicr_client_raw_session.h
+++ b/src/quicr_client_raw_session.h
@@ -15,18 +15,18 @@
 
 #pragma once
 
+#include "quicr/encode.h"
+#include "quicr/message_buffer.h"
+#include "quicr/quicr_client.h"
+#include "quicr/quicr_client_delegate.h"
+#include "quicr/quicr_common.h"
+
+#include <quicr_name>
+#include <transport/transport.h>
+
 #include <map>
 #include <memory>
 #include <string>
-
-#include "quicr/encode.h"
-#include "quicr/message_buffer.h"
-#include "quicr/quicr_common.h"
-#include "transport/transport.h"
-#include "quicr/quicr_client_delegate.h"
-#include "quicr/quicr_client.h"
-
-#include <quicr_name>
 
 namespace quicr {
 
@@ -41,8 +41,8 @@ public:
    *
    * @param relayInfo        : Relay Information to be used by the transport
    * @param tconfig          : Transport configuration
-   * @param logger           : Log handler, used by transport and API for loggings
-   * operations
+   * @param logger           : Log handler, used by transport and API for
+   *                           loggings operations
    */
   QuicRClientRawSession(RelayInfo& relayInfo,
                         qtransport::TransportConfig tconfig,
@@ -182,7 +182,8 @@ public:
                                   bytes&& data) override;
 
   void handle(messages::MessageBuffer&& msg);
-  void removeSubscribeState(bool all, const quicr::Namespace& quicr_namespace,
+  void removeSubscribeState(bool all,
+                            const quicr::Namespace& quicr_namespace,
                             const SubscribeResult::SubscribeStatus& reason);
 
   std::shared_ptr<qtransport::ITransport> transport;
@@ -192,10 +193,10 @@ protected:
   std::mutex session_mutex;
 
   bool notify_pub_fragment(const messages::PublishDatagram& datagram,
-                           const std::weak_ptr<SubscriberDelegate> &delegate,
+                           const std::weak_ptr<SubscriberDelegate>& delegate,
                            const std::map<int, bytes>& frag_map);
   void handle_pub_fragment(messages::PublishDatagram&& datagram,
-                           const std::weak_ptr<SubscriberDelegate> &delegate);
+                           const std::weak_ptr<SubscriberDelegate>& delegate);
 
   qtransport::LogHandler def_log_handler;
 
@@ -243,7 +244,7 @@ protected:
     uint64_t offset{ 0 };
   };
 
-  bool need_pacing { false };
+  bool need_pacing{ false };
   ClientStatus client_status{ ClientStatus::TERMINATED };
   qtransport::TransportContextId transport_context_id;
   namespace_map<std::weak_ptr<SubscriberDelegate>> sub_delegates;
@@ -252,7 +253,6 @@ protected:
   namespace_map<PublishContext> publish_state{};
   std::unique_ptr<qtransport::ITransport::TransportDelegate> transport_delegate;
   uint64_t transport_stream_id{ 0 };
-
 };
 
 }

--- a/src/quicr_server_raw_session.cpp
+++ b/src/quicr_server_raw_session.cpp
@@ -15,16 +15,15 @@
 
 #include "quicr_server_raw_session.h"
 
-#include <quicr/quicr_common.h>
+#include "quicr/encode.h"
+#include "quicr/message_buffer.h"
+#include "quicr/quicr_common.h"
 
 #include <algorithm>
+#include <arpa/inet.h>
 #include <iostream>
-#include <quicr/encode.h>
-#include <quicr/message_buffer.h>
 #include <sstream>
 #include <thread>
-
-#include <arpa/inet.h>
 
 namespace quicr {
 /*

--- a/src/quicr_server_raw_session.h
+++ b/src/quicr_server_raw_session.h
@@ -15,14 +15,15 @@
 
 #pragma once
 
-#include <map>
-#include <mutex>
-
-#include <quicr/encode.h>
-#include <quicr/message_buffer.h>
-#include <transport/transport.h>
+#include "quicr/encode.h"
+#include "quicr/message_buffer.h"
 #include "quicr/quicr_server_delegate.h"
 #include "quicr/quicr_server_session.h"
+
+#include <transport/transport.h>
+
+#include <map>
+#include <mutex>
 
 /*
  * QUICR Server Raw Session Interface
@@ -55,7 +56,6 @@ public:
     qtransport::LogHandler& logger);
 
   ~QuicRServerRawSession() = default;
-
 
   // Transport APIs
   bool is_transport_ready() override;
@@ -148,13 +148,10 @@ private:
       const qtransport::TransportStatus status) override;
     void on_new_connection(const qtransport::TransportContextId& context_id,
                            const qtransport::TransportRemote& remote) override;
-    void on_new_stream(
-      const qtransport::TransportContextId& context_id,
-      const qtransport::StreamId& streamId) override;
+    void on_new_stream(const qtransport::TransportContextId& context_id,
+                       const qtransport::StreamId& streamId) override;
     void on_recv_notify(const qtransport::TransportContextId& context_id,
                         const qtransport::StreamId& streamId) override;
-
-
 
   private:
     QuicRServerRawSession& server;
@@ -166,18 +163,17 @@ public:
   /*
    * Metrics
    */
-  uint64_t recv_data_count { 0 };
-  uint64_t recv_data_count_null { 0 };
-  uint64_t recv_publish { 0 };
-  uint64_t recv_subscribes { 0 };
-  uint64_t recv_unsubscribes { 0 };
-  uint64_t recv_pub_intents { 0 };
-
+  uint64_t recv_data_count{ 0 };
+  uint64_t recv_data_count_null{ 0 };
+  uint64_t recv_publish{ 0 };
+  uint64_t recv_subscribes{ 0 };
+  uint64_t recv_unsubscribes{ 0 };
+  uint64_t recv_pub_intents{ 0 };
 
 private:
-
   std::shared_ptr<qtransport::ITransport> setupTransport(
-    RelayInfo& relayInfo, qtransport::TransportConfig cfg);
+    RelayInfo& relayInfo,
+    qtransport::TransportConfig cfg);
 
   void handle_subscribe(const qtransport::TransportContextId& context_id,
                         const qtransport::StreamId& streamId,

--- a/test/encode.cpp
+++ b/test/encode.cpp
@@ -28,7 +28,7 @@ TEST_CASE("MessageBuffer Decode Exception")
 
 TEST_CASE("Subscribe Message encode/decode")
 {
-  quicr::Namespace qnamespace{ 0x10000000000000002000_name, 125 };
+  quicr::Namespace qnamespace{ 0x10000000000000002000_name, 128 };
 
   Subscribe s{ 1, 0x1000, qnamespace, SubscribeIntent::immediate };
   MessageBuffer buffer;
@@ -65,8 +65,7 @@ TEST_CASE("SubscribeEnd Message encode/decode")
                   .reason = SubscribeResult::SubscribeStatus::Ok };
 
   MessageBuffer buffer;
-  auto s_copy = s;
-  buffer << std::move(s_copy);
+  buffer << s;
   SubscribeEnd s_out;
   CHECK_NOTHROW((buffer >> s_out));
 
@@ -137,8 +136,7 @@ TEST_CASE("Publish Message encode/decode")
 
   PublishDatagram p{ d, MediaType::Text, uintVar_t{ 256 }, data };
   MessageBuffer buffer;
-  auto p_copy = p;
-  buffer << std::move(p_copy);
+  buffer << p;
   PublishDatagram p_out;
   CHECK_NOTHROW((buffer >> p_out));
 
@@ -157,8 +155,7 @@ TEST_CASE("PublishStream Message encode/decode")
 {
   PublishStream ps{ uintVar_t{ 5 }, { 0, 1, 2, 3, 4 } };
   MessageBuffer buffer;
-  auto ps_copy = ps;
-  buffer << std::move(ps_copy);
+  buffer << ps;
   PublishStream ps_out;
   CHECK_NOTHROW((buffer >> ps_out));
 
@@ -172,8 +169,7 @@ TEST_CASE("PublishIntentEnd Message encode/decode")
                         { 12345_name, 0u },
                         { 0, 1, 2, 3, 4 } };
   MessageBuffer buffer;
-  auto pie_copy = pie;
-  buffer << std::move(pie_copy);
+  buffer << pie;
   PublishIntentEnd pie_out;
   CHECK_NOTHROW((buffer >> pie_out));
 

--- a/test/encode.cpp
+++ b/test/encode.cpp
@@ -1,7 +1,14 @@
 #include <doctest/doctest.h>
-#include <memory>
 
 #include <quicr/encode.h>
+#include <quicr/message_buffer.h>
+#include <quicr/quicr_common.h>
+#include <quicr_name>
+
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
 
 using namespace quicr;
 using namespace quicr::messages;
@@ -92,8 +99,7 @@ TEST_CASE("PublishIntent Message encode/decode")
                     qnamespace,           { 0, 1, 2, 3, 4 },
                     uintVar_t{ 0x0100 },  uintVar_t{ 0x0000 } };
   MessageBuffer buffer;
-  auto pi_copy = pi;
-  buffer << std::move(pi_copy);
+  buffer << pi;
   PublishIntent pi_out;
   CHECK_NOTHROW((buffer >> pi_out));
 
@@ -190,20 +196,18 @@ TEST_CASE("VarInt Encode/Decode")
     CHECK_NE(out, uintVar_t{ 0 });
   }
 }
-  ///
-  /// Fetch tests
-  ///
+///
+/// Fetch tests
+///
 
-  TEST_CASE("Fetch Message encode/decode")
-  {
-    quicr::Name qname{ 0x10000000000000002000_name};
+TEST_CASE("Fetch Message encode/decode")
+{
+  Fetch f{ 0x1000, 0x10000000000000002000_name };
+  MessageBuffer buffer;
+  buffer << f;
+  Fetch fout;
+  CHECK_NOTHROW((buffer >> fout));
 
-    Fetch f{ 0x1000, qname};
-    MessageBuffer buffer;
-    buffer << f;
-    Fetch fout;
-    CHECK_NOTHROW((buffer >> fout));
-
-    CHECK_EQ(fout.transaction_id, f.transaction_id);
-    CHECK_EQ(fout.name, f.name);
-  }
+  CHECK_EQ(fout.transaction_id, f.transaction_id);
+  CHECK_EQ(fout.name, f.name);
+}

--- a/test/encode.cpp
+++ b/test/encode.cpp
@@ -119,6 +119,7 @@ TEST_CASE("PublishIntentResponse Message encode/decode")
   CHECK_NOTHROW((buffer >> pir_out));
 
   CHECK_EQ(pir_out.message_type, pir.message_type);
+  CHECK_EQ(pir_out.quicr_namespace, pir.quicr_namespace);
   CHECK_EQ(pir_out.response, pir.response);
   CHECK_EQ(pir_out.transaction_id, pir.transaction_id);
 }
@@ -141,6 +142,7 @@ TEST_CASE("Publish Message encode/decode")
   CHECK_NOTHROW((buffer >> p_out));
 
   CHECK_EQ(p_out.header.media_id, p.header.media_id);
+  CHECK_EQ(p_out.header.name, p.header.name);
   CHECK_EQ(p_out.header.group_id, p.header.group_id);
   CHECK_EQ(p_out.header.object_id, p.header.object_id);
   CHECK_EQ(p_out.header.offset_and_fin, p.header.offset_and_fin);
@@ -181,20 +183,19 @@ TEST_CASE("PublishIntentEnd Message encode/decode")
 TEST_CASE("VarInt Encode/Decode")
 {
   MessageBuffer buffer;
-  std::vector<uintVar_t> values = { uintVar_t{ 128 },
-                                    uintVar_t{ 16384 },
-                                    uintVar_t{ 536870912 } };
+  std::vector<uintVar_t> values = { 128_uV, 16384_uV, 536870912_uV };
   for (const auto& value : values) {
     buffer << value;
     uintVar_t out;
     buffer >> out;
 
-    CHECK_NE(out, uintVar_t{ 0 });
+    CHECK_EQ(out, value);
   }
 }
-///
-/// Fetch tests
-///
+
+/*===========================================================================*/
+// Fetch Tests
+/*===========================================================================*/
 
 TEST_CASE("Fetch Message encode/decode")
 {


### PR DESCRIPTION
Okay, this PR started off as me messing around on my time off. It ended up becoming a pretty large thing, though I think it's made MessageBuffer stronger.

The big parts here are that:
- Name and consequently Namespace are cheaper to write
- Message types and uintVar_t are in their own respective headers
- encode.h has been turned into what's its name implies: a header with encode/decode methods
- MessageBuffer has become more concrete, and hopefully slightly faster
- Span is being used now when passing vectors to write to the buffer, and when access an immutable view/slice of the buffer (to reduce copy)

For sure Name is noticeably cheaper, going from 34-40ns on average to write to the buffer before to 5-8ns on average (all on my machine, GH Actions tells a similar story though)