### PR TITLE
Streams per track

### DIFF
--- a/include/quicr/gap_check.h
+++ b/include/quicr/gap_check.h
@@ -37,13 +37,13 @@ namespace quicr {
                 log_s << (is_tx ? "TX " : "RX ")
                       << "Group gap for name: " << name << " " << group_id
                       << " - " << last_group_id << " = "
-                      << group_id - last_group_id;
+                      << (group_id - last_group_id) - 1;
 
             } else if (group_id == last_group_id && object_id - last_object_id > 1) {
                 log_s << (is_tx ? "TX " : "RX ")
                       << "Object gap for name: " << name << " "
                       << object_id << " - " << last_object_id
-                      << " = " << object_id - last_object_id;
+                      << " = " << (object_id - last_object_id) - 1;
             }
         }
 

--- a/include/quicr/gap_check.h
+++ b/include/quicr/gap_check.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <string>
+#include <sstream>
+#include "encode.h"
+#include "quicr/name.h"
+#include "message_buffer.h"
+
+
+/*
+ * Methods to perform quicr group/object gap checks on received and transmitted objects
+ */
+namespace quicr {
+    /**
+     * @brief constructs a string to log based on namespace group/object id gaps
+     *
+     * @param [in]      is_tx               True if TX, False if RX
+     * @param [in]      name                Name to check
+     * @param [in,out]  last_group_id       Previous group id from last call
+     * @param [in, out] last_object_id      Previous object id from last call
+     *
+     * @returns string messages if there is a gap. Empty message indicates no gap
+     */
+    std::string gap_check(bool is_tx,
+                          const Name& name,
+                          uint64_t& last_group_id,
+                          uint64_t& last_object_id) {
+
+        uint64_t group_id = name.bits<uint64_t>(16, 32);
+        uint64_t object_id = name.bits<uint64_t>(0, 16);
+
+        std::ostringstream log_s;
+
+        if (last_group_id != 0 && last_object_id != 0) {
+
+            if (group_id - last_group_id > 1) {
+                log_s << (is_tx ? "TX " : "RX ")
+                      << "Group gap for name: " << name << " " << group_id
+                      << " - " << last_group_id << " = "
+                      << group_id - last_group_id;
+
+            } else if (object_id - last_object_id > 1) {
+                log_s << (is_tx ? "TX " : "RX ")
+                      << "Object gap for name: " << name << " "
+                      << object_id << " - " << last_object_id
+                      << " = " << object_id - last_object_id;
+            }
+        }
+
+        last_group_id = group_id;
+        last_object_id = object_id;
+
+        return log_s.str();
+    }
+
+} // namespace quicr

