### PR TITLE
Handle metrics exceptions

### DIFF
--- a/src/metrics_exporter.cpp
+++ b/src/metrics_exporter.cpp
@@ -212,7 +212,13 @@ namespace quicr {
             }
           }
 
-        _influxDb->flushBatch();
+        try {
+          _influxDb->flushBatch();
+        } catch (const std::exception& exception) {
+          logger->error << "Failure flushing metrics batch: " << exception.what() << std::flush;
+        } catch (...) {
+          logger->error << "Unknown failure flushing metrics batch" << std::flush;
+        }
       }
 
       logger->Log("metrics writer thread done");


### PR DESCRIPTION
I am occasionally seeing an unhandled exception during flushing of the batch if the submission fails due to, for example, a local network issue. 

This handles any submission errors and logs an error instead of crashing. 

```
* thread #23, stop reason = signal SIGABRT
    frame #0: 0x0000000189e62a60 libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x0000000105d22be8 libsystem_pthread.dylib`pthread_kill + 288
    frame #2: 0x0000000189da7a20 libsystem_c.dylib`abort + 180
    frame #3: 0x0000000189e51d30 libc++abi.dylib`abort_message + 132
    frame #4: 0x0000000189e41fcc libc++abi.dylib`demangling_terminate_handler() + 320
    frame #5: 0x0000000189ae01e0 libobjc.A.dylib`_objc_terminate() + 160
    frame #6: 0x0000000189e510f4 libc++abi.dylib`std::__terminate(void (*)()) + 16
    frame #7: 0x0000000189e54348 libc++abi.dylib`__cxxabiv1::failed_throw(__cxxabiv1::__cxa_exception*) + 88
    frame #8: 0x0000000189e5428c libc++abi.dylib`__cxa_throw + 308
  * frame #9: 0x0000000106c56440 qmedia`influxdb::transports::(anonymous namespace)::checkResponse(resp=0x000000016c2829c0) at HTTP.cxx:39:17 [opt]
    frame #10: 0x0000000106c56f90 qmedia`influxdb::transports::HTTP::send(this=<unavailable>, lineprotocol=<unavailable>) at HTTP.cxx:111:9 [opt]
    frame #11: 0x0000000106c4e998 qmedia`influxdb::InfluxDB::flushBatch() [inlined] influxdb::InfluxDB::transmit(this=0x0000600000d48d80, point="quic-connection,endpoint_id=a@cisco.com,relay_id=laps-relay-test.eu-west-2,source=client tx_retransmits=23u,tx_congested=31u,tx_lost_pkts=51u,tx_dgram_lost=20u,tx_dgram_ack=1485u,tx_dgram_cb=1513u,tx_dgram_spurious=0u,dgram_invalid_ctx_id=0u,cwin_congested=23u,tx_rate_bps_min=29572792u,tx_rate_bps_max=29572792u,tx_rate_bps_avg=29572792u,rx_rate_bps_min=16056u,rx_rate_bps_max=1690056u,rx_rate_bps_avg=140535u,tx_cwin_bytes_min=34429u,tx_cwin_bytes_max=34429u,tx_cwin_bytes_avg=34429u,rtt_us_min=9588u,rtt_us_max=55765u,rtt_us_avg=11873u,srtt_us_min=21188u,srtt_us_max=59291u,srtt_us_avg=32238u 1713280918121926000\nquic-dataFlow,endpoint_id=a@cisco.com,relay_id=laps-relay-test.eu-west-2,source=client,type=publish,namespace=0x00000000000000000000000000000000/0 enqueued_objs=9u,tx_queue_size_min=0u,tx_queue_size_max=0u,tx_queue_size_avg=0u,rx_buffer_drops=0u,rx_dgrams=0u,rx_dgrams_bytes=0u,rx_stream_objs=9u,rx_invalid_drops=0u,rx_stream_bytes=275u,rx_stream_cb=0u,tx_dgrams=0u,tx_dgrams_bytes=0u,tx_stream_objs=9u,tx_st"...) at InfluxDB.cxx:105:21 [opt]
    frame #12: 0x0000000106c4e984 qmedia`influxdb::InfluxDB::flushBatch(this=0x0000600000d48d80) at InfluxDB.cxx:72:13 [opt]
    frame #13: 0x0000000106bbcfc4 qmedia`quicr::MetricsExporter::writer(this=0x000000012100cd18) at metrics_exporter.cpp:209:20 [opt]
    frame #14: 0x0000000106bbf968 qmedia`void* std::__1::__thread_proxy[abi:ue170006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (quicr::MetricsExporter::*)(), quicr::MetricsExporter*>>(void*) [inlined] decltype(*std::declval<quicr::MetricsExporter*>().*std::declval<void (quicr::MetricsExporter::*)()>()()) std::__1::__invoke[abi:ue170006]<void (quicr::MetricsExporter::*)(), quicr::MetricsExporter*, void>(__f=0x0000600002981748, __a0=0x0000600002981758) at invoke.h:308:25 [opt]
    frame #15: 0x0000000106bbf94c qmedia`void* std::__1::__thread_proxy[abi:ue170006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (quicr::MetricsExporter::*)(), quicr::MetricsExporter*>>(void*) [inlined] void std::__1::__thread_execute[abi:ue170006]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (quicr::MetricsExporter::*)(), quicr::MetricsExporter*, 2ul>(__t=size=3, (null)=<unavailable>) at thread.h:227:5 [opt]
    frame #16: 0x0000000106bbf94c qmedia`void* std::__1::__thread_proxy[abi:ue170006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (quicr::MetricsExporter::*)(), quicr::MetricsExporter*>>(__vp=0x0000600002981740) at thread.h:238:5 [opt]
    frame #17: 0x0000000105d215c0 libsystem_pthread.dylib`_pthread_start + 136
```