### PR TITLE
Remove circular Server Delegate dependency

### DIFF
--- a/cmd/really/really.cpp
+++ b/cmd/really/really.cpp
@@ -133,15 +133,6 @@ public:
   {
   }
 
-  /**
-   * Hacky dependency injection.
-   * TODO(trigaux): Remove this once delegate no longer depends on server.
-   */
-  void setServer(std::shared_ptr<quicr::Server> server_in)
-  {
-    server = std::move(server_in);
-  }
-
   quicr::PublishIntentResult onPublishIntent(
     const quicr::Namespace& quicr_namespace,
     const std::string& /* origin_url */,
@@ -168,8 +159,6 @@ public:
     quicr::messages::PublishDatagram&& datagram) override
   {
     auto list = subscribeList.find(datagram.header.name);
-    std::erase_if(list,
-                  [&](const auto& s) { return s.context_id == context_id; });
 
     std::vector<quicr::PublishResult> matching_subscriptions;
     for (const auto remote : list) {
@@ -230,9 +219,6 @@ public:
 private:
   cantina::LoggerPointer logger;
 
-  // TODO(trigaux): Remove this once all above server logic is moved
-  std::shared_ptr<quicr::Server> server;
-
   std::shared_ptr<qtransport::ITransport> transport;
 
   std::set<uint64_t> subscribers = {};
@@ -266,9 +252,6 @@ main()
     auto delegate = std::make_shared<ReallyServerDelegate>(logger);
     auto server =
       std::make_shared<quicr::Server>(relayInfo, tcfg, delegate, logger);
-
-    // TODO(trigaux): Remove this once delegate no longer depends on server.
-    delegate->setServer(server);
 
     server->run();
 

--- a/cmd/really/really.cpp
+++ b/cmd/really/really.cpp
@@ -156,7 +156,7 @@ public:
     const qtransport::TransportContextId& context_id,
     [[maybe_unused]] const qtransport::StreamId& stream_id,
     [[maybe_unused]] bool use_reliable_transport,
-    quicr::messages::PublishDatagram&& datagram) override
+    const quicr::messages::PublishDatagram& datagram) override
   {
     auto list = subscribeList.find(datagram.header.name);
 

--- a/cmd/really/reallyTest.cpp
+++ b/cmd/really/reallyTest.cpp
@@ -21,8 +21,7 @@ public:
     [[maybe_unused]] const quicr::Namespace& quicr_namespace,
     [[maybe_unused]] const quicr::SubscribeResult& result) override
   {
-    logger->info << "onSubscriptionResponse: name: " << quicr_namespace << "/"
-                 << int(quicr_namespace.length())
+    logger->info << "onSubscriptionResponse: name: " << quicr_namespace
                  << " status: " << static_cast<unsigned>(result.status)
                  << std::flush;
   }
@@ -32,8 +31,7 @@ public:
     [[maybe_unused]] const quicr::SubscribeResult::SubscribeStatus& reason)
     override
   {
-    logger->info << "onSubscriptionEnded: name: " << quicr_namespace << "/"
-                 << static_cast<unsigned>(quicr_namespace.length())
+    logger->info << "onSubscriptionEnded: name: " << quicr_namespace
                  << std::flush;
   }
 
@@ -104,28 +102,27 @@ main(int argc, char* argv[])
     std::cerr << std::endl;
     std::cerr << "Usage PUB: reallyTest FF0001 pubData" << std::endl;
     std::cerr << "Usage SUB: reallyTest FF0000" << std::endl;
-    exit(-1); // NOLINT(concurrency-mt-unsafe)
   }
 
   // NOLINTNEXTLINE(concurrency-mt-unsafe)
