### PR TITLE
Safety and Modernise

### DIFF
--- a/include/moq/publish_track_handler.h
+++ b/include/moq/publish_track_handler.h
@@ -69,12 +69,7 @@ namespace moq {
             kSendingUnannounce,         ///< In this state, callbacks will not be called
         };
 
-        PublishTrackHandler() = delete;
-
-        // --------------------------------------------------------------------------
-        // Public API methods
-        // --------------------------------------------------------------------------
-
+      private:
         /**
          * @brief Publish track handler constructor
          *
@@ -94,6 +89,24 @@ namespace moq {
         {
         }
 
+      public:
+        /**
+         * @brief Create a shared Publish track handler
+         *
+         * @param full_track_name       Full track name
+         * @param track_mode            The track mode to operate using
+         * @param default_priority      Default priority for objects if not specified in ObjectHeaderss
+         * @param default_ttl           Default TTL for objects if not specified in ObjectHeaderss
+         */
+        static std::shared_ptr<PublishTrackHandler> Create(const FullTrackName& full_track_name,
+                                                           TrackMode track_mode,
+                                                           uint8_t default_priority,
+                                                           uint32_t default_ttl)
+        {
+            return std::shared_ptr<PublishTrackHandler>(
+              new PublishTrackHandler(full_track_name, track_mode, default_priority, default_ttl));
+        }
+
         // --------------------------------------------------------------------------
         // Public Virtual API callback event methods
         // --------------------------------------------------------------------------
