### PR TITLE
Indicate remote close on remote close in connection status

### DIFF
--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -102,6 +102,12 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
 
     void ObjectReceived(const quicr::ObjectHeaders& object_headers, quicr::BytesSpan data) override
     {
+        if (data.size() > 255) {
+            SPDLOG_CRITICAL("Example server is for example only, received data > 255 bytes is not allowed!");
+            SPDLOG_CRITICAL("Use github.com/quicr/laps for full relay functionality");
+            throw std::runtime_error("Example server is for example only, received data > 255 bytes is not allowed!");
+        }
+
         std::lock_guard<std::mutex> _(qserver_vars::state_mutex);
 
         auto track_alias = GetTrackAlias();

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -261,7 +261,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
             SPDLOG_LOGGER_INFO(transport->logger, "Application closed conn_id: {0}", conn_id);
             [[fallthrough]];
         case picoquic_callback_close: {
-            uint64_t app_reason_code = 0;
+            uint64_t app_reason_code = picoquic_get_application_error(pq_cnx);
             std::ostringstream log_msg;
             log_msg << "Closing connection conn_id: " << conn_id << " stream_id: " << stream_id;
 
@@ -727,7 +727,7 @@ PicoQuicTransport::Close(const TransportConnId& conn_id, uint64_t app_reason_cod
             break;
 
         case 100: // Client shutting down connection
-            OnConnectionStatus(conn_id, TransportStatus::kShutdown);
+            OnConnectionStatus(conn_id, TransportStatus::kRemoteRequestClose);
             picoquic_close(conn_it->second.pq_cnx, app_reason_code);
             break;
 


### PR DESCRIPTION
Fixes the connection status reason type to correctly indicate the reason for the close.

Also adds a limit of 255 byte objects for `examples/qserver`.  Example `qserver` is for simple testing and demo/examples.  Full relay functionality is only maintained under https://github.com/quicr/laps