-  const auto* relayName = getenv("REALLY_RELAY");
-  if (relayName != nullptr) {
+  const char* relayName = getenv("REALLY_RELAY");
+  if (!relayName) {
     relayName = "127.0.0.1";
   }
 
   // NOLINTNEXTLINE(concurrency-mt-unsafe)
-  const auto* portVar = getenv("REALLY_PORT");
+  const char* portVar = getenv("REALLY_PORT");
   int port = 1234;
-  if (portVar != nullptr) {
+  if (portVar) {
     port = atoi(portVar); // NOLINT(cert-err34-c)
   }
 
   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-  const auto name = quicr::Name(std::string(argv[1]));
+  const auto name = quicr::Name(std::string(relayName));
 
   logger->info << "Name = " << name << std::flush;
 
-  auto data = std::vector<uint8_t>{};
+  std::vector<uint8_t> data;
   if (argc == 3) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     const auto data_str = std::string(argv[2]);
@@ -134,12 +131,13 @@ main(int argc, char* argv[])
 
   logger->info << "Connecting to " << relayName << ":" << port << std::flush;
 
-  const auto relay =
-    quicr::RelayInfo{ .hostname = relayName,
-                      .port = uint16_t(port),
-                      .proto = quicr::RelayInfo::Protocol::QUIC };
+  quicr::RelayInfo relay{
+    .hostname = relayName,
+    .port = uint16_t(port),
+    .proto = quicr::RelayInfo::Protocol::QUIC,
+  };
 
-  const auto tcfg = qtransport::TransportConfig{
+  qtransport::TransportConfig tcfg{
     .tls_cert_filename = nullptr,
     .tls_key_filename = nullptr,
   };

--- a/include/quicr/quicr_client.h
+++ b/include/quicr/quicr_client.h
@@ -103,11 +103,8 @@ public:
   /**
    * @brief Stop publishing on the given QUICR namespace
    *
-   * @param quicr_namespace        : Identifies QUICR namespace
-   * @param origin_url             : Origin serving the QUICR Session
-   * @param auth_token             : Auth Token to validate Subscribe Requests
-   * @param payload                : Opaque payload to be forwarded to the
-   * Origin
+   * @param quicr_namespace : Identifies QUICR namespace
+   * @param auth_token      : Auth Token to validate Subscribe Request
    */
   void publishIntentEnd(const quicr::Namespace& quicr_namespace,
                         const std::string& auth_token);
@@ -118,7 +115,7 @@ public:
    * @param subscriber_delegate     : Reference to receive callback for
    *                                  subscriber operations
    * @param quicr_namespace         : Identifies QUICR namespace
-   * @param subscribe_intent        : Subscribe intent to determine the start
+   * @param intent                  : Subscribe intent to determine the start
    *                                  point for serving the matched objects. The
    *                                  application may choose a different intent
    *                                  mode, but must be aware of the effects.
@@ -146,10 +143,9 @@ public:
   /**
    * @brief Stop subscription on the given QUICR namespace
    *
-   * @param quicr_namespace       : Identifies QUICR namespace
-   * @param origin_url            : Origin serving the QUICR Session
-   * @param auth_token            : Auth Token to validate the Subscribe
-   *                                Request
+   * @param quicr_namespace : Identifies QUICR namespace
+   * @param origin_url      : Origin serving the QUICR Session
+   * @param auth_token      : Auth Token to validate the Subscribe Request
    */
   void unsubscribe(const quicr::Namespace& quicr_namespace,
                    const std::string& origin_url,

--- a/include/quicr/quicr_client_delegate.h
+++ b/include/quicr/quicr_client_delegate.h
@@ -17,13 +17,14 @@
 
 #include "quicr/quicr_common.h"
 
-#include <qname>
+#include <quicr/name.h>
+#include <quicr/namespace.h>
 
 #include <cstdint>
 
 namespace quicr {
 
-/*
+/**
  *  QUICR Subscriber delegate callback methods
  */
 class SubscriberDelegate
@@ -35,9 +36,9 @@ public:
   /**
    * @brief Callback for subscription response
    *
-   * @param quicr_namespace: QUICR Namespace associated with the
-   *                         Subscribe Request
-   * @param result         : Result for the subscription
+   * @param quicr_namespace : QUICR Namespace associated with the Subscribe
+   *                          Request
+   * @param result          : Result for the subscription
    *
    * @details This callback will be called when a subscription response
    *          is received, on error, or timeout.
@@ -52,8 +53,8 @@ public:
    *           the stream or subscription timeout or other application
    *           reasons
    *
-   * @param quicr_namespace       : Identifies QUICR namespace
-   * @param reason                : Reason indicating end operation
+   * @param quicr_namespace : Identifies QUICR namespace
+   * @param reason          : Reason indicating end operation
    *
    */
   virtual void onSubscriptionEnded(
@@ -67,7 +68,7 @@ public:
    * @param priority                 : Identifies the relative priority of the
    *                                   current object
    * @param expiry_age_ms            : Time hint for the object to be in cache
-   *                                      before being purged after reception
+   *                                   before being purged after reception
    * @param use_reliable_transport   : Indicates the preference for the object's
    *                                   transport, if forwarded.
    * @param data                     : Opaque payload of the fragment
@@ -94,7 +95,7 @@ public:
    * @param quicr_name               : Identifies the QUICR Name for the object
    * @param priority                 : Identifies the relative priority of the
    *                                   current object
-   * @param best_before              : TTL for the object to be useful for the
+   * @param expiry_age_ms            : TTL for the object to be useful for the
    *                                   application
    * @param use_reliable_transport   : Indicates the preference for the object's
    *                                   transport, if forwarded.
@@ -129,8 +130,8 @@ public:
   /**
    * @brief Callback on the response to the  publish intent
    *
-   * @param quicr_namespace       : Identifies QUICR namespace
-   * @param result                : Status of Publish Intent
+   * @param quicr_namespace : Identifies QUICR namespace
+   * @param result          : Status of Publish Intent
    *
    * @details Entities processing the Subscribe Request MUST validate the
    *          request

--- a/include/quicr/quicr_client_session.h
+++ b/include/quicr/quicr_client_session.h
@@ -63,11 +63,11 @@ public:
    * @param quicr_namespace         : Identifies QUICR namespace
    * @param origin_url              : Origin serving the QUICR Session
    * @param auth_token              : Auth Token to validate the Subscribe
-   * Request
+   *                                  Request
    * @param payload                 : Opaque payload to be forwarded to the
-   * Origin
+   *                                  Origin
    * @param use_reliable_transport  : Indicates to use reliable for matching
-   * published objects
+   *                                  published objects
    */
   virtual bool publishIntent(std::shared_ptr<PublisherDelegate> pub_delegate,
                              const quicr::Namespace& quicr_namespace,
@@ -79,12 +79,8 @@ public:
   /**
    * @brief Stop publishing on the given QUICR namespace
    *
-   * @param quicr_namespace        : Identifies QUICR namespace
-   * @param origin_url             : Origin serving the QUICR Session
-   * @param auth_token             : Auth Token to valiadate the Subscribe
-   * Request
-   * @param payload                : Opaque payload to be forwarded to the
-   * Origin
+   * @param quicr_namespace : Identifies QUICR namespace
+   * @param auth_token      : Auth Token to validate the Subscribe Request
    */
   virtual void publishIntentEnd(const quicr::Namespace& quicr_namespace,
                                 const std::string& auth_token) = 0;
@@ -92,24 +88,26 @@ public:
   /**
    * @brief Perform subscription operation a given QUICR namespace
    *
-   * @param subscriber_delegate   : Reference to receive callback for subscriber
-   *                                ooperations
-   * @param quicr_namespace       : Identifies QUICR namespace
-   * @param subscribe_intent      : Subscribe intent to determine the start
-   * point for serving the matched objects. The application may choose a
-   * different intent mode, but must be aware of the effects.
-   * @param origin_url            : Origin serving the QUICR Session
-   * @param use_reliable_transport: Reliable or Unreliable transport
-   * @param auth_token            : Auth Token to validate the Subscribe Request
-   * @param e2e_token              : Opaque token to be forwarded to the Origin
+   * @param subscriber_delegate     : Reference to receive callback for
+   *                                  subscriber operations
+   * @param quicr_namespace         : Identifies QUICR namespace
+   * @param intent                  : Subscribe intent to determine the start
+   *                                  point for serving the matched objects. The
+   *                                  application may choose a different intent
+   *                                  mode, but must be aware of the effects.
+   * @param origin_url              : Origin serving the QUICR Session
+   * @param use_reliable_transport  : Reliable or Unreliable transport
+   * @param auth_token              : Auth Token to validate the Subscribe
+   *                                  Request
+   * @param e2e_token               : Opaque token to be forwarded to the Origin
    *
    * @details Entities processing the Subscribe Request MUST validate the
-   * request against the token, verify if the Origin specified in the origin_url
-   *          is trusted and forward the request to the next hop Relay for that
-   *          Origin or to the Origin (if it is the next hop) unless the entity
-   *          itself the Origin server.
-   *          It is expected for the Relays to store the subscriber state
-   * mapping the subscribe context, namespaces and other relation information.
+   *          request against the token, verify if the Origin specified in the
+   *          origin_url is trusted and forward the request to the next hop
+   *          Relay for that Origin or to the Origin (if it is the next hop)
+   *          unless the entity itself the Origin server. It is expected for the
+   *          Relays to store the subscriber state mapping the subscribe
+   *          context, namespaces and other relation information.
    */
   virtual void subscribe(
     std::shared_ptr<SubscriberDelegate> subscriber_delegate,
@@ -158,7 +156,7 @@ public:
    * @param priority                 : Identifies the relative priority of the
    *                                   current object
    * @param expiry_age_ms            : Time hint for the object to be in cache
-                                       before being purged after reception
+   *                                   before being purged after reception
    * @param use_reliable_transport   : Indicates the preference for the object's
    *                                   transport, if forwarded.
    * @param offset                   : Current fragment offset

--- a/include/quicr/quicr_common.h
+++ b/include/quicr/quicr_common.h
@@ -76,6 +76,13 @@ struct RelayInfo
   Protocol proto;       // Transport protocol to use
 };
 
+struct PublishResult
+{
+  std::uint64_t subscription_id;
+  std::uint8_t priority;
+  std::uint16_t expiry_ms;
+};
+
 /**
  * SubscribeResult defines the result of a subscription request
  */

--- a/include/quicr/quicr_server_delegate.h
+++ b/include/quicr/quicr_server_delegate.h
@@ -95,7 +95,7 @@ public:
     const qtransport::TransportContextId& context_id,
     const qtransport::StreamId& stream_id,
     bool use_reliable_transport,
-    messages::PublishDatagram&& datagram) = 0;
+    const messages::PublishDatagram& datagram) = 0;
 
   /**
    * @brief Report arrival of subscribe request for a QUICR Namespace

--- a/include/quicr/quicr_server_delegate.h
+++ b/include/quicr/quicr_server_delegate.h
@@ -55,11 +55,12 @@ public:
    *           It is expected for the Relays to store the publisher state
    * mapping the namespaces and other relation information.
    */
-  virtual void onPublishIntent(const quicr::Namespace& quicr_name,
-                               const std::string& origin_url,
-                               bool use_reliable_transport,
-                               const std::string& auth_token,
-                               bytes&& e2e_token) = 0;
+  virtual PublishIntentResult onPublishIntent(
+    const quicr::Namespace& quicr_name,
+    const std::string& origin_url,
+    bool use_reliable_transport,
+    const std::string& auth_token,
+    bytes&& e2e_token) = 0;
 
   /**
    * @brief Reports intent to publish for name is ended.
@@ -90,7 +91,7 @@ public:
    *         callbacks will be called. The delegate implementation
    *         shall decide the right callback for their usage.
    */
-  virtual void onPublisherObject(
+  virtual std::vector<PublishResult> onPublisherObject(
     const qtransport::TransportContextId& context_id,
     const qtransport::StreamId& stream_id,
     bool use_reliable_transport,
@@ -123,15 +124,16 @@ public:
    * @param payload               : Opaque payload to be forwarded to the Origin
    *
    */
-  virtual void onSubscribe(const quicr::Namespace& quicr_namespace,
-                           const uint64_t& subscriber_id,
-                           const qtransport::TransportContextId& context_id,
-                           const qtransport::StreamId& stream_id,
-                           const SubscribeIntent subscribe_intent,
-                           const std::string& origin_url,
-                           bool use_reliable_transport,
-                           const std::string& auth_token,
-                           bytes&& data) = 0;
+  virtual SubscribeResult onSubscribe(
+    const quicr::Namespace& quicr_namespace,
+    const uint64_t& subscriber_id,
+    const qtransport::TransportContextId& context_id,
+    const qtransport::StreamId& stream_id,
+    const SubscribeIntent subscribe_intent,
+    const std::string& origin_url,
+    bool use_reliable_transport,
+    const std::string& auth_token,
+    bytes&& data) = 0;
 
   /**
    * @brief Unsubscribe callback method

--- a/src/quicr_server_raw_session.cpp
+++ b/src/quicr_server_raw_session.cpp
@@ -250,10 +250,10 @@ ServerRawSession::handle_unsubscribe(
   const qtransport::StreamId& /* streamId */,
   messages::MessageBuffer&& msg)
 {
-  messages::Unsubscribe unsub;
+  messages::Unsubscribe unsub{};
   msg >> unsub;
 
-  std::lock_guard<std::mutex> _(session_mutex);
+  const std::lock_guard<std::mutex> _(session_mutex);
 
   // TODO(trigaux): Add authentication
 
@@ -306,7 +306,7 @@ ServerRawSession::handle_publish(
   }
 
   const auto& results = delegate->onPublisherObject(
-    context_id, streamId, false, std::move(datagram));
+    context_id, streamId, false, datagram);
 
   for (const auto& publish_result : results) {
     sendNamedObject(publish_result.subscription_id,
@@ -337,15 +337,16 @@ ServerRawSession::handle_publish_intent(
 
     publish_namespaces[intent.quicr_namespace] = context;
   } else {
-    auto state = publish_namespaces[intent.quicr_namespace].state;
-    switch (state) {
-      case PublishIntentContext::State::Pending:
-        [[fallthrough]];
-      case PublishIntentContext::State::Ready:
-        [[fallthrough]];
-      default:
-        break;
-    }
+    // TODO(trigaux): Figure out if we want to do something on these states.
+    // auto state = publish_namespaces[intent.quicr_namespace].state;
+    // switch (state) {
+    //   case PublishIntentContext::State::Pending:
+    //     [[fallthrough]];
+    //   case PublishIntentContext::State::Ready:
+    //     [[fallthrough]];
+    //   default:
+    //     break;
+    // }
   }
 
   auto result = delegate->onPublishIntent(intent.quicr_namespace,

--- a/test/quicr_server.cpp
+++ b/test/quicr_server.cpp
@@ -69,7 +69,7 @@ class TestServerDelegate : public ServerDelegate
     [[maybe_unused]] const qtransport::TransportContextId& context_id,
     [[maybe_unused]] const qtransport::StreamId& stream_id,
     [[maybe_unused]] bool use_reliable_transport,
-    [[maybe_unused]] messages::PublishDatagram&& datagram) override
+    [[maybe_unused]] const messages::PublishDatagram& datagram) override
   {
     return {};
   }

--- a/test/quicr_server.cpp
+++ b/test/quicr_server.cpp
@@ -49,12 +49,14 @@ struct TestSubscriberDelegate : public SubscriberDelegate
 class TestServerDelegate : public ServerDelegate
 {
 
-  void onPublishIntent(const quicr::Namespace& /* quicr_name */,
-                       const std::string& /* origin_url */,
-                       bool /* use_reliable_transport */,
-                       const std::string& /* auth_token */,
-                       bytes&& /* e2e_token */) override
+  quicr::PublishIntentResult onPublishIntent(
+    const quicr::Namespace& /* quicr_name */,
+    const std::string& /* origin_url */,
+    bool /* use_reliable_transport */,
+    const std::string& /* auth_token */,
+    bytes&& /* e2e_token */) override
   {
+    return {};
   }
 
   void onPublishIntentEnd(const quicr::Namespace& /* quicr_namespace */,
@@ -63,24 +65,27 @@ class TestServerDelegate : public ServerDelegate
   {
   }
 
-  void onPublisherObject(
+  std::vector<quicr::PublishResult> onPublisherObject(
     [[maybe_unused]] const qtransport::TransportContextId& context_id,
     [[maybe_unused]] const qtransport::StreamId& stream_id,
     [[maybe_unused]] bool use_reliable_transport,
     [[maybe_unused]] messages::PublishDatagram&& datagram) override
   {
+    return {};
   }
 
-  void onSubscribe(const quicr::Namespace& /* quicr_namespace */,
-                   const uint64_t& /* subscriber_id */,
-                   const qtransport::TransportContextId& /* context_id */,
-                   const qtransport::TransportContextId& /*stream_id */,
-                   const SubscribeIntent /* subscribe_intent */,
-                   const std::string& /* origin_url */,
-                   bool /* use_reliable_transport */,
-                   const std::string& /* auth_token */,
-                   bytes&& /* data */) override
+  SubscribeResult onSubscribe(
+    const quicr::Namespace& /* quicr_namespace */,
+    const uint64_t& /* subscriber_id */,
+    const qtransport::TransportContextId& /* context_id */,
+    const qtransport::TransportContextId& /*stream_id */,
+    const SubscribeIntent /* subscribe_intent */,
+    const std::string& /* origin_url */,
+    bool /* use_reliable_transport */,
+    const std::string& /* auth_token */,
+    bytes&& /* data */) override
   {
+    return {};
   }
 
   void onUnsubscribe(const quicr::Namespace& /* quicr_namespace */,


### PR DESCRIPTION
A bit of an API change, this affects server only. The work here was to address the TODOs in really (which in effect affects LAPS) which were to remove the circular dependency between the server and server delegate. Basically, the changes just pull any calls to server methods out of the delegate, so that mechanics of responding are not the responsibility of the application.