@@ -105,7 +118,7 @@ namespace moq {
          *
          * @param status        Indicates the status of being able to publish
          */
-        virtual void StatusChanged(Status status) {}
+        virtual void StatusChanged(Status status);
 
 
         /**
@@ -117,7 +130,7 @@ namespace moq {
          *
          * @param metrics           Copy of the published metrics for the sample period
          */
-        virtual void MetricsSampled(const PublishTrackMetrics&& metrics) {}
+        virtual void MetricsSampled(const PublishTrackMetrics&& metrics);
 
         // --------------------------------------------------------------------------
         // Various getter/setters
@@ -125,19 +138,19 @@ namespace moq {
         /**
          * @brief set/update the default priority for published objects
          */
-        void SetDefaultPriority(const uint8_t priority) { default_priority_ = priority; }
+        void SetDefaultPriority(const uint8_t priority) noexcept { default_priority_ = priority; }
 
         /**
          * @brief set/update the default TTL expiry for published objects
          */
-        void SetDefaultTTL(const uint32_t ttl) { default_ttl_ = ttl; }
+        void SetDefaultTTL(const uint32_t ttl) noexcept { default_ttl_ = ttl; }
 
         /**
          * @brief Get the publish status
          *
          * @return Status of publish
          */
-        Status GetStatus() { return publish_status_; }
+        constexpr Status GetStatus() const noexcept { return publish_status_; }
 
         // --------------------------------------------------------------------------
         // Methods that normally do not need to be overridden
@@ -170,7 +183,7 @@ namespace moq {
          *
          * @returns Publish status of the publish
          */
-        [[maybe_unused]] PublishObjectStatus PublishObject(const ObjectHeaders& object_headers, BytesSpan data);
+        PublishObjectStatus PublishObject(const ObjectHeaders& object_headers, BytesSpan data);
 
         /**
          * @brief Publish object to the announced track
@@ -243,12 +256,12 @@ namespace moq {
          *
          * @details The MOQ Handler sets the data context ID
          */
-        void SetDataContextId(uint64_t data_ctx_id) { publish_data_ctx_id_ = data_ctx_id; };
+        void SetDataContextId(uint64_t data_ctx_id) noexcept { publish_data_ctx_id_ = data_ctx_id; };
 
         /**
          * @brief Get the Data context ID
          */
-        uint64_t GetDataContextId() { return publish_data_ctx_id_; };
+        constexpr uint64_t GetDataContextId() const noexcept { return publish_data_ctx_id_; };
 
         void SetPublishObjectFunction(PublishObjFunction&& publish_func)
         {
@@ -259,7 +272,7 @@ namespace moq {
          * @brief Set the publish status
          * @param status                Status of publishing (aka publish objects)
          */
-        void SetStatus(Status status) { publish_status_ = status; }
+        void SetStatus(Status status) noexcept { publish_status_ = status; }
 
         // --------------------------------------------------------------------------
         // Member variables

--- a/include/moq/server_publish_track_handler.h
+++ b/include/moq/server_publish_track_handler.h
@@ -61,12 +61,7 @@ namespace moq {
             kNoSubscriber,
         };
 
-        ServerPublishTrackHandler() = delete;
-
-        // --------------------------------------------------------------------------
-        // Public API methods
-        // --------------------------------------------------------------------------
-
+      private:
         /**
          * @brief Publish track handler constructor
          *
@@ -84,6 +79,24 @@ namespace moq {
           , default_priority_(default_priority)
           , default_ttl_(default_ttl)
         {
+        }
+
+      public:
+        /**
+         * @brief Create shared Publish track handler
+         *
+         * @param full_track_name       Full track name
+         * @param track_mode            The track mode to operate using
+         * @param default_priority      Default priority for objects if not specified in ObjectHeaderss
+         * @param default_ttl           Default TTL for objects if not specified in ObjectHeaderss
+         */
+        static std::shared_ptr<ServerPublishTrackHandler> Create(const FullTrackName& full_track_name,
+                                                                 TrackMode track_mode,
+                                                                 uint8_t default_priority,
+                                                                 uint32_t default_ttl)
+        {
+            return std::shared_ptr<ServerPublishTrackHandler>(
+              new ServerPublishTrackHandler(full_track_name, track_mode, default_priority, default_ttl));
         }
 
         // --------------------------------------------------------------------------

--- a/include/moq/subscribe_track_handler.h
+++ b/include/moq/subscribe_track_handler.h
@@ -49,12 +49,7 @@ namespace moq {
             kSendingUnsubscribe                 ///< In this state, callbacks will not be called
         };
 
-        SubscribeTrackHandler() = delete;
-
-        // --------------------------------------------------------------------------
-        // Public API methods
-        // --------------------------------------------------------------------------
-
+      private:
         /**
          * @brief Subscribe track handler constructor
          *
@@ -65,12 +60,23 @@ namespace moq {
         {
         }
 
+      public:
+        /**
+         * @brief Create shared Subscribe track handler
+         *
+         * @param full_track_name           Full track name struct
+         */
+        static std::shared_ptr<SubscribeTrackHandler> Create(const FullTrackName& full_track_name)
+        {
+            return std::shared_ptr<SubscribeTrackHandler>(new SubscribeTrackHandler(full_track_name));
+        }
+
         /**
          * @brief Get the status of the subscribe
          *
          * @return Status of the subscribe
          */
-        Status GetStatus() { return status_; }
+        constexpr Status GetStatus() const noexcept { return status_; }
 
         // --------------------------------------------------------------------------
         // Public Virtual API callback event methods
@@ -86,8 +92,7 @@ namespace moq {
          * @param object_headers    Object headers, must include group and object Ids
          * @param data              Object payload data received, **MUST** match ObjectHeaders::payload_length.
          */
-        virtual void ObjectReceived(const ObjectHeaders& object_headers,
-                                    Span<uint8_t> data) {}
+        virtual void ObjectReceived(const ObjectHeaders& object_headers, Span<uint8_t> data) {}
 
         /**
          * @brief Notification of a partial object received data object
@@ -99,8 +104,7 @@ namespace moq {
          * @param object_headers    Object headers, must include group and object Ids
          * @param data              Object payload data received, can be <= ObjectHeaders::payload_length
          */
-        virtual void PartialObjectReceived(const ObjectHeaders& object_headers,
-                                           Span<uint8_t> data) {}
+        virtual void PartialObjectReceived(const ObjectHeaders& object_headers, Span<uint8_t> data) {}
 
         /**
          * @brief Notification of subscribe status
@@ -142,7 +146,7 @@ namespace moq {
          * @brief Set the subscribe status
          * @param status                Status of the subscribe
          */
-        void SetStatus(Status status) { status_ = status; }
+        void SetStatus(Status status) noexcept { status_ = status; }
 
         // --------------------------------------------------------------------------
         // Member variables

--- a/src/moq/publish_track_handler_base.cpp
+++ b/src/moq/publish_track_handler_base.cpp
@@ -7,6 +7,8 @@
 #include <moq/publish_track_handler.h>
 
 namespace moq {
+    void PublishTrackHandler::StatusChanged(Status) {}
+    void PublishTrackHandler::MetricsSampled(const PublishTrackMetrics&&) {}
 
     PublishTrackHandler::PublishObjectStatus PublishTrackHandler::PublishObject(
       const moq::ObjectHeaders& object_headers,
@@ -27,14 +29,19 @@ namespace moq {
                     is_stream_header_needed = true;
                     sent_track_header_ = true;
                 }
-                
                 break;
         }
 
         prev_object_group_id_ = object_headers.group_id;
 
         if (publish_object_func_ != nullptr) {
-            return publish_object_func_(priority, ttl, is_stream_header_needed, group_id, object_id, object);
+            return publish_object_func_(object_headers.priority.has_value() ? object_headers.priority.value()
+                                                                            : default_priority_,
+                                        object_headers.ttl.has_value() ? object_headers.ttl.value() : default_ttl_,
+                                        is_stream_header_needed,
+                                        object_headers.group_id,
+                                        object_headers.object_id,
+                                        data);
         } else {
             return PublishObjectStatus::kInternalError;
         }


### PR DESCRIPTION
Made track handlers only constructable as shared_ptr, adding noexcept, const, and constexpr keywords to track handler APIs.