### PR TITLE
Fix spdlog teardown issue

### DIFF
--- a/include/moq/detail/transport.h
+++ b/include/moq/detail/transport.h
@@ -96,7 +96,7 @@ namespace moq {
          */
         Transport(const ServerConfig& cfg);
 
-        ~Transport() = default;
+        ~Transport();
 
         // -------------------------------------------------------------------------------------------------
         // Public API MoQ Instance API methods

--- a/src/moq/transport.cpp
+++ b/src/moq/transport.cpp
@@ -87,6 +87,11 @@ namespace moq {
         Init();
     }
 
+    Transport::~Transport()
+    {
+        spdlog::drop(logger_->name());
+    }
+
     void Transport::Init() {}
 
     Transport::Status Transport::Start()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(quicr_test
     moq_messages.cpp
     moq_test.cpp
     track_handlers.cpp
+    client.cpp
 )
 target_include_directories(quicr_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
 

--- a/test/client.cpp
+++ b/test/client.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <doctest/doctest.h>
+
+#include <memory>
+#include <moq/client.h>
+#include <moq/config.h>
+
+TEST_CASE("Multiple client creation")
+{
+    auto client = std::make_shared<moq::Client>(moq::ClientConfig());
+    client = nullptr;
+    client = std::make_shared<moq::Client>(moq::ClientConfig());
+}


### PR DESCRIPTION
Looks like the spdloggers created by `Transport` need to be explicitly torn down. Added a test that will demonstrate the issue when the `Transport` destructor is defaulted, and passes now that it drops the created logger. 