### PR TITLE
Handle control parse errors

### DIFF
--- a/src/server.cpp
+++ b/src/server.cpp
@@ -369,5 +369,4 @@ namespace quicr {
         return false;
     }
 
-    }
 } // namespace quicr


### PR DESCRIPTION
This fixes the server so that it doesn't crash due to invalid parsing (throws). 