### PR TITLE
Fix compare and add chunk_size to client constructor

### DIFF
--- a/cmd/really/reallyTest.cpp
+++ b/cmd/really/reallyTest.cpp
@@ -228,7 +228,7 @@ main(int argc, char* argv[])
     .tls_key_filename = nullptr,
   };
 
-  quicr::Client client(relay, "a@cisco.com", tcfg, logger);
+  quicr::Client client(relay, "a@cisco.com", 0, tcfg, logger);
   auto pd = std::make_shared<pubDelegate>(logger);
 
   if (!client.connect()) {

--- a/include/quicr/quicr_client.h
+++ b/include/quicr/quicr_client.h
@@ -43,6 +43,7 @@ public:
    * @param relay_info  : Relay Information to be used by the transport
    * @param endpoint_id : Client endpoint ID (e.g., email)
    * @param chunk_size  : Size in bytes to chunk messages if greater than this size
+   *                      Zero disables, value is max(chunk_size, max_transport_data_size)
    * @param tconfig     : Transport configuration
    * @param logger      : Shared pointer to cantina::Logger object
    *                      loggings operations

--- a/include/quicr/quicr_client.h
+++ b/include/quicr/quicr_client.h
@@ -42,12 +42,14 @@ public:
    *
    * @param relay_info  : Relay Information to be used by the transport
    * @param endpoint_id : Client endpoint ID (e.g., email)
+   * @param chunk_size  : Size in bytes to chunk messages if greater than this size
    * @param tconfig     : Transport configuration
    * @param logger      : Shared pointer to cantina::Logger object
    *                      loggings operations
    */
   Client(const RelayInfo& relay_info,
          const std::string& endpoint_id,
+         size_t chunk_size,
          const qtransport::TransportConfig& tconfig,
          const cantina::LoggerPointer& logger);
 

--- a/src/quicr_client.cpp
+++ b/src/quicr_client.cpp
@@ -14,6 +14,7 @@ namespace quicr {
 
 Client::Client(const RelayInfo& relay_info,
                const std::string& endpoint_id,
+               size_t chunk_size,
                const qtransport::TransportConfig& tconfig,
                const cantina::LoggerPointer& logger)
 {
@@ -22,7 +23,7 @@ Client::Client(const RelayInfo& relay_info,
       [[fallthrough]];
     case RelayInfo::Protocol::QUIC:
       client_session =
-        std::make_unique<ClientRawSession>(relay_info, endpoint_id, tconfig, logger);
+        std::make_unique<ClientRawSession>(relay_info, endpoint_id, chunk_size, tconfig, logger);
       break;
     default:
       throw ClientException("Unsupported relay protocol");

--- a/src/quicr_client_raw_session.cpp
+++ b/src/quicr_client_raw_session.cpp
@@ -571,7 +571,7 @@ ClientRawSession::publishNamedObject(const quicr::Name& quicr_name,
       break;
   }
 
-  const auto fragment_size = transport_needs_fragmentation
+  const size_t fragment_size = transport_needs_fragmentation
       || context.transport_mode == TransportMode::Unreliable ? max_transport_data_size : max_transport_data_size * 3;
 
   // Fragment the payload if needed

--- a/src/quicr_client_raw_session.h
+++ b/src/quicr_client_raw_session.h
@@ -47,6 +47,7 @@ public:
    * @param relayInfo   : Relay Information to be used by the transport
    * @param endpoint_id : Client endpoint ID (e.g., email)
    * @param chunk_size  : Size in bytes to chunk messages if greater than this size
+   *                      Zero disables, value is max(chunk_size, max_transport_data_size)
    * @param tconfig     : Transport configuration
    * @param logger      : Shared pointer to a cantina::Logger object
    *

--- a/src/quicr_client_raw_session.h
+++ b/src/quicr_client_raw_session.h
@@ -46,6 +46,7 @@ public:
    *
    * @param relayInfo   : Relay Information to be used by the transport
    * @param endpoint_id : Client endpoint ID (e.g., email)
+   * @param chunk_size  : Size in bytes to chunk messages if greater than this size
    * @param tconfig     : Transport configuration
    * @param logger      : Shared pointer to a cantina::Logger object
    *
@@ -53,6 +54,7 @@ public:
    */
   ClientRawSession(const RelayInfo& relay_info,
                    const std::string& endpoint_id,
+                   size_t chunk_size,
                    const qtransport::TransportConfig& tconfig,
                    const cantina::LoggerPointer& logger);
 
@@ -326,6 +328,7 @@ protected:
   cantina::LoggerPointer logger;
 
   const std::string _endpoint_id;           /// Client Endpoint ID
+  size_t _chunk_size {0};                   /// Size in bytes to break up a message
   std::string _relay_id;                    /// Relay Id
 
   namespace_map<std::shared_ptr<PublisherDelegate>> pub_delegates;


### PR DESCRIPTION
Fixes a compare build error and adds chunk size to quicr client constructor. This allows clients to configure their stream chunk (aka fragment) size.  Zero will disable the feature and will not chunk/fragment.