### PR TITLE
Fix the polarity of a containment check

### DIFF
--- a/src/quicr_server_raw_session.cpp
+++ b/src/quicr_server_raw_session.cpp
@@ -309,7 +309,7 @@ ServerRawSession::handle_publish_intent(
   messages::PublishIntent intent;
   msg >> intent;
 
-  if (publish_namespaces.contains(intent.quicr_namespace)) {
+  if (!publish_namespaces.contains(intent.quicr_namespace)) {
     PublishIntentContext context;
     context.state = PublishIntentContext::State::Pending;
     context.transport_context_id = context_id;


### PR DESCRIPTION
This change was probably introduced in #81, which changed a lot of `.count()` checks to `.contains()` checks -- and had no testing to verify that we got the polarity right in changing them.  Note that the library is broken right now: The `publish_namespaces` map is never populated, so all published objects are dropped.