### PR TITLE
Fix recv datagram handling with no data context

### DIFF
--- a/src/quicr_client_raw_session.cpp
+++ b/src/quicr_client_raw_session.cpp
@@ -935,7 +935,11 @@ ClientRawSession::handle(std::optional<uint64_t> stream_id,
 
         auto& context = subscribe_state[ns];
 
-        if (!data_ctx_id) {
+        if (stream_id.has_value() && not data_ctx_id.has_value() ) {
+          /* NOTE:
+           * In picoquic there isn't a data_ctx_id because there isn't a
+           * stream context for datagram.
+           */
           transport->setStreamIdDataCtxId(context.transport_conn_id,
                                           context.transport_data_ctx_id,
                                           *stream_id);


### PR DESCRIPTION
Fixes issues with datagram handling, updates picoquic to latest as of June 3rd, and adds transport config option to set priority bypass. 
