### PR TITLE
Fix race issue with picoquic streams and other minor updates

### DIFF
--- a/include/quicr/detail/priority_queue.h
+++ b/include/quicr/detail/priority_queue.h
@@ -122,7 +122,7 @@ namespace quicr {
                 if (!tqueue || tqueue->Empty())
                     continue;
 
-                return std::move(tqueue->Front());
+                return tqueue->Front();
             }
 
             return {};
@@ -141,7 +141,7 @@ namespace quicr {
                 if (!tqueue || tqueue->Empty())
                     continue;
 
-                return std::move(tqueue->PopFront());
+                return tqueue->PopFront();
             }
 
             return {};

--- a/include/quicr/detail/time_queue.h
+++ b/include/quicr/detail/time_queue.h
@@ -23,8 +23,8 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
-#include <vector>
 #include <stdexcept>
+#include <vector>
 
 #include "tick_service.h"
 

--- a/include/quicr/detail/time_queue.h
+++ b/include/quicr/detail/time_queue.h
@@ -20,16 +20,11 @@
 
 #pragma once
 
-#include <algorithm>
-#include <array>
 #include <atomic>
 #include <chrono>
 #include <memory>
-#include <mutex>
-#include <sys/select.h>
-#include <thread>
-#include <type_traits>
 #include <vector>
+#include <stdexcept>
 
 #include "tick_service.h"
 
@@ -198,7 +193,7 @@ namespace quicr {
          */
         [[nodiscard]] TimeQueueElement<T> PopFront()
         {
-            auto obj = std::move(Front());
+            auto obj = Front();
             if (obj.has_value) {
                 Pop();
             }

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -238,7 +238,7 @@ namespace quicr {
 
         void Init();
 
-        PublishTrackHandler::PublishObjectStatus SendObject(const PublishTrackHandler& track_handler,
+        PublishTrackHandler::PublishObjectStatus SendObject(PublishTrackHandler& track_handler,
                                                             uint8_t priority,
                                                             uint32_t ttl,
                                                             bool stream_header_needed,

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -296,7 +296,7 @@ namespace quicr {
         uint64_t object_payload_remaining_length_{ 0 };
         bool sent_track_header_{ false }; // Used only in stream per track mode
 
-        Bytes object_msg_buffer_;   // TODO(tievens): Review shrink/resize
+        Bytes object_msg_buffer_; // TODO(tievens): Review shrink/resize
 
         friend class Transport;
         friend class Client;

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -296,6 +296,8 @@ namespace quicr {
         uint64_t object_payload_remaining_length_{ 0 };
         bool sent_track_header_{ false }; // Used only in stream per track mode
 
+        Bytes object_msg_buffer_;   // TODO(tievens): Review shrink/resize
+
         friend class Transport;
         friend class Client;
         friend class Server;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -94,7 +94,22 @@ namespace quicr {
         spdlog::drop(logger_->name());
     }
 
-    void Transport::Init() {}
+    void Transport::Init()
+    {
+        if (client_mode_) {
+            // client init items
+
+            if (client_config_.transport_config.debug) {
+                logger_->set_level(spdlog::level::debug);
+            }
+        } else {
+            // Server init items
+
+            if (server_config_.transport_config.debug) {
+                logger_->set_level(spdlog::level::debug);
+            }
+        }
+    }
 
     Transport::Status Transport::Start()
     {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -565,7 +565,7 @@ namespace quicr {
         conn_it->second.pub_tracks_by_data_ctx_id[track_handler->publish_data_ctx_id_] = std::move(track_handler);
     }
 
-    PublishTrackHandler::PublishObjectStatus Transport::SendObject(const PublishTrackHandler& track_handler,
+    PublishTrackHandler::PublishObjectStatus Transport::SendObject(PublishTrackHandler& track_handler,
                                                                    uint8_t priority,
                                                                    uint32_t ttl,
                                                                    bool stream_header_needed,
@@ -584,8 +584,7 @@ namespace quicr {
 
         ITransport::EnqueueFlags eflags;
 
-        Bytes buffer;
-        buffer.reserve(data.size());
+        track_handler.object_msg_buffer_.clear();
 
         switch (track_handler.default_track_mode_) {
             case TrackMode::kDatagram: {
@@ -597,7 +596,7 @@ namespace quicr {
                 object.track_alias = *track_handler.GetTrackAlias();
                 object.extensions = extensions;
                 object.payload.assign(data.begin(), data.end());
-                buffer << object;
+                track_handler.object_msg_buffer_ << object;
                 break;
             }
             case TrackMode::kStreamPerObject: {
@@ -612,7 +611,7 @@ namespace quicr {
                 object.track_alias = *track_handler.GetTrackAlias();
                 object.extensions = extensions;
                 object.payload.assign(data.begin(), data.end());
-                buffer << object;
+                track_handler.object_msg_buffer_ << object;
 
                 break;
             }
@@ -630,14 +629,14 @@ namespace quicr {
                     group_hdr.priority = priority;
                     group_hdr.subscribe_id = *track_handler.GetSubscribeId();
                     group_hdr.track_alias = *track_handler.GetTrackAlias();
-                    buffer << group_hdr;
+                    track_handler.object_msg_buffer_ << group_hdr;
                 }
 
                 MoqStreamGroupObject object;
                 object.object_id = object_id;
                 object.extensions = extensions;
                 object.payload.assign(data.begin(), data.end());
-                buffer << object;
+                track_handler.object_msg_buffer_ << object;
 
                 break;
             }
@@ -651,7 +650,7 @@ namespace quicr {
                     track_hdr.priority = priority;
                     track_hdr.subscribe_id = *track_handler.GetSubscribeId();
                     track_hdr.track_alias = *track_handler.GetTrackAlias();
-                    buffer << track_hdr;
+                    track_handler.object_msg_buffer_ << track_hdr;
                 }
 
                 MoqStreamTrackObject object;
@@ -659,14 +658,19 @@ namespace quicr {
                 object.object_id = object_id;
                 object.extensions = extensions;
                 object.payload.assign(data.begin(), data.end());
-                buffer << object;
+                track_handler.object_msg_buffer_ << object;
 
                 break;
             }
         }
 
-        quic_transport_->Enqueue(
-          track_handler.connection_handle_, track_handler.publish_data_ctx_id_, buffer, priority, ttl, 0, eflags);
+        quic_transport_->Enqueue(track_handler.connection_handle_,
+                                 track_handler.publish_data_ctx_id_,
+                                 track_handler.object_msg_buffer_,
+                                 priority,
+                                 ttl,
+                                 0,
+                                 eflags);
 
         return PublishTrackHandler::PublishObjectStatus::kOk;
     }


### PR DESCRIPTION
Fixes stream race issue causing picoquic to close connections due to local error 5. 

Also added the following:

* Fixed debug logging in transport to be set when transport config enables debug
* Added reusable publish send object buffer to avoid needless allocations for every object sent