### PR TITLE
Offsite changes, add priority end-to-end and update transport 

### DIFF
--- a/include/quicr/message_types.h
+++ b/include/quicr/message_types.h
@@ -107,7 +107,7 @@ struct Header
   uintVar_t group_id;
   uintVar_t object_id;
   uintVar_t offset_and_fin;
-  uint8_t flags;
+  uint8_t priority;
 };
 
 struct PublishDatagram

--- a/src/encode.cpp
+++ b/src/encode.cpp
@@ -386,7 +386,7 @@ operator<<(MessageBuffer& buffer, const Header& msg)
   buffer << msg.group_id;
   buffer << msg.object_id;
   buffer << msg.offset_and_fin;
-  buffer << msg.flags;
+  buffer << msg.priority;
 
   return buffer;
 }
@@ -399,7 +399,7 @@ operator>>(MessageBuffer& buffer, Header& msg)
   buffer >> msg.group_id;
   buffer >> msg.object_id;
   buffer >> msg.offset_and_fin;
-  buffer >> msg.flags;
+  buffer >> msg.priority;
 
   return buffer;
 }

--- a/src/quicr_client_raw_session.cpp
+++ b/src/quicr_client_raw_session.cpp
@@ -435,7 +435,7 @@ ClientRawSession::publishNamedObject(const quicr::Name& quicr_name,
   datagram.header.media_id = context.transport_stream_id;
   datagram.header.group_id = context.last_group_id;
   datagram.header.object_id = context.last_object_id;
-  datagram.header.flags = 0x0;
+  datagram.header.priority = priority;
   datagram.header.offset_and_fin = 1ULL;
   datagram.media_type = messages::MediaType::RealtimeMedia;
 

--- a/src/quicr_server_raw_session.cpp
+++ b/src/quicr_server_raw_session.cpp
@@ -446,7 +446,7 @@ ServerRawSession::TransportDelegate::on_recv_notify(
   for (int i = 0; i < 150; i++) {
     auto data = server.transport->dequeue(context_id, streamId);
 
-    if (data.has_value()) {
+    if (data.has_value() && data.value().size() > 0) {
       server.recv_data_count++;
       try {
         auto msg_type = static_cast<messages::MessageType>(data->front());

--- a/test/encode.cpp
+++ b/test/encode.cpp
@@ -191,7 +191,7 @@ TEST_CASE("Publish Message encode/decode")
   CHECK_EQ(p_out.header.group_id, p.header.group_id);
   CHECK_EQ(p_out.header.object_id, p.header.object_id);
   CHECK_EQ(p_out.header.offset_and_fin, p.header.offset_and_fin);
-  CHECK_EQ(p_out.header.flags, p.header.flags);
+  CHECK_EQ(p_out.header.priority, p.header.priority);
   CHECK_EQ(p_out.media_type, p.media_type);
   CHECK_EQ(p_out.media_data_length, p.media_data_length);
   CHECK_EQ(p_out.media_data, p.media_data);


### PR DESCRIPTION
* Renames quicr header `flags` to `priority`
* Sets quicr header priority correctly so that it's sent to remote/relay
* Other fixes based on offsite findings