### PR TITLE
expose connection handle to external application

### DIFF
--- a/include/quicr/client.h
+++ b/include/quicr/client.h
@@ -220,6 +220,16 @@ namespace quicr {
             }
         }
 
+        /**
+         * @brief Get the connection handle
+         *
+         * @return ConnectionHandle of the client
+         */
+        std::optional<ConnectionHandle> GetConnectionHandle() const
+        {
+            return connection_handle_;
+        }
+
       private:
         bool ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan stream_buffer) override;
 

--- a/include/quicr/client.h
+++ b/include/quicr/client.h
@@ -225,10 +225,7 @@ namespace quicr {
          *
          * @return ConnectionHandle of the client
          */
-        std::optional<ConnectionHandle> GetConnectionHandle() const
-        {
-            return connection_handle_;
-        }
+        std::optional<ConnectionHandle> GetConnectionHandle() const { return connection_handle_; }
 
       private:
         bool ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan stream_buffer) override;


### PR DESCRIPTION
For one homer server, it should be able to connect different relay servers for the different conferences, this connection handle should be defined as one map identification in libquicr.