### PR TITLE
Stop publishing if no subscribers and reduce noise on related logs

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -77,6 +77,9 @@ class MyPublishTrackHandler : public quicr::PublishTrackHandler
                 break;
             }
             default:
+                if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
+                    SPDLOG_INFO("Publish track alias: {0} status {1}", track_alias.value(), static_cast<int>(status));
+                }
                 break;
         }
     }

--- a/include/quicr/metrics.h
+++ b/include/quicr/metrics.h
@@ -15,6 +15,14 @@ namespace quicr {
         MetricsTimeStampUs last_sample_time; ///< Last sampled time in microseconds
 
         QuicConnectionMetrics quic; ///< QUIC connection metrics
+
+        uint64_t rx_dgram_unknown_subscribe_id{ 0 }; ///< Received datagram with unknown subscribe ID
+        uint64_t rx_dgram_invalid_type{ 0 };         ///< Received datagram with invalid type of OBJECT_DATAGRAM
+        uint64_t rx_dgram_decode_failed{ 0 };        ///< Failed to decode datagram
+
+        uint64_t rx_stream_buffer_error{ 0 };         ///< Stream buffer error that results in bad parsing
+        uint64_t rx_stream_unknown_subscribe_id{ 0 }; ///< Received stream header with unknown subscribe ID
+        uint64_t rx_stream_invalid_type{ 0 };         ///< Invalid message type
     };
 
     struct SubscribeTrackMetrics

