### PR TITLE
Implements transport API support of per object pacing

### DIFF
--- a/src/quicr_client_raw_session.cpp
+++ b/src/quicr_client_raw_session.cpp
@@ -700,7 +700,7 @@ ClientRawSession::notify_pub_fragment(
   }
 
   const auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - fragment.start_time).count();
-  if (duration_ms > 20) {
+  if (duration_ms > 22) {
       logger->debug << "Fragment complete name: " << datagram.header.name
                     << " duration_ms: " << duration_ms
                     << std::flush;

--- a/src/quicr_client_raw_session.cpp
+++ b/src/quicr_client_raw_session.cpp
@@ -701,9 +701,9 @@ ClientRawSession::notify_pub_fragment(
 
   const auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - fragment.start_time).count();
   if (duration_ms > 2) {
-      logger->info << "Fragment complete name: " << datagram.header.name
-                   << " duration_ms: " << duration_ms
-                   << std::flush;
+      logger->debug << "Fragment complete name: " << datagram.header.name
+                    << " duration_ms: " << duration_ms
+                    << std::flush;
   }
 
   delegate->onSubscribedObject(

--- a/src/quicr_client_raw_session.cpp
+++ b/src/quicr_client_raw_session.cpp
@@ -700,7 +700,7 @@ ClientRawSession::notify_pub_fragment(
   }
 
   const auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - fragment.start_time).count();
-  if (duration_ms > 2) {
+  if (duration_ms > 20) {
       logger->debug << "Fragment complete name: " << datagram.header.name
                     << " duration_ms: " << duration_ms
                     << std::flush;

--- a/src/quicr_client_raw_session.cpp
+++ b/src/quicr_client_raw_session.cpp
@@ -23,6 +23,7 @@
 #include "quicr/quicr_common.h"
 
 #include <chrono>
+#include <iterator>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -236,11 +237,7 @@ ClientRawSession::on_recv_notify(
       return;
     }
 
-    //      std::cout << "on_recv_notify: conn_id: " << conn_id
-    //                << " data_ctx_id: " << data_ctx_id
-    //                << " data sz: " << data.value().size() << std::endl;
-
-    messages::MessageBuffer msg_buffer{ data.value() };
+    messages::MessageBuffer msg_buffer{ *data };
 
     try {
       handle(std::move(msg_buffer));
@@ -600,8 +597,11 @@ ClientRawSession::publishNamedObject(const quicr::Name& quicr_name,
 
       msg << datagram;
 
+      trace.push_back({"libquicr:publishNamedObject:afterEnqueue:LasgFrag", trace_start_time});
+
       if (auto err = transport->enqueue(
-            context.transport_conn_id, context.transport_data_ctx_id, msg.take(), std::move(trace), priority, expiry_age_ms);
+            context.transport_conn_id, context.transport_data_ctx_id, msg.take(), std::move(trace), priority,
+            expiry_age_ms, pop_delay_ms, eflags);
           err != qtransport::TransportError::None) {
         LOGGER_WARNING(logger,
                        "Published object delayed due to enqueue error "
@@ -677,16 +677,17 @@ bool
 ClientRawSession::notify_pub_fragment(
   const messages::PublishDatagram& datagram,
   const std::shared_ptr<SubscriberDelegate>& delegate,
-  const std::map<uint32_t, bytes>& frag_map)
+  const MsgFragment& fragment)
 {
-  if ((frag_map.rbegin()->first & 1U) != 0x1) {
+  if ((fragment.data.rbegin()->first & 1U) != 0x1) {
     return false; // Not complete, return false that this can NOT be deleted
   }
 
   auto reassembled = bytes{};
   auto seq_bytes = size_t(0);
-  for (const auto& [sequence_num, data] : frag_map) {
-    if ((sequence_num >> 1U) - seq_bytes != 0) {
+  for (const auto& [sequence_num, data] : fragment.data) {
+    const auto offset = sequence_num >> 1U;
+    if (offset - seq_bytes != 0) {
       // Gap in offsets, missing data, return false that this can NOT be deleted
       return false;
     }
@@ -696,6 +697,13 @@ ClientRawSession::notify_pub_fragment(
                        std::make_move_iterator(data.end()));
 
     seq_bytes += data.size();
+  }
+
+  const auto duration_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - fragment.start_time).count();
+  if (duration_ms > 2) {
+      logger->info << "Fragment complete name: " << datagram.header.name
+                   << " duration_ms: " << duration_ms
+                   << std::flush;
   }
 
   delegate->onSubscribedObject(
@@ -745,11 +753,15 @@ ClientRawSession::handle_pub_fragment(
   // datagram
   auto& buffer = fragments.at(curr_index);
   auto& msg_fragments = buffer.at(name);
-  msg_fragments.emplace(datagram.header.offset_and_fin,
-                        std::move(datagram.media_data));
+  msg_fragments.data.emplace(datagram.header.offset_and_fin,
+                             std::move(datagram.media_data));
   if (notify_pub_fragment(datagram, delegate, msg_fragments)) {
     buffer.erase(name);
-  }
+  } /*else {
+      logger->info << "Fragments name: " << datagram.header.name
+                   << " offset: " << (datagram.header.offset_and_fin >> 1U)
+                   << std::flush;
+  }*/
 }
 
 void

--- a/src/quicr_client_raw_session.h
+++ b/src/quicr_client_raw_session.h
@@ -209,6 +209,11 @@ public:
                                   bytes&& data) override;
 
 protected:
+    struct MsgFragment {
+        std::map<uint32_t, bytes> data;
+        const std::chrono::time_point<std::chrono::steady_clock> start_time { std::chrono::steady_clock::now() };
+    };
+
   void on_connection_status(const qtransport::TransportConnId& conn_id,
                             const qtransport::TransportStatus status) override;
 
@@ -223,10 +228,10 @@ protected:
                       const qtransport::DataContextId& data_ctx_id,
                       const bool is_bidir) override;
 
-  static bool notify_pub_fragment(
+  bool notify_pub_fragment(
     const messages::PublishDatagram& datagram,
     const std::shared_ptr<SubscriberDelegate>& delegate,
-    const std::map<uint32_t, bytes>& frag_map);
+    const MsgFragment& fragment);
 
   void handle_pub_fragment(messages::PublishDatagram&& datagram,
                            const std::shared_ptr<SubscriberDelegate>& delegate);
@@ -310,7 +315,8 @@ protected:
   static constexpr size_t max_pending_per_buffer = 5000;
   static constexpr size_t max_fragment_buffers = 20;
 
-  using FragmentBuffer = std::map<quicr::Name, std::map<uint32_t, bytes>>;
+
+  using FragmentBuffer = std::map<quicr::Name, MsgFragment>;
   std::array<FragmentBuffer, max_fragment_buffers> fragments;
 
   cantina::LoggerPointer logger;

--- a/src/quicr_server_raw_session.cpp
+++ b/src/quicr_server_raw_session.cpp
@@ -252,6 +252,7 @@ ServerRawSession::sendNamedObject(const uint64_t& subscriber_id,
                      { qtransport::MethodTraceItem{} },
                      priority,
                      expiry_age_ms,
+                     0,
                      eflags);
 }
 

--- a/test/fake_transport.h
+++ b/test/fake_transport.h
@@ -66,6 +66,7 @@ struct FakeTransport : public ITransport
                          std::vector<MethodTraceItem>&&,
                          const uint8_t,
                          const uint32_t,
+                         const uint32_t,
                          const EnqueueFlags) override
   {
     stored_data = std::move(bytes);


### PR DESCRIPTION
Initially only UDP uses this feature. QUIC transport sets delay to 0 for all objects. 