--- a/include/quicr/gap_check.h
+++ b/include/quicr/gap_check.h
@@ -39,7 +39,7 @@ namespace quicr {
                       << " - " << last_group_id << " = "
                       << group_id - last_group_id;
 
-            } else if (object_id - last_object_id > 1) {
+            } else if (group_id == last_group_id && object_id - last_object_id > 1) {
                 log_s << (is_tx ? "TX " : "RX ")
                       << "Object gap for name: " << name << " "
                       << object_id << " - " << last_object_id

--- a/include/quicr/quicr_client.h
+++ b/include/quicr/quicr_client.h
@@ -103,7 +103,7 @@ public:
                      const std::string& origin_url,
                      const std::string& auth_token,
                      bytes&& payload,
-                     bool use_reliable_transport);
+                     bool use_reliable_transport=false);
 
   /**
    * @brief Stop publishing on the given QUICR namespace

--- a/include/quicr/quicr_client.h
+++ b/include/quicr/quicr_client.h
@@ -91,17 +91,19 @@ public:
   /**
    * @brief Publish intent to publish on a QUICR Namespace
    *
-   * @param pub_delegate          : Publisher delegate reference
-   * @param quicr_namespace       : Identifies QUICR namespace
-   * @param origin_url            : Origin serving the QUICR Session
-   * @param auth_token            : Auth Token to validate the Subscribe Request
-   * @param payload               : Opaque payload to be forwarded to the Origin
+   * @param pub_delegate            : Publisher delegate reference
+   * @param quicr_namespace         : Identifies QUICR namespace
+   * @param origin_url              : Origin serving the QUICR Session
+   * @param auth_token              : Auth Token to validate the Subscribe Request
+   * @param payload                 : Opaque payload to be forwarded to the Origin
+   * @param use_reliable_transport  : Indicates to use reliable for matching published objects
    */
   bool publishIntent(std::shared_ptr<PublisherDelegate> pub_delegate,
                      const quicr::Namespace& quicr_namespace,
                      const std::string& origin_url,
                      const std::string& auth_token,
-                     bytes&& payload);
+                     bytes&& payload,
+                     bool use_reliable_transport);
 
   /**
    * @brief Stop publishing on the given QUICR namespace

--- a/include/quicr/quicr_client_session.h
+++ b/include/quicr/quicr_client_session.h
@@ -64,17 +64,19 @@ public:
   /**
    * @brief Publish intent to publish on a QUICR Namespace
    *
-   * @param pub_delegate          : Publisher delegate reference
-   * @param quicr_namespace       : Identifies QUICR namespace
-   * @param origin_url            : Origin serving the QUICR Session
-   * @param auth_token            : Auth Token to validate the Subscribe Request
-   * @param payload               : Opaque payload to be forwarded to the Origin
+   * @param pub_delegate            : Publisher delegate reference
+   * @param quicr_namespace         : Identifies QUICR namespace
+   * @param origin_url              : Origin serving the QUICR Session
+   * @param auth_token              : Auth Token to validate the Subscribe Request
+   * @param payload                 : Opaque payload to be forwarded to the Origin
+   * @param use_reliable_transport  : Indicates to use reliable for matching published objects
    */
   virtual bool publishIntent(std::shared_ptr<PublisherDelegate> pub_delegate,
                              const quicr::Namespace& quicr_namespace,
                              const std::string& origin_url,
                              const std::string& auth_token,
-                             bytes&& payload) = 0;
+                             bytes&& payload,
+                             bool use_reliable_transport) = 0;
 
   /**
    * @brief Stop publishing on the given QUICR namespace

--- a/src/quicr_client.cpp
+++ b/src/quicr_client.cpp
@@ -53,10 +53,11 @@ QuicRClient::publishIntent(std::shared_ptr<PublisherDelegate> pub_delegate,
                            const quicr::Namespace& quicr_namespace,
                            const std::string& origin_url,
                            const std::string& auth_token,
-                           bytes&& payload)
+                           bytes&& payload,
+                           bool use_reliable_transport)
 {
   return client_session->publishIntent(
-    pub_delegate, quicr_namespace, origin_url, auth_token, std::move(payload));
+    pub_delegate, quicr_namespace, origin_url, auth_token, std::move(payload), use_reliable_transport);
 }
 
 void

--- a/src/quicr_client_raw_session.h
+++ b/src/quicr_client_raw_session.h
@@ -108,7 +108,7 @@ public:
                      const std::string& origin_url,
                      const std::string& auth_token,
                      bytes&& payload,
-                     bool use_reliable_transport=false) override;
+                     bool use_reliable_transport) override;
 
   /**
    * @brief Stop publishing on the given QUICR namespace

--- a/src/quicr_client_raw_session.h
+++ b/src/quicr_client_raw_session.h
@@ -96,17 +96,19 @@ public:
   /**
    * @brief Publish intent to publish on a QUICR Namespace
    *
-   * @param pub_delegate          : Publisher delegate reference
-   * @param quicr_namespace       : Identifies QUICR namespace
-   * @param origin_url            : Origin serving the QUICR Session
-   * @param auth_token            : Auth Token to validate the Subscribe Request
-   * @param payload               : Opaque payload to be forwarded to the Origin
+   * @param pub_delegate            : Publisher delegate reference
+   * @param quicr_namespace         : Identifies QUICR namespace
+   * @param origin_url              : Origin serving the QUICR Session
+   * @param auth_token              : Auth Token to validate the Subscribe Request
+   * @param payload                 : Opaque payload to be forwarded to the Origin
+   * @param use_reliable_transport  : Indicates to use reliable for matching published objects
    */
   bool publishIntent(std::shared_ptr<PublisherDelegate> pub_delegate,
                      const quicr::Namespace& quicr_namespace,
                      const std::string& origin_url,
                      const std::string& auth_token,
-                     bytes&& payload) override;
+                     bytes&& payload,
+                     bool use_reliable_transport=false) override;
 
   /**
    * @brief Stop publishing on the given QUICR namespace

--- a/src/quicr_client_raw_session.h
+++ b/src/quicr_client_raw_session.h
@@ -246,11 +246,9 @@ protected:
     State state{ State::Unknown };
     qtransport::TransportContextId transport_context_id{ 0 };
     qtransport::StreamId transport_stream_id{ 0 };
-    uint64_t transaction_id{ 0 };
-    uint64_t prev_group_id{ 0 };
-    uint64_t prev_object_id{ 0 };
-    uint64_t group_id{ 0 };
-    uint64_t object_id{ 0 };
+    uint64_t transaction_id {0};
+    uint64_t last_group_id {0};
+    uint64_t last_object_id {0};
   };
 
   // State per publish_intent and related publish
@@ -266,10 +264,8 @@ protected:
     State state{ State::Unknown };
     qtransport::TransportContextId transport_context_id{ 0 };
     qtransport::StreamId transport_stream_id{ 0 };
-    uint64_t prev_group_id{ 0 };
-    uint64_t prev_object_id{ 0 };
-    uint64_t group_id{ 0 };
-    uint64_t object_id{ 0 };
+    uint64_t last_group_id {0};
+    uint64_t last_object_id {0};
     uint64_t offset{ 0 };
   };
 

--- a/src/quicr_server_raw_session.h
+++ b/src/quicr_server_raw_session.h
@@ -222,11 +222,9 @@ private:
 
   struct PublishIntentContext : public Context
   {
-    uint64_t transaction_id{ 0 };
-    uint64_t group_id{ 0 };
-    uint64_t object_id{ 0 };
-    uint64_t prev_group_id{ 0 };
-    uint64_t prev_object_id{ 0 };
+    uint64_t transaction_id {0};
+    uint64_t last_group_id {0};
+    uint64_t last_object_id {0};
   };
 
   ServerDelegate& delegate;


### PR DESCRIPTION
This PR adds reliability per track. Per track is per publish intent and subscription.  The API already had a reliable flag for subscriptions and publish object, but not for publish intent.  This PR adds a reliable boolean (default is false to support existing code) to publish intent API.  

Considering this is per publish intent and subscription, the client can set how it wants to transmit (publish) and receive (subscribe).  Right now, the idea is that we'll set them the same. 

It's also possible to set reliable per published object. The client should ideally match the publish intent setting. The knob is there so that the client can decide if wants to switch back to unreliable for specific objects being published. If the publish intent is unreliable, the published objects will always use unreliable even if the boolean on published object is set to use reliable.  