--- a/include/quicr/metrics.h
+++ b/include/quicr/metrics.h
@@ -40,6 +40,8 @@ namespace quicr {
         uint64_t bytes_published{ 0 };   ///< sum of payload bytes published
         uint64_t objects_published{ 0 }; ///< count of objects published
 
+        uint64_t objects_dropped_not_ok{ 0 }; ///< Objects dropped upon publish object call due to status not being OK
+
         struct Quic
         {
             uint64_t tx_buffer_drops{ 0 };   ///< count of write buffer drops of data due to RESET request

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -14,16 +14,20 @@ namespace quicr {
             case Status::kOk:
                 break;
             case Status::kNoSubscribers:
+                publish_track_metrics_.objects_dropped_not_ok++;
                 return PublishObjectStatus::kNoSubscribers;
             case Status::kPendingAnnounceResponse:
                 [[fallthrough]];
             case Status::kNotAnnounced:
                 [[fallthrough]];
             case Status::kNotConnected:
+                publish_track_metrics_.objects_dropped_not_ok++;
                 return PublishObjectStatus::kNotAnnounced;
             case Status::kAnnounceNotAuthorized:
+                publish_track_metrics_.objects_dropped_not_ok++;
                 return PublishObjectStatus::kNotAuthorized;
             default:
+                publish_track_metrics_.objects_dropped_not_ok++;
                 return PublishObjectStatus::kInternalError;
         }
 

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -10,22 +10,22 @@ namespace quicr {
     PublishTrackHandler::PublishObjectStatus PublishTrackHandler::PublishObject(const ObjectHeaders& object_headers,
                                                                                 BytesSpan data)
     {
-            switch (publish_status_) {
-                case Status::kOk:
-                    break;
-                case Status::kNoSubscribers:
-                    return PublishObjectStatus::kNoSubscribers;
-                case Status::kPendingAnnounceResponse:
-                    [[fallthrough]];
-                case Status::kNotAnnounced:
-                    [[fallthrough]];
-                case Status::kNotConnected:
-                    return PublishObjectStatus::kNotAnnounced;
-                case Status::kAnnounceNotAuthorized:
-                    return PublishObjectStatus::kNotAuthorized;
-                default:
-                    return PublishObjectStatus::kInternalError;
-            }
+        switch (publish_status_) {
+            case Status::kOk:
+                break;
+            case Status::kNoSubscribers:
+                return PublishObjectStatus::kNoSubscribers;
+            case Status::kPendingAnnounceResponse:
+                [[fallthrough]];
+            case Status::kNotAnnounced:
+                [[fallthrough]];
+            case Status::kNotConnected:
+                return PublishObjectStatus::kNotAnnounced;
+            case Status::kAnnounceNotAuthorized:
+                return PublishObjectStatus::kNotAuthorized;
+            default:
+                return PublishObjectStatus::kInternalError;
+        }
 
         if (object_headers.track_mode.has_value() && object_headers.track_mode != default_track_mode_) {
             SetDefaultTrackMode(*object_headers.track_mode);

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -10,6 +10,23 @@ namespace quicr {
     PublishTrackHandler::PublishObjectStatus PublishTrackHandler::PublishObject(const ObjectHeaders& object_headers,
                                                                                 BytesSpan data)
     {
+            switch (publish_status_) {
+                case Status::kOk:
+                    break;
+                case Status::kNoSubscribers:
+                    return PublishObjectStatus::kNoSubscribers;
+                case Status::kPendingAnnounceResponse:
+                    [[fallthrough]];
+                case Status::kNotAnnounced:
+                    [[fallthrough]];
+                case Status::kNotConnected:
+                    return PublishObjectStatus::kNotAnnounced;
+                case Status::kAnnounceNotAuthorized:
+                    return PublishObjectStatus::kNotAuthorized;
+                default:
+                    return PublishObjectStatus::kInternalError;
+            }
+
         if (object_headers.track_mode.has_value() && object_headers.track_mode != default_track_mode_) {
             SetDefaultTrackMode(*object_headers.track_mode);
         }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -87,6 +87,8 @@ namespace quicr {
         // Hold onto track handler
         conn_it->second.pub_tracks_by_name[th.track_namespace_hash][th.track_name_hash] = track_handler;
         conn_it->second.pub_tracks_by_data_ctx_id[track_handler->publish_data_ctx_id_] = std::move(track_handler);
+
+        track_handler->SetStatus(PublishTrackHandler::Status::kOk);
     }
 
     bool Server::ProcessCtrlMessage(ConnectionContext& conn_ctx,

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -838,7 +838,8 @@ namespace quicr {
 
                 auto msg_type = buffer.DecodeUintV();
                 if (!msg_type || static_cast<MoqMessageType>(*msg_type) != MoqMessageType::OBJECT_DATAGRAM) {
-                    SPDLOG_LOGGER_DEBUG(logger_, "Received datagram that is not message type OBJECT_DATAGRAM, dropping");
+                    SPDLOG_LOGGER_DEBUG(logger_,
+                                        "Received datagram that is not message type OBJECT_DATAGRAM, dropping");
                     auto& conn_ctx = connections_[conn_id];
                     conn_ctx.metrics.rx_dgram_invalid_type++;
                     continue;
@@ -856,8 +857,8 @@ namespace quicr {
                         conn_ctx.metrics.rx_dgram_unknown_subscribe_id++;
 
                         SPDLOG_LOGGER_DEBUG(logger_,
-                                           "Received datagram to unknown subscribe track subscribe_id: {0}, ignored",
-                                           msg.subscribe_id);
+                                            "Received datagram to unknown subscribe track subscribe_id: {0}, ignored",
+                                            msg.subscribe_id);
 
                         // TODO(tievens): Should close/reset stream in this case but draft leaves this case hanging
 
@@ -892,9 +893,9 @@ namespace quicr {
                     conn_ctx.metrics.rx_dgram_decode_failed++;
 
                     SPDLOG_LOGGER_DEBUG(logger_,
-                                       "Failed to decode datagram conn_id: {0} data_ctx_id: {1}",
-                                       conn_id,
-                                       (data_ctx_id ? *data_ctx_id : 0));
+                                        "Failed to decode datagram conn_id: {0} data_ctx_id: {1}",
+                                        conn_id,
+                                        (data_ctx_id ? *data_ctx_id : 0));
                 }
             }
         }
@@ -1020,8 +1021,8 @@ namespace quicr {
 
                     conn_ctx.metrics.rx_stream_unknown_subscribe_id++;
                     SPDLOG_LOGGER_DEBUG(logger_,
-                                       "Received stream_object to unknown subscribe track subscribe_id: {0}, ignored",
-                                       msg.subscribe_id);
+                                        "Received stream_object to unknown subscribe track subscribe_id: {0}, ignored",
+                                        msg.subscribe_id);
 
                     // TODO(tievens): Should close/reset stream in this case but draft leaves this case hanging
 
@@ -1185,8 +1186,8 @@ namespace quicr {
     {
         if (!stream_buffer->AnyHasValue()) {
             SPDLOG_LOGGER_DEBUG(logger_,
-                               "Received stream message (type = {0}), init stream buffer",
-                               static_cast<std::uint64_t>(msg_type));
+                                "Received stream message (type = {0}), init stream buffer",
+                                static_cast<std::uint64_t>(msg_type));
             stream_buffer->InitAny<MessageType>(static_cast<uint64_t>(msg_type));
         }
 


### PR DESCRIPTION
Updates publish object method to only publish if there are subscribers.  If not, it'll drop them with an increment to the dropped objects metric. 

Add other metrics to replace some noisy log messages that were triggered by allowing objects to be sent when there are no subscribers. 
