### PR TITLE
Add reliable flag to server publish object cb

### DIFF
--- a/cmd/really/really.cpp
+++ b/cmd/really/really.cpp
@@ -165,6 +165,7 @@ public:
 
   void onPublisherObject(const qtransport::TransportConnId& conn_id,
                          [[maybe_unused]] const qtransport::DataContextId& data_ctx_id,
+                         [[maybe_unused]] bool reliable,
                          quicr::messages::PublishDatagram&& datagram) override
   {
     const auto list = subscribeList.find(datagram.header.name);

--- a/include/quicr/quicr_server_delegate.h
+++ b/include/quicr/quicr_server_delegate.h
@@ -74,6 +74,8 @@ public:
    *
    * @param conn_id               : Context id the message was received on
    * @param data_ctx_id           : Stream ID the message was received on
+   * @param reliable              : Indicates if object was received using
+   *                                reliable transport
    * @param datagram              : QuicR Published Message Datagram
    *
    * @note: It is important that the implementations not perform
@@ -87,6 +89,7 @@ public:
    */
   virtual void onPublisherObject(const qtransport::TransportConnId& conn_id,
                                  const qtransport::DataContextId& data_ctx_id,
+                                 bool reliable,
                                  messages::PublishDatagram&& datagram) = 0;
 
   /**

--- a/src/quicr_server_raw_session.cpp
+++ b/src/quicr_server_raw_session.cpp
@@ -579,6 +579,7 @@ ServerRawSession::handle_publish(qtransport::TransportConnId conn_id,
 #endif
   }
 
+  // NOTE: if stream_id is nullopt, it means it's not reliable and MUST be datagram
   delegate->onPublisherObject(conn_id, *data_ctx_id, stream_id.has_value(), std::move(datagram));
 }
 

--- a/src/quicr_server_raw_session.cpp
+++ b/src/quicr_server_raw_session.cpp
@@ -579,7 +579,7 @@ ServerRawSession::handle_publish(qtransport::TransportConnId conn_id,
 #endif
   }
 
-  delegate->onPublisherObject(conn_id, *data_ctx_id, std::move(datagram));
+  delegate->onPublisherObject(conn_id, *data_ctx_id, stream_id.has_value(), std::move(datagram));
 }
 
 void

--- a/test/fake_transport.h
+++ b/test/fake_transport.h
@@ -55,6 +55,10 @@ struct FakeTransport : public ITransport
                           [[maybe_unused]] DataContextId data_ctx_id,
                           [[maybe_unused]] uint64_t stream_id) override {}
 
+  void setDataCtxPriority([[maybe_unused]] const TransportConnId conn_id,
+                          [[maybe_unused]] DataContextId data_ctx_id,
+                          [[maybe_unused]] uint8_t priority) override {}
+
   std::shared_ptr<StreamBuffer<uint8_t>> getStreamBuffer(TransportConnId, uint64_t) override { return nullptr;}
   void close(const TransportConnId& /* conn_id */) override {};
 

--- a/test/quicr_server.cpp
+++ b/test/quicr_server.cpp
@@ -60,6 +60,7 @@ class TestServerDelegate : public ServerDelegate
 
   void onPublisherObject([[maybe_unused]] const qtransport::TransportConnId& conn_id,
                          [[maybe_unused]] const qtransport::DataContextId& data_ctx_id,
+                         [[maybe_unused]] bool reliable,
                          [[maybe_unused]] messages::PublishDatagram&& datagram) override
   {
   }


### PR DESCRIPTION
Relay needs to know if the received object was
via a reliable stream or datagram.