### PR TITLE
Add extensible object header encode/decode

### DIFF
--- a/include/moq/detail/messages.h
+++ b/include/moq/detail/messages.h
@@ -7,6 +7,7 @@
 #include "moq/detail/serializer.h"
 #include "stream_buffer.h"
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -24,6 +25,7 @@ namespace moq::messages {
     using SubscribeId = uint64_t;
     using TrackAlias = uint64_t;
     using ParamType = uint64_t;
+    using Extensions = std::map<uint64_t, std::vector<uint8_t>>;
 
     enum class MoqTerminationReason : uint64_t
     {
@@ -334,11 +336,14 @@ namespace moq::messages {
         GroupId group_id;
         ObjectId object_id;
         ObjectPriority priority;
+        std::optional<Extensions> extensions;
         Bytes payload;
         friend bool operator>>(qtransport::StreamBuffer<uint8_t>& buffer, MoqObjectStream& msg);
         friend Serializer& operator<<(Serializer& buffer, const MoqObjectStream& msg);
 
       private:
+        uint64_t num_extensions{ 0 };
+        std::optional<uint64_t> current_tag{};
         uint64_t current_pos{ 0 };
         bool parse_completed{ false };
     };
@@ -350,11 +355,14 @@ namespace moq::messages {
         GroupId group_id;
         ObjectId object_id;
         ObjectPriority priority;
+        std::optional<Extensions> extensions;
         Bytes payload;
         friend bool operator>>(qtransport::StreamBuffer<uint8_t>& buffer, MoqObjectDatagram& msg);
         friend Serializer& operator<<(Serializer& buffer, const MoqObjectDatagram& msg);
 
       private:
+        uint64_t num_extensions{ 0 };
+        std::optional<uint64_t> current_tag{};
         uint64_t current_pos{ 0 };
         bool parse_completed{ false };
     };
@@ -376,11 +384,14 @@ namespace moq::messages {
     {
         GroupId group_id;
         ObjectId object_id;
+        std::optional<Extensions> extensions;
         Bytes payload;
         friend bool operator>>(qtransport::StreamBuffer<uint8_t>& buffer, MoqStreamTrackObject& msg);
         friend Serializer& operator<<(Serializer& buffer, const MoqStreamTrackObject& msg);
 
       private:
+        uint64_t num_extensions{ 0 };
+        std::optional<uint64_t> current_tag{};
         uint64_t current_pos{ 0 };
         bool parse_completed{ false };
     };
@@ -402,11 +413,14 @@ namespace moq::messages {
     struct MoqStreamGroupObject
     {
         ObjectId object_id;
+        std::optional<Extensions> extensions;
         Bytes payload;
         friend bool operator>>(qtransport::StreamBuffer<uint8_t>& buffer, MoqStreamGroupObject& msg);
         friend Serializer& operator<<(Serializer& buffer, const MoqStreamGroupObject& msg);
 
       private:
+        uint64_t num_extensions{ 0 };
+        std::optional<uint64_t> current_tag{};
         uint64_t current_pos{ 0 };
         bool parse_completed{ false };
     };

--- a/include/moq/detail/transport.h
+++ b/include/moq/detail/transport.h
@@ -239,6 +239,7 @@ namespace moq {
                                                             bool stream_header_needed,
                                                             uint64_t group_id,
                                                             uint64_t object_id,
+                                                            std::optional<Extensions> extensions,
                                                             BytesSpan data);
 
         void SendCtrlMsg(const ConnectionContext& conn_ctx, Span<const uint8_t> data);

--- a/include/moq/publish_track_handler.h
+++ b/include/moq/publish_track_handler.h
@@ -251,6 +251,7 @@ namespace moq {
                                                                      bool stream_header_needed,
                                                                      uint64_t group_id,
                                                                      uint64_t object_id,
+                                                                     std::optional<Extensions> extensions,
                                                                      BytesSpan data)>;
         /**
          * @brief Set the Data context ID

--- a/src/moq/messages.cpp
+++ b/src/moq/messages.cpp
@@ -36,12 +36,14 @@ namespace moq::messages {
             if (current_tag == std::nullopt) {
                 uint64_t tag{ 0 };
                 if (!ParseUintVField(buffer, tag)) {
+                    count -= completed;
                     return false;
                 }
                 current_tag = tag;
             }
             auto val = buffer.DecodeBytes();
             if (!val) {
+                count -= completed;
                 return false;
             }
             extensions.value()[current_tag.value()] = std::move(val.value());

--- a/src/moq/publish_track_handler.cpp
+++ b/src/moq/publish_track_handler.cpp
@@ -44,6 +44,7 @@ namespace moq {
                                         is_stream_header_needed,
                                         object_headers.group_id,
                                         object_headers.object_id,
+                                        object_headers.extensions,
                                         data);
         } else {
             return PublishObjectStatus::kInternalError;


### PR DESCRIPTION
Adds extensible object headers in the form of `count` (varint) followed by `count` entries of `tag` (varint), `length` (varint) and `bytes` (of size `length`). 