### PR TITLE
Shared memory access implementation

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -188,7 +188,7 @@ void
 DoPublisher(const quicr::FullTrackName& full_track_name, const std::shared_ptr<quicr::Client>& client, const bool& stop)
 {
     auto track_handler = std::make_shared<MyPublishTrackHandler>(
-      full_track_name, quicr::TrackMode::kStream /*mode*/, 2 /*prirority*/, 3000 /*ttl*/);
+      full_track_name, quicr::TrackMode::kDatagram /*mode*/, 2 /*priority*/, 3000 /*ttl*/);
 
     SPDLOG_INFO("Started publisher track");
 

--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -188,7 +188,7 @@ void
 DoPublisher(const quicr::FullTrackName& full_track_name, const std::shared_ptr<quicr::Client>& client, const bool& stop)
 {
     auto track_handler = std::make_shared<MyPublishTrackHandler>(
-      full_track_name, quicr::TrackMode::kDatagram /*mode*/, 2 /*priority*/, 3000 /*ttl*/);
+      full_track_name, quicr::TrackMode::kStream /*mode*/, 2 /*priority*/, 3000 /*ttl*/);
 
     SPDLOG_INFO("Started publisher track");
 

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -505,7 +505,7 @@ class MyServer : public quicr::Server
                     attrs.priority);
 
         auto pub_track_h =
-          std::make_shared<MyPublishTrackHandler>(track_full_name, quicr::TrackMode::kDatagram, attrs.priority, 50000);
+          std::make_shared<MyPublishTrackHandler>(track_full_name, quicr::TrackMode::kStream, attrs.priority, 50000);
         qserver_vars::subscribes[th.track_fullname_hash][connection_handle] = pub_track_h;
         qserver_vars::subscribe_alias_sub_id[connection_handle][subscribe_id] = th.track_fullname_hash;
 

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -625,19 +625,11 @@ class MyServer : public quicr::Server
             return false;
         }
 
-        for (const auto& group : groups) {
-            for (const auto& object : *group) {
-                SPDLOG_INFO("Fetch cache group: {} object_id: {}", object.headers.group_id, object.headers.object_id);
-            }
-        }
-
-        bool status = std::any_of(groups.begin(), groups.end(), [&](const auto& group) {
+        return std::any_of(groups.begin(), groups.end(), [&](const auto& group) {
             return !group->empty() && group->begin()->headers.object_id <= attrs.start_object &&
                    std::prev(group->end())->headers.object_id >= (attrs.end_object - 1);
         });
-
-        SPDLOG_INFO("Fetch status is {}", status);
-        return status;
+        ;
     }
 
     /**

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -505,7 +505,7 @@ class MyServer : public quicr::Server
                     attrs.priority);
 
         auto pub_track_h =
-          std::make_shared<MyPublishTrackHandler>(track_full_name, quicr::TrackMode::kStream, attrs.priority, 50000);
+          std::make_shared<MyPublishTrackHandler>(track_full_name, quicr::TrackMode::kDatagram, attrs.priority, 50000);
         qserver_vars::subscribes[th.track_fullname_hash][connection_handle] = pub_track_h;
         qserver_vars::subscribe_alias_sub_id[connection_handle][subscribe_id] = th.track_fullname_hash;
 

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -22,13 +22,7 @@ using FullTrackNameHash = uint64_t;
  */
 struct CacheObject
 {
-    uint8_t priority;
-    uint32_t ttl;
-    bool stream_header_needed;
-    uint64_t group_id;
-    uint64_t subgroup_id;
-    uint64_t object_id;
-    std::optional<quicr::Extensions> extensions;
+    quicr::ObjectHeaders headers;
     quicr::Bytes data;
 };
 
@@ -40,7 +34,7 @@ struct std::less<CacheObject>
 {
     constexpr bool operator()(const CacheObject& lhs, const CacheObject& rhs) const noexcept
     {
-        return lhs.object_id < rhs.object_id;
+        return lhs.headers.object_id < rhs.headers.object_id;
     }
 };
 
@@ -116,6 +110,17 @@ namespace qserver_vars {
     std::unordered_map<quicr::messages::TrackAlias,
                        std::unordered_map<quicr::ConnectionHandle, std::shared_ptr<quicr::SubscribeTrackHandler>>>
       pub_subscribes;
+
+    /**
+     * Cache of MoQ objects by track namespace hash
+     */
+    std::map<quicr::TrackNamespaceHash, quicr::Cache<quicr::messages::GroupId, std::set<CacheObject>>> cache;
+
+    /**
+     * Tick Service used by the cache
+     */
+    std::shared_ptr<quicr::ThreadedTickService> tick_service = std::make_shared<quicr::ThreadedTickService>();
+
 }
 
 /**
@@ -159,6 +164,24 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
             return;
         }
 
+        // Cache Object
+        if (qserver_vars::cache.count(*track_alias) == 0) {
+            qserver_vars::cache.insert(std::make_pair(
+              *track_alias,
+              quicr::Cache<quicr::messages::GroupId, std::set<CacheObject>>{ 50000, 1, qserver_vars::tick_service }));
+        }
+
+        auto& cache_entry = qserver_vars::cache.at(*track_alias);
+
+        CacheObject object{ object_headers, { data.begin(), data.end() } };
+
+        if (auto group = cache_entry.Get(object_headers.group_id)) {
+            group->insert(std::move(object));
+        } else {
+            cache_entry.Insert(object_headers.group_id, { std::move(object) }, 50000);
+        }
+
+        // Fan out to all subscribers
         for (const auto& [conn_id, pth] : sub_it->second) {
             pth->PublishObject(object_headers, data);
         }
@@ -513,35 +536,8 @@ class MyServer : public quicr::Server
         qserver_vars::subscribe_active[th.track_namespace_hash][th.track_name_hash].emplace(
           qserver_vars::SubscribeInfo{ connection_handle, subscribe_id, th.track_fullname_hash });
 
-        auto&& cache_message_callback = [&, tnsh = th.track_namespace_hash](uint8_t priority,
-                                                                            uint32_t ttl,
-                                                                            bool stream_header_needed,
-                                                                            uint64_t group_id,
-                                                                            uint64_t subgroup_id,
-                                                                            uint64_t object_id,
-                                                                            std::optional<quicr::Extensions> extensions,
-                                                                            quicr::BytesSpan data) {
-            if (cache_.count(tnsh) == 0) {
-                cache_.insert(std::make_pair(
-                  tnsh, quicr::Cache<quicr::messages::GroupId, std::set<CacheObject>>{ ttl, 1, GetTickService() }));
-            }
-
-            auto& cache_entry = cache_.at(tnsh);
-
-            CacheObject object{
-                priority,    ttl,       stream_header_needed, group_id,
-                subgroup_id, object_id, extensions,           { data.begin(), data.end() },
-            };
-
-            if (auto group = cache_entry.Get(group_id)) {
-                group->insert(std::move(object));
-            } else {
-                cache_entry.Insert(group_id, { std::move(object) }, ttl);
-            }
-        };
-
         // Create a subscribe track that will be used by the relay to send to subscriber for matching objects
-        BindPublisherTrack(connection_handle, subscribe_id, pub_track_h, false, std::move(cache_message_callback));
+        BindPublisherTrack(connection_handle, subscribe_id, pub_track_h, false);
 
         // Subscribe to announcer if announcer is active
         auto anno_ns_it = qserver_vars::announce_active.find(th.track_namespace_hash);
@@ -597,7 +593,7 @@ class MyServer : public quicr::Server
      * @param connection_handle Source connection ID.
      * @param subscribe_id      Subscribe ID received.
      * @param track_full_name   Track full name
-     * @param attributes        Fetch attributes received.
+     * @param attrs             Fetch attributes received.
      *
      * @returns true if the range of groups and objects exist in the cache, otherwise returns false.
      */
@@ -614,9 +610,9 @@ class MyServer : public quicr::Server
 
         const auto th = quicr::TrackHash(track_full_name);
 
-        auto cache_entry_it = cache_.find(th.track_namespace_hash);
-        if (cache_entry_it == cache_.end()) {
-            SPDLOG_WARN("No cache entry for the hash {}", th.track_namespace_hash);
+        auto cache_entry_it = qserver_vars::cache.find(th.track_fullname_hash);
+        if (cache_entry_it == qserver_vars::cache.end()) {
+            SPDLOG_WARN("No cache entry for the hash {}", th.track_fullname_hash);
             return false;
         }
 
@@ -629,10 +625,19 @@ class MyServer : public quicr::Server
             return false;
         }
 
-        return std::any_of(groups.begin(), groups.end(), [&](const auto& group) {
-            return !group->empty() && group->begin()->object_id <= attrs.start_object &&
-                   std::prev(group->end())->object_id >= (attrs.end_object - 1);
+        for (const auto& group : groups) {
+            for (const auto& object : *group) {
+                SPDLOG_INFO("Fetch cache group: {} object_id: {}", object.headers.group_id, object.headers.object_id);
+            }
+        }
+
+        bool status = std::any_of(groups.begin(), groups.end(), [&](const auto& group) {
+            return !group->empty() && group->begin()->headers.object_id <= attrs.start_object &&
+                   std::prev(group->end())->headers.object_id >= (attrs.end_object - 1);
         });
+
+        SPDLOG_INFO("Fetch status is {}", status);
+        return status;
     }
 
     /**
@@ -658,26 +663,15 @@ class MyServer : public quicr::Server
         const auto th = quicr::TrackHash(track_full_name);
 
         std::thread retrieve_cache_thread(
-          [=, cache_entries = cache_.at(th.track_namespace_hash).Get(attrs.start_group, attrs.end_group)] {
+          [=, cache_entries = qserver_vars::cache.at(th.track_fullname_hash).Get(attrs.start_group, attrs.end_group)] {
               for (const auto& cache_entry : cache_entries) {
                   for (const auto& object : *cache_entry) {
-                      if ((object.group_id < attrs.start_group || object.group_id >= attrs.end_group) ||
-                          (object.object_id < attrs.start_object || object.object_id >= attrs.end_object))
+                      if ((object.headers.group_id < attrs.start_group || object.headers.group_id >= attrs.end_group) ||
+                          (object.headers.object_id < attrs.start_object ||
+                           object.headers.object_id >= attrs.end_object))
                           continue;
 
-                      quicr::ObjectHeaders obj_headers{
-                          object.group_id,
-                          object.object_id,
-                          object.subgroup_id,
-                          object.data.size(),
-                          quicr::ObjectStatus::kAvailable,
-                          object.priority,
-                          object.ttl,
-                          std::nullopt,
-                          object.extensions,
-                      };
-
-                      pub_track_h->PublishObject(obj_headers, object.data);
+                      pub_track_h->PublishObject(object.headers, object.data);
                       std::this_thread::sleep_for(std::chrono::milliseconds(1));
                   }
               }
@@ -694,7 +688,6 @@ class MyServer : public quicr::Server
 
   private:
     /// The server cache for fetching from.
-    std::map<quicr::TrackNamespaceHash, quicr::Cache<quicr::messages::GroupId, std::set<CacheObject>>> cache_;
     const int kSubscriptionDampenDurationMs_ = 1000;
     std::optional<std::chrono::time_point<std::chrono::steady_clock>> last_subscription_time_;
 };

--- a/include/quicr/detail/data_storage.h
+++ b/include/quicr/detail/data_storage.h
@@ -142,7 +142,7 @@ namespace quicr {
             return value;
         }
 
-        std::size_t erase(std::size_t len) noexcept
+        std::size_t EraseFront(std::size_t len) noexcept
         {
             for (const auto s : buffer_) {
                 if (s == nullptr)
@@ -171,10 +171,10 @@ namespace quicr {
         BufferType buffer_;
     };
 
-    class DataStorageSpan
+    class DataStorageDynView
     {
       public:
-        DataStorageSpan(std::shared_ptr<DataStorage<>> storage,
+        DataStorageDynView(std::shared_ptr<DataStorage<>> storage,
                         std::size_t start_pos = 0,
                         std::optional<std::size_t> end_pos = std::nullopt)
           : storage_(std::move(storage))
@@ -183,22 +183,22 @@ namespace quicr {
         {
         }
 
-        DataStorageSpan(const DataStorageSpan&) = default;
-        DataStorageSpan(DataStorageSpan&&) = default;
-        DataStorageSpan& operator=(const DataStorageSpan&) = default;
-        DataStorageSpan& operator=(DataStorageSpan&&) = default;
+        DataStorageDynView(const DataStorageDynView&) = default;
+        DataStorageDynView(DataStorageDynView&&) = default;
+        DataStorageDynView& operator=(const DataStorageDynView&) = default;
+        DataStorageDynView& operator=(DataStorageDynView&&) = default;
 
-        DataStorageSpan Subspan(std::size_t start_pos, std::optional<std::size_t> end_pos = std::nullopt) const noexcept
+        DataStorageDynView Subspan(std::size_t start_pos, std::optional<std::size_t> end_pos = std::nullopt) const noexcept
         {
             if (not end_pos.has_value() || *end_pos > storage_->size()) {
                 end_pos = storage_->size();
             }
 
-            return DataStorageSpan(storage_, start_pos, *end_pos);
+            return DataStorageDynView(storage_, start_pos, *end_pos);
         }
 
         // NOLINTBEGIN(readability-identifier-naming)
-        std::size_t size() const noexcept { return end_pos_.has_value() ? *end_pos_ : storage_->size(); }
+        std::size_t size() const noexcept { return (end_pos_.has_value() ? *end_pos_ : storage_->size()) - start_pos_; }
 
         DataStorage<>::iterator begin() noexcept { return std::next(storage_->begin(), start_pos_); }
         DataStorage<>::iterator end() noexcept { return std::next(this->begin(), size()); }

--- a/include/quicr/detail/data_storage.h
+++ b/include/quicr/detail/data_storage.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <deque>
 #include <vector>
 
 namespace quicr {
@@ -86,7 +87,7 @@ namespace quicr {
 
       protected:
         using SliceType = std::shared_ptr<std::vector<uint8_t, Allocator>>;
-        using BufferType = std::vector<SliceType>;
+        using BufferType = std::deque<SliceType>;
 
         DataStorage() = default;
 
@@ -110,6 +111,7 @@ namespace quicr {
 
         const SliceType& First() const noexcept { return *(this->begin()); }
         const SliceType& Last() const noexcept { return *std::prev(this->end()); }
+        const SliceType GetLast() const noexcept { return *std::prev(this->end()); }
 
         void Push(Span<const uint8_t> bytes)
         {

--- a/include/quicr/detail/data_storage.h
+++ b/include/quicr/detail/data_storage.h
@@ -194,7 +194,7 @@ namespace quicr {
                 end_pos = storage_->size();
             }
 
-            return DataStorageSpan(storage_, start_pos_, *end_pos);
+            return DataStorageSpan(storage_, start_pos, *end_pos);
         }
 
         // NOLINTBEGIN(readability-identifier-naming)

--- a/include/quicr/detail/data_storage.h
+++ b/include/quicr/detail/data_storage.h
@@ -4,11 +4,10 @@
 #pragma once
 
 #include "span.h"
-
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <optional>
-#include <deque>
 #include <vector>
 
 namespace quicr {
@@ -141,6 +140,23 @@ namespace quicr {
                 value += buf->size();
             }
             return value;
+        }
+
+        std::size_t erase(std::size_t len) const noexcept
+        {
+            for (const auto s : buffer_) {
+                if (s == nullptr)
+                    return 0;
+
+                if (len >= s->size()) {
+                    buffer_.pop_front();
+                    len -= s->size();
+                } else {
+                    return len;
+                }
+            }
+
+            return 0;
         }
 
         iterator begin() noexcept { return iterator(buffer_.begin(), buffer_.end()); }

--- a/include/quicr/detail/data_storage.h
+++ b/include/quicr/detail/data_storage.h
@@ -175,8 +175,8 @@ namespace quicr {
     {
       public:
         DataStorageDynView(std::shared_ptr<DataStorage<>> storage,
-                        std::size_t start_pos = 0,
-                        std::optional<std::size_t> end_pos = std::nullopt)
+                           std::size_t start_pos = 0,
+                           std::optional<std::size_t> end_pos = std::nullopt)
           : storage_(std::move(storage))
           , start_pos_(start_pos)
           , end_pos_(end_pos)
@@ -188,7 +188,8 @@ namespace quicr {
         DataStorageDynView& operator=(const DataStorageDynView&) = default;
         DataStorageDynView& operator=(DataStorageDynView&&) = default;
 
-        DataStorageDynView Subspan(std::size_t start_pos, std::optional<std::size_t> end_pos = std::nullopt) const noexcept
+        DataStorageDynView Subspan(std::size_t start_pos,
+                                   std::optional<std::size_t> end_pos = std::nullopt) const noexcept
         {
             if (not end_pos.has_value() || *end_pos > storage_->size()) {
                 end_pos = storage_->size();

--- a/include/quicr/detail/messages.h
+++ b/include/quicr/detail/messages.h
@@ -408,7 +408,6 @@ namespace quicr::messages {
 
     struct MoqObjectDatagram
     {
-        SubscribeId subscribe_id;
         TrackAlias track_alias;
         GroupId group_id;
         ObjectId object_id;
@@ -433,7 +432,6 @@ namespace quicr::messages {
     struct MoqStreamHeaderSubGroup
     {
         TrackAlias track_alias;
-        SubscribeId subscribe_id;
         GroupId group_id;
         SubGroupId subgroup_id;
         ObjectPriority priority;

--- a/include/quicr/detail/priority_queue.h
+++ b/include/quicr/detail/priority_queue.h
@@ -168,7 +168,7 @@ namespace quicr {
             std::lock_guard<std::mutex> _(mutex_);
 
             for (auto& tqueue : queue_) {
-                if (tqueue && !tqueue->Empty())
+                if (tqueue)
                     tqueue->Clear();
             }
         }

--- a/include/quicr/detail/priority_queue.h
+++ b/include/quicr/detail/priority_queue.h
@@ -112,9 +112,11 @@ namespace quicr {
         /**
          * @brief Get the first object from queue
          *
+         * @param elem[out]          Time queue element storage. Will be updated.
+         *
          * @return TimeQueueElement<DataType> value from time queue
          */
-        TimeQueueElement<DataType> Front()
+        void Front(TimeQueueElement<DataType>& elem)
         {
             std::lock_guard<std::mutex> _(mutex_);
 
@@ -122,18 +124,18 @@ namespace quicr {
                 if (!tqueue || tqueue->Empty())
                     continue;
 
-                return tqueue->Front();
+                tqueue->Front(elem);
             }
-
-            return {};
         }
 
         /**
          * @brief Get and remove the first object from queue
          *
+         * @param elem[out]          Time queue element storage. Will be updated.
+         *
          * @return TimeQueueElement<DataType> from time queue
          */
-        TimeQueueElement<DataType> PopFront()
+        void PopFront(TimeQueueElement<DataType>& elem)
         {
             std::lock_guard<std::mutex> _(mutex_);
 
@@ -141,10 +143,8 @@ namespace quicr {
                 if (!tqueue || tqueue->Empty())
                     continue;
 
-                return tqueue->PopFront();
+                tqueue->PopFront(elem);
             }
-
-            return {};
         }
 
         /**

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -124,7 +124,7 @@ namespace quicr {
         std::any caller_any; ///< Caller any object - Set and used by caller/app
 
         /// Data queue for received data on the stream
-        SafeQueue<std::shared_ptr<std::vector<uint8_t>>> data_queue;
+        SafeQueue<std::shared_ptr<const std::vector<uint8_t>>> data_queue;
     };
 
     /**
@@ -425,7 +425,7 @@ namespace quicr {
          *
          * @returns std::nullopt if there is no data
          */
-        virtual std::optional<std::shared_ptr<std::vector<uint8_t>>> Dequeue(
+        virtual std::optional<std::shared_ptr<const std::vector<uint8_t>>> Dequeue(
           TransportConnId conn_id,
           std::optional<DataContextId> data_ctx_id) = 0;
 

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -124,7 +124,7 @@ namespace quicr {
         std::any caller_any; ///< Caller any object - Set and used by caller/app
 
         /// Data queue for received data on the stream
-        SafeQueue<std::shared_ptr<std::vector<uint8_t>>> data_queue;
+        SafeQueue<std::shared_ptr<const std::vector<uint8_t>>> data_queue;
     };
 
     /**

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include "quic_transport_metrics.h"
-#include "quicr/detail/tick_service.h"
 #include "quicr/detail/data_storage.h"
+#include "quicr/detail/tick_service.h"
 #include "safe_queue.h"
 #include "span.h"
 #include "stream_buffer.h"
@@ -13,12 +13,11 @@
 
 #include <spdlog/spdlog.h>
 
+#include <any>
 #include <array>
 #include <chrono>
 #include <memory>
 #include <mutex>
-#include <any>
-#include <memory>
 #include <optional>
 #include <queue>
 #include <string>
@@ -122,7 +121,7 @@ namespace quicr {
     /// Stream receive data context
     struct StreamRxContext
     {
-        std::any caller_any;                           ///< Caller any object - Set and used by caller/app
+        std::any caller_any; ///< Caller any object - Set and used by caller/app
 
         /// Data queue for received data on the stream
         SafeQueue<std::shared_ptr<std::vector<uint8_t>>> data_queue;

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -124,7 +124,7 @@ namespace quicr {
         std::any caller_any; ///< Caller any object - Set and used by caller/app
 
         /// Data queue for received data on the stream
-        SafeQueue<std::shared_ptr<const std::vector<uint8_t>>> data_queue;
+        SafeQueue<std::shared_ptr<std::vector<uint8_t>>> data_queue;
     };
 
     /**
@@ -425,7 +425,7 @@ namespace quicr {
          *
          * @returns std::nullopt if there is no data
          */
-        virtual std::optional<std::shared_ptr<const std::vector<uint8_t>>> Dequeue(
+        virtual std::optional<std::shared_ptr<std::vector<uint8_t>>> Dequeue(
           TransportConnId conn_id,
           std::optional<DataContextId> data_ctx_id) = 0;
 

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -425,9 +425,8 @@ namespace quicr {
          *
          * @returns std::nullopt if there is no data
          */
-        virtual std::optional<std::shared_ptr<const std::vector<uint8_t>>> Dequeue(
-          TransportConnId conn_id,
-          std::optional<DataContextId> data_ctx_id) = 0;
+        virtual std::shared_ptr<const std::vector<uint8_t>> Dequeue(TransportConnId conn_id,
+                                                                    std::optional<DataContextId> data_ctx_id) = 0;
 
         /**
          * @brief Get the stream RX context by connection ID and stream ID

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -106,11 +106,20 @@ namespace quicr {
         uint8_t quic_priority_limit{ 0 };      /// Lowest priority that will not be bypassed from pacing/CC in picoquic
     };
 
+    /// Stream action that should be done by send/receive processing
+    enum class StreamAction : uint8_t
+    {
+        kNoAction = 0,
+        kReplaceStreamUseReset,
+        kReplaceStreamUseFin,
+    };
+
     struct ConnData
     {
         TransportConnId conn_id;
         DataContextId data_ctx_id;
         uint8_t priority;
+        StreamAction stream_action{ StreamAction::kNoAction };
 
         /// Shared pointer is used so transport can take ownership of the vector without copy/new allocation
         std::shared_ptr<const std::vector<uint8_t>> data;
@@ -122,7 +131,7 @@ namespace quicr {
     struct StreamRxContext
     {
         std::any caller_any; ///< Caller any object - Set and used by caller/app
-        bool is_new {true}; ///< Indicates if new stream, on read set to false
+        bool is_new{ true }; ///< Indicates if new stream, on read set to false
 
         /// Data queue for received data on the stream
         SafeQueue<std::shared_ptr<const std::vector<uint8_t>>> data_queue;

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -122,6 +122,7 @@ namespace quicr {
     struct StreamRxContext
     {
         std::any caller_any; ///< Caller any object - Set and used by caller/app
+        bool is_new {true}; ///< Indicates if new stream, on read set to false
 
         /// Data queue for received data on the stream
         SafeQueue<std::shared_ptr<const std::vector<uint8_t>>> data_queue;

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -444,9 +444,9 @@ namespace quicr {
          * @param conn_id                   Connection ID to get stream context from
          * @param stream_id                 Context stream ID
          *
-         * @returns reference to StreamRxContext
+         * @returns Shared pointer to StreamRxContext
          * @throws TransportError for invalid connection or stream id
          */
-        virtual StreamRxContext& GetStreamRxContext(TransportConnId conn_id, uint64_t stream_id) = 0;
+        virtual std::shared_ptr<StreamRxContext> GetStreamRxContext(TransportConnId conn_id, uint64_t stream_id) = 0;
     };
 } // namespace quicr

--- a/include/quicr/detail/safe_queue.h
+++ b/include/quicr/detail/safe_queue.h
@@ -31,7 +31,7 @@ namespace quicr {
          * @param limit     Limit number of messages in queue before push blocks. Zero
          *                  is unlimited.
          */
-        SafeQueue(uint32_t limit = 1000)
+        SafeQueue(uint32_t limit = 5'000)
           : stop_waiting_{ false }
           , limit_{ limit }
         {

--- a/include/quicr/detail/stream_buffer.h
+++ b/include/quicr/detail/stream_buffer.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "data_storage.h"
 #include "span.h"
 #include "uintvar.h"
 
@@ -24,6 +25,7 @@ namespace quicr {
     class StreamBuffer
     {
         using BufferT = std::deque<T, Allocator>;
+        //using BufferT = DataStorage<Allocator>;
 
       public:
         StreamBuffer() = default;

--- a/include/quicr/detail/stream_buffer.h
+++ b/include/quicr/detail/stream_buffer.h
@@ -92,6 +92,12 @@ namespace quicr {
          */
         void SetAnyType(uint64_t type) { parsed_data_type_ = type; }
 
+        void Clear()
+        {
+            ResetAny();
+            buffer_.clear();
+        }
+
         void ResetAny()
         {
             parsed_data_.reset();

--- a/include/quicr/detail/stream_buffer.h
+++ b/include/quicr/detail/stream_buffer.h
@@ -25,7 +25,6 @@ namespace quicr {
     class StreamBuffer
     {
         using BufferT = std::deque<T, Allocator>;
-        //using BufferT = DataStorage<Allocator>;
 
       public:
         StreamBuffer() = default;

--- a/include/quicr/detail/time_queue.h
+++ b/include/quicr/detail/time_queue.h
@@ -268,11 +268,10 @@ namespace quicr {
 
             queue_.clear();
 
-            for (const auto& index : buckets_in_use_) {
+            for (const auto& index : buckets_) {
                 buckets_.at(index).clear();
             }
 
-            buckets_in_use_.clear();
             queue_index_ = bucket_index_ = 0;
         }
 
@@ -338,7 +337,6 @@ namespace quicr {
 
             bucket.emplace_back(value);
             queue_.emplace_back(bucket, bucket.size() - 1, expiry_tick, ticks + delay_ttl);
-            buckets_in_use_.push_back(future_index);
         }
 
       protected:
@@ -368,9 +366,6 @@ namespace quicr {
 
         /// Tick service for calculating new tick and jumps in time.
         std::shared_ptr<TickService> tick_service_;
-
-        /// Set of buckets in use that should be cleared when clear is called
-        std::vector<IndexType> buckets_in_use_;
     };
 
 }; // namespace quicr

--- a/include/quicr/detail/time_queue.h
+++ b/include/quicr/detail/time_queue.h
@@ -268,8 +268,8 @@ namespace quicr {
 
             queue_.clear();
 
-            for (const auto& index : buckets_) {
-                buckets_.at(index).clear();
+            for (const auto& bucket : buckets_) {
+                buckets_.clear();
             }
 
             queue_index_ = bucket_index_ = 0;

--- a/include/quicr/detail/time_queue.h
+++ b/include/quicr/detail/time_queue.h
@@ -321,17 +321,19 @@ namespace quicr {
         {
             if (ttl > duration_) {
                 throw std::invalid_argument("TTL is greater than max duration");
-            } else if (ttl == 0) {
+            }
+
+            if (ttl == 0) {
                 ttl = duration_;
             }
 
-            ttl = ttl / interval_;
+            auto relative_ttl = ttl / interval_;
 
             const TickType ticks = Advance();
 
             const TickType expiry_tick = ticks + ttl;
 
-            const IndexType future_index = (bucket_index_ + ttl - 1) % total_buckets_;
+            const IndexType future_index = (bucket_index_ + relative_ttl - 1) % total_buckets_;
 
             BucketType& bucket = buckets_[future_index];
 

--- a/include/quicr/detail/time_queue.h
+++ b/include/quicr/detail/time_queue.h
@@ -195,13 +195,13 @@ namespace quicr {
          */
         [[nodiscard]] TimeQueueElement<T> PopFront()
         {
-            TimeQueueElement<T> obj;
+            TimeQueueElement<T> obj{};
             Front(obj);
             if (obj.has_value) {
                 Pop();
             }
 
-            return obj;
+            return std::move(obj);
         }
 
         /**

--- a/include/quicr/detail/time_queue.h
+++ b/include/quicr/detail/time_queue.h
@@ -268,8 +268,8 @@ namespace quicr {
 
             queue_.clear();
 
-            for (const auto& bucket : buckets_) {
-                buckets_.clear();
+            for (auto& bucket : buckets_) {
+                bucket.clear();
             }
 
             queue_index_ = bucket_index_ = 0;
@@ -335,7 +335,7 @@ namespace quicr {
 
             BucketType& bucket = buckets_[future_index];
 
-            bucket.emplace_back(value);
+            bucket.push_back(value);
             queue_.emplace_back(bucket, bucket.size() - 1, expiry_tick, ticks + delay_ttl);
         }
 

--- a/include/quicr/detail/time_queue.h
+++ b/include/quicr/detail/time_queue.h
@@ -195,8 +195,8 @@ namespace quicr {
          */
         [[nodiscard]] TimeQueueElement<T> PopFront()
         {
-            TimeQueueElement<T> result;
-            auto obj = Front(result);
+            TimeQueueElement<T> obj;
+            Front(obj);
             if (obj.has_value) {
                 Pop();
             }

--- a/include/quicr/detail/time_queue.h
+++ b/include/quicr/detail/time_queue.h
@@ -263,7 +263,7 @@ namespace quicr {
          */
         void Clear() noexcept
         {
-            if (queue_.empty() || queue_.size() < 40)
+            if (queue_.empty() /*|| queue_.size() < 40 */) // TODO: Need to review delayed purge
                 return;
 
             queue_.clear();

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -254,6 +254,9 @@ namespace quicr {
             /// Tracks by subscribe ID (Subscribe and Fetch)
             std::map<messages::SubscribeId, std::shared_ptr<SubscribeTrackHandler>> tracks_by_sub_id;
 
+            /// Subscribes by Track Alais is used for data object forwarding
+            std::map<messages::TrackAlias, std::shared_ptr<SubscribeTrackHandler>> sub_by_track_alias;
+
             /// Publish tracks by namespace and name. map[track namespace][track name] = track handler
             std::map<TrackNamespaceHash, std::map<TrackNameHash, std::shared_ptr<PublishTrackHandler>>>
               pub_tracks_by_name;

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -363,8 +363,7 @@ namespace quicr {
 
         virtual bool ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan msg_bytes) = 0;
 
-        bool ProcessStreamDataMessage(ConnectionContext& conn_ctx,
-                                      StreamBuffer<uint8_t>& stream_buffer);
+        bool ProcessStreamDataMessage(ConnectionContext& conn_ctx, StreamBuffer<uint8_t>& stream_buffer);
 
         template<class MessageType>
         std::pair<MessageType&, bool> ParseDataMessage(StreamBuffer<uint8_t>& stream_buffer,

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -272,6 +272,12 @@ namespace quicr {
 
         void Init();
 
+        PublishTrackHandler::PublishObjectStatus SendData(PublishTrackHandler& track_handler,
+                                                          uint8_t priority,
+                                                          uint32_t ttl,
+                                                          bool stream_header_needed,
+                                                          std::shared_ptr<const std::vector<uint8_t>> data);
+
         PublishTrackHandler::PublishObjectStatus SendObject(PublishTrackHandler& track_handler,
                                                             uint8_t priority,
                                                             uint32_t ttl,
@@ -281,6 +287,7 @@ namespace quicr {
                                                             uint64_t object_id,
                                                             std::optional<Extensions> extensions,
                                                             BytesSpan data);
+
 
         void SendCtrlMsg(const ConnectionContext& conn_ctx, BytesSpan data);
         void SendClientSetup();

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -288,7 +288,6 @@ namespace quicr {
                                                             std::optional<Extensions> extensions,
                                                             BytesSpan data);
 
-
         void SendCtrlMsg(const ConnectionContext& conn_ctx, BytesSpan data);
         void SendClientSetup();
         void SendServerSetup(ConnectionContext& conn_ctx);

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -364,14 +364,14 @@ namespace quicr {
         virtual bool ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan msg_bytes) = 0;
 
         bool ProcessStreamDataMessage(ConnectionContext& conn_ctx,
-                                      std::shared_ptr<SafeStreamBuffer<uint8_t>>& stream_buffer);
+                                      StreamBuffer<uint8_t>& stream_buffer);
 
         template<class MessageType>
-        std::pair<MessageType&, bool> ParseDataMessage(std::shared_ptr<SafeStreamBuffer<uint8_t>>& stream_buffer,
+        std::pair<MessageType&, bool> ParseDataMessage(StreamBuffer<uint8_t>& stream_buffer,
                                                        messages::DataMessageType msg_type);
 
         template<class HeaderType, class MessageType>
-        std::pair<HeaderType&, bool> ParseStreamData(std::shared_ptr<SafeStreamBuffer<uint8_t>>& stream_buffer,
+        std::pair<HeaderType&, bool> ParseStreamData(StreamBuffer<uint8_t>& stream_buffer,
                                                      messages::DataMessageType msg_type);
 
       private:

--- a/include/quicr/metrics.h
+++ b/include/quicr/metrics.h
@@ -16,13 +16,13 @@ namespace quicr {
 
         QuicConnectionMetrics quic; ///< QUIC connection metrics
 
-        uint64_t rx_dgram_unknown_subscribe_id{ 0 }; ///< Received datagram with unknown subscribe ID
-        uint64_t rx_dgram_invalid_type{ 0 };         ///< Received datagram with invalid type of OBJECT_DATAGRAM
-        uint64_t rx_dgram_decode_failed{ 0 };        ///< Failed to decode datagram
+        uint64_t rx_dgram_unknown_track_alias{ 0 }; ///< Received datagram with unknown track alias
+        uint64_t rx_dgram_invalid_type{ 0 };        ///< Received datagram with invalid type of OBJECT_DATAGRAM
+        uint64_t rx_dgram_decode_failed{ 0 };       ///< Failed to decode datagram
 
-        uint64_t rx_stream_buffer_error{ 0 };         ///< Stream buffer error that results in bad parsing
-        uint64_t rx_stream_unknown_subscribe_id{ 0 }; ///< Received stream header with unknown subscribe ID
-        uint64_t rx_stream_invalid_type{ 0 };         ///< Invalid message type
+        uint64_t rx_stream_buffer_error{ 0 };        ///< Stream buffer error that results in bad parsing
+        uint64_t rx_stream_unknown_track_alias{ 0 }; ///< Received stream header with unknown track alias
+        uint64_t rx_stream_invalid_type{ 0 };        ///< Invalid message type
 
         uint64_t invalid_ctrl_stream_msg{ 0 }; ///< Invalid control stream message received. Should always be 0.
     };

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -295,26 +295,6 @@ namespace quicr {
                                             bool stream_header_needed,
                                             std::shared_ptr<const std::vector<uint8_t>> data)>;
 
-
-        /**
-         * @brief Event on Publish Object function via the MoQ instance
-         *
-         * @param priority              Priority to use for object; set on next track change
-         * @param ttl                   Expire time to live in milliseconds
-         * @param stream_header_needed  Indicates if group or track header is needed before this data object
-         * @param group_id              The ID of the group the message belongs to
-         * @param object_id             The ID of the object this message represents
-         * @param extensions            Extensions to send along with the message
-         * @param data                  Raw data/object that should be transmitted - MoQInstance serializes the data
-         */
-        using OnPublishObjFunction = std::function<void(uint8_t priority,
-                                                        uint32_t ttl,
-                                                        bool stream_header_needed,
-                                                        uint64_t group_id,
-                                                        uint64_t subgroup_id,
-                                                        uint64_t object_id,
-                                                        std::optional<Extensions> extensions,
-                                                        BytesSpan data)>;
         /**
          * @brief Set the Data context ID
          *

--- a/include/quicr/server.h
+++ b/include/quicr/server.h
@@ -89,13 +89,11 @@ namespace quicr {
          * @param subscribe_id              Subscribe ID from the received subscribe
          * @param track_handler             Server publish track handler
          * @param ephemeral                 Bool value to indicate if the state tracking is needed
-         * @param callback                  Callback to run extra functionality on sending messages.
          */
         void BindPublisherTrack(ConnectionHandle connection_handle,
                                 uint64_t subscribe_id,
                                 const std::shared_ptr<PublishTrackHandler>& track_handler,
-                                bool ephemeral = false,
-                                PublishTrackHandler::OnPublishObjFunction&& callback = nullptr);
+                                bool ephemeral = false);
 
         /**
          * @brief Unbind a server publish track handler

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -5,6 +5,7 @@
 
 #include <quicr/detail/base_track_handler.h>
 #include <quicr/detail/messages.h>
+#include <quicr/detail/stream_buffer.h>
 #include <quicr/metrics.h>
 
 namespace quicr {
@@ -211,6 +212,7 @@ namespace quicr {
         messages::ObjectPriority priority_;
         messages::GroupOrder group_order_;
         messages::FilterType filter_type_;
+        StreamBuffer<uint8_t> stream_buffer_;
 
         friend class Transport;
         friend class Client;

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -145,9 +145,12 @@ namespace quicr {
          * @details Event notification to provide the caller the raw data received on a stream
          *
          * @param is_start    True to indicate if this data is the start of a new stream
+         * @param stream_id   Stream ID data was received on
          * @param data        Shared pointer to the data received
          */
-        virtual void StreamDataRecv(bool is_start, std::shared_ptr<const std::vector<uint8_t>> data);
+        virtual void StreamDataRecv(bool is_start,
+                                    uint64_t stream_id,
+                                    std::shared_ptr<const std::vector<uint8_t>> data);
 
         /**
          * @brief Notification of received datagram data
@@ -220,6 +223,7 @@ namespace quicr {
         messages::GroupOrder group_order_;
         messages::FilterType filter_type_;
         StreamBuffer<uint8_t> stream_buffer_;
+        uint64_t current_stream_id_{ 0 };
 
         friend class Transport;
         friend class Client;

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -90,6 +90,13 @@ namespace quicr {
         constexpr Status GetStatus() const noexcept { return status_; }
 
         /**
+         * @brief Set the priority of received data
+         *
+         * @param priority      Priority value of received data
+         */
+        void SetPriority(uint8_t priority) noexcept { priority_ = priority; }
+
+        /**
          * @brief Get subscription priority
          *
          * @return Priority value

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -129,9 +129,26 @@ namespace quicr {
          * @param data              Object payload data received, **MUST** match ObjectHeaders::payload_length.
          */
         virtual void ObjectReceived([[maybe_unused]] const ObjectHeaders& object_headers,
-                                    [[maybe_unused]] BytesSpan data)
-        {
-        }
+                                    [[maybe_unused]] BytesSpan data);
+
+        /**
+         * @brief Notification of received stream data slice
+         *
+         * @details Event notification to provide the caller the raw data received on a stream
+         *
+         * @param is_start    True to indicate if this data is the start of a new stream
+         * @param data        Shared pointer to the data received
+         */
+        virtual void StreamDataRecv(bool is_start, std::shared_ptr<const std::vector<uint8_t>> data);
+
+        /**
+         * @brief Notification of received datagram data
+         *
+         * @details Event notification to provide the caller the raw data received as a datagram
+         *
+         * @param data        Shared pointer to the data received
+         */
+        virtual void DgramDataRecv(std::shared_ptr<const std::vector<uint8_t>> data);
 
         /**
          * @brief Notification of a partial object received data object

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources (quicr PRIVATE
     client.cpp
     messages.cpp
     publish_track_handler.cpp
+    subscribe_track_handler.cpp
     server.cpp
     quic_transport.cpp
     transport.cpp

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -376,11 +376,12 @@ namespace quicr {
 
                 auto fetch_it = conn_ctx.tracks_by_sub_id.find(msg.subscribe_id);
                 if (fetch_it == conn_ctx.tracks_by_sub_id.end()) {
-                    SPDLOG_LOGGER_WARN(
-                      logger_,
-                      "Received fetch error for unkown fetch track conn_id: {0} subscribe_id: {1}, ignored",
-                      conn_ctx.connection_handle,
-                      msg.subscribe_id);
+                    SPDLOG_LOGGER_WARN(logger_,
+                                       "Received fetch error for unknown fetch track conn_id: {} subscribe_id: {} "
+                                       "error code: {}, ignored",
+                                       conn_ctx.connection_handle,
+                                       msg.subscribe_id,
+                                       msg.err_code);
                     return true;
                 }
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -859,7 +859,6 @@ namespace quicr::messages {
     Bytes& operator<<(Bytes& buffer, const MoqObjectDatagram& msg)
     {
         buffer << UintVar(static_cast<uint64_t>(DataMessageType::OBJECT_DATAGRAM));
-        buffer << UintVar(msg.subscribe_id);
         buffer << UintVar(msg.track_alias);
         buffer << UintVar(msg.group_id);
         buffer << UintVar(msg.object_id);
@@ -882,34 +881,27 @@ namespace quicr::messages {
     {
         switch (msg.current_pos) {
             case 0: {
-                if (!ParseUintVField(buffer, msg.subscribe_id)) {
-                    return false;
-                }
-                msg.current_pos += 1;
-                [[fallthrough]];
-            }
-            case 1: {
                 if (!ParseUintVField(buffer, msg.track_alias)) {
                     return false;
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 2: {
+            case 1: {
                 if (!ParseUintVField(buffer, msg.group_id)) {
                     return false;
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 3: {
+            case 2: {
                 if (!ParseUintVField(buffer, msg.object_id)) {
                     return false;
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 4: {
+            case 3: {
                 auto val = buffer.Front();
                 if (!val) {
                     return false;
@@ -919,14 +911,14 @@ namespace quicr::messages {
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 5: {
+            case 4: {
                 if (!ParseUintVField(buffer, msg.payload_len)) {
                     return false;
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 6: {
+            case 5: {
                 if (msg.payload_len == 0) {
                     uint64_t status = 0;
                     if (!ParseUintVField(buffer, status)) {
@@ -938,7 +930,7 @@ namespace quicr::messages {
                 [[fallthrough]];
             }
 
-            case 7: {
+            case 6: {
                 if (!ParseExtensions(buffer, msg.num_extensions, msg.extensions, msg.current_tag)) {
                     return false;
                 }
@@ -950,7 +942,7 @@ namespace quicr::messages {
                 [[fallthrough]];
             }
 
-            case 8: {
+            case 7: {
                 if (!buffer.Available(msg.payload_len)) {
                     return false;
                 }
@@ -978,7 +970,6 @@ namespace quicr::messages {
     {
         buffer << UintVar(static_cast<uint64_t>(DataMessageType::STREAM_HEADER_SUBGROUP));
         buffer << UintVar(msg.track_alias);
-        buffer << UintVar(msg.subscribe_id);
         buffer << UintVar(msg.group_id);
         buffer << UintVar(msg.subgroup_id);
         buffer.push_back(msg.priority);
@@ -997,34 +988,26 @@ namespace quicr::messages {
                 [[fallthrough]];
             }
             case 1: {
-                if (!ParseUintVField(buffer, msg.subscribe_id)) {
-                    return false;
-                }
-                msg.current_pos += 1;
-                [[fallthrough]];
-            }
-            case 2: {
                 if (!ParseUintVField(buffer, msg.group_id)) {
                     return false;
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 3: {
+            case 2: {
                 if (!ParseUintVField(buffer, msg.subgroup_id)) {
                     return false;
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 4: {
+            case 3: {
                 auto val = buffer.Front();
                 if (!val) {
                     return false;
                 }
                 buffer.Pop();
                 msg.priority = val.value();
-                ;
                 msg.current_pos += 1;
                 msg.parse_completed = true;
                 [[fallthrough]];

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -16,36 +16,34 @@ namespace quicr {
                 break;
             case Status::kNoSubscribers:
                 publish_track_metrics_.objects_dropped_not_ok++;
-            return PublishObjectStatus::kNoSubscribers;
+                return PublishObjectStatus::kNoSubscribers;
             case Status::kPendingAnnounceResponse:
                 [[fallthrough]];
             case Status::kNotAnnounced:
                 [[fallthrough]];
             case Status::kNotConnected:
                 publish_track_metrics_.objects_dropped_not_ok++;
-            return PublishObjectStatus::kNotAnnounced;
+                return PublishObjectStatus::kNotAnnounced;
             case Status::kAnnounceNotAuthorized:
                 publish_track_metrics_.objects_dropped_not_ok++;
-            return PublishObjectStatus::kNotAuthorized;
+                return PublishObjectStatus::kNotAuthorized;
             case Status::kSubscriptionUpdated:
                 // reset the status to ok to imply change
-                    publish_status_ = Status::kOk;
-            break;
+                publish_status_ = Status::kOk;
+                break;
             default:
                 publish_track_metrics_.objects_dropped_not_ok++;
-            return PublishObjectStatus::kInternalError;
+                return PublishObjectStatus::kInternalError;
         }
 
         publish_track_metrics_.bytes_published += data->size();
 
         if (forward_publish_data_func_ != nullptr) {
             return forward_publish_data_func_(default_priority_, default_ttl_, is_new_stream, data);
-
         }
 
         return PublishObjectStatus::kInternalError;
     }
-
 
     PublishTrackHandler::PublishObjectStatus PublishTrackHandler::PublishObject(const ObjectHeaders& object_headers,
                                                                                 BytesSpan data)

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -7,6 +7,46 @@ namespace quicr {
     void PublishTrackHandler::StatusChanged(Status) {}
     void PublishTrackHandler::MetricsSampled(const PublishTrackMetrics&) {}
 
+    PublishTrackHandler::PublishObjectStatus PublishTrackHandler::ForwardPublishedData(
+      bool is_new_stream,
+      std::shared_ptr<const std::vector<uint8_t>> data)
+    {
+        switch (publish_status_) {
+            case Status::kOk:
+                break;
+            case Status::kNoSubscribers:
+                publish_track_metrics_.objects_dropped_not_ok++;
+            return PublishObjectStatus::kNoSubscribers;
+            case Status::kPendingAnnounceResponse:
+                [[fallthrough]];
+            case Status::kNotAnnounced:
+                [[fallthrough]];
+            case Status::kNotConnected:
+                publish_track_metrics_.objects_dropped_not_ok++;
+            return PublishObjectStatus::kNotAnnounced;
+            case Status::kAnnounceNotAuthorized:
+                publish_track_metrics_.objects_dropped_not_ok++;
+            return PublishObjectStatus::kNotAuthorized;
+            case Status::kSubscriptionUpdated:
+                // reset the status to ok to imply change
+                    publish_status_ = Status::kOk;
+            break;
+            default:
+                publish_track_metrics_.objects_dropped_not_ok++;
+            return PublishObjectStatus::kInternalError;
+        }
+
+        publish_track_metrics_.bytes_published += data->size();
+
+        if (forward_publish_data_func_ != nullptr) {
+            return forward_publish_data_func_(default_priority_, default_ttl_, is_new_stream, data);
+
+        }
+
+        return PublishObjectStatus::kInternalError;
+    }
+
+
     PublishTrackHandler::PublishObjectStatus PublishTrackHandler::PublishObject(const ObjectHeaders& object_headers,
                                                                                 BytesSpan data)
     {

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -101,9 +101,9 @@ namespace quicr {
                                         object_headers.object_id,
                                         object_headers.extensions,
                                         data);
-        } else {
-            return PublishObjectStatus::kInternalError;
         }
+
+        return PublishObjectStatus::kInternalError;
     }
 
 } // namespace quicr

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -139,11 +139,10 @@ namespace quicr {
             uint32_t ttl,
             bool stream_header_needed,
             std::shared_ptr<const std::vector<uint8_t>> data) -> PublishTrackHandler::PublishObjectStatus {
-            auto handler = weak_track_handler.lock();
-            if (!handler) {
-                return PublishTrackHandler::PublishObjectStatus::kInternalError;
+            if (auto handler = weak_track_handler.lock()) {
+                return SendData(*handler, priority, ttl, stream_header_needed, data);
             }
-            return SendData(*handler, priority, ttl, stream_header_needed, data);
+            return PublishTrackHandler::PublishObjectStatus::kInternalError;
         };
 
         if (!ephemeral) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -83,8 +83,7 @@ namespace quicr {
     void Server::BindPublisherTrack(TransportConnId conn_id,
                                     uint64_t subscribe_id,
                                     const std::shared_ptr<PublishTrackHandler>& track_handler,
-                                    bool ephemeral,
-                                    PublishTrackHandler::OnPublishObjFunction&& callback)
+                                    bool ephemeral)
     {
         // Generate track alias
         const auto& tfn = track_handler->GetFullTrackName();
@@ -116,22 +115,18 @@ namespace quicr {
 
         // Setup the function for the track handler to use to send objects with thread safety
         std::weak_ptr weak_track_handler(track_handler);
-        track_handler->publish_object_func_ = [&, weak_track_handler, cb = std::move(callback)](
-                                                uint8_t priority,
-                                                uint32_t ttl,
-                                                bool stream_header_needed,
-                                                uint64_t group_id,
-                                                uint64_t subgroup_id,
-                                                uint64_t object_id,
-                                                std::optional<Extensions> extensions,
-                                                Span<uint8_t const> data) -> PublishTrackHandler::PublishObjectStatus {
+        track_handler->publish_object_func_ =
+          [&, weak_track_handler](uint8_t priority,
+                                  uint32_t ttl,
+                                  bool stream_header_needed,
+                                  uint64_t group_id,
+                                  uint64_t subgroup_id,
+                                  uint64_t object_id,
+                                  std::optional<Extensions> extensions,
+                                  Span<uint8_t const> data) -> PublishTrackHandler::PublishObjectStatus {
             auto th = weak_track_handler.lock();
             if (!th) {
                 return PublishTrackHandler::PublishObjectStatus::kInternalError;
-            }
-
-            if (cb) {
-                cb(priority, ttl, stream_header_needed, group_id, subgroup_id, object_id, extensions, data);
             }
 
             return SendObject(

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -138,6 +138,19 @@ namespace quicr {
               *th, priority, ttl, stream_header_needed, group_id, subgroup_id, object_id, extensions, data);
         };
 
+        track_handler->forward_publish_data_func_ =
+          [&, weak_track_handler](
+            uint8_t priority,
+            uint32_t ttl,
+            bool stream_header_needed,
+            std::shared_ptr<const std::vector<uint8_t>> data) -> PublishTrackHandler::PublishObjectStatus {
+            auto handler = weak_track_handler.lock();
+            if (!handler) {
+                return PublishTrackHandler::PublishObjectStatus::kInternalError;
+            }
+            return SendData(*handler, priority, ttl, stream_header_needed, data);
+        };
+
         if (!ephemeral) {
             // Hold onto track handler
             conn_it->second.pub_tracks_by_name[th.track_namespace_hash][th.track_name_hash] = track_handler;

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include "quicr/detail/messages.h"
+#include "quicr/detail/stream_buffer.h"
+#include <quicr/subscribe_track_handler.h>
+
+namespace quicr {
+
+    void SubscribeTrackHandler::ObjectReceived(const ObjectHeaders& object_headers, BytesSpan data) {}
+
+    void SubscribeTrackHandler::StreamDataRecv(bool is_start, std::shared_ptr<const std::vector<uint8_t>> data)
+    {
+        if (is_start) { // New stream
+            stream_buffer_.Clear();
+
+            // Parse stream header
+        }
+
+    }
+
+    void SubscribeTrackHandler::DgramDataRecv(std::shared_ptr<const std::vector<uint8_t>> data)
+    {
+        stream_buffer_.Clear();
+
+        stream_buffer_.Push(*data);
+        stream_buffer_.Pop();   // Remove type header
+
+        messages::MoqObjectDatagram msg;
+        if (stream_buffer_ >> msg) {
+            SPDLOG_LOGGER_TRACE(logger_,
+                                "Received object datagram conn_id: {0} data_ctx_id: {1} subscriber_id: {2} "
+                                "track_alias: {3} group_id: {4} object_id: {5} data size: {6}",
+                                conn_id,
+                                (data_ctx_id ? *data_ctx_id : 0),
+                                msg.subscribe_id,
+                                msg.track_alias,
+                                msg.group_id,
+                                msg.object_id,
+                                msg.payload.size());
+
+            subscribe_track_metrics_.objects_received++;
+            subscribe_track_metrics_.bytes_received += msg.payload.size();
+            ObjectReceived(
+              {
+                msg.group_id,
+                msg.object_id,
+                0, // datagrams don't have subgroups
+                msg.payload.size(),
+                ObjectStatus::kAvailable,
+                msg.priority,
+                std::nullopt,
+                TrackMode::kDatagram,
+                msg.extensions,
+              },
+              std::move(msg.payload));
+        }
+    }
+
+} // namespace quicr

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -12,8 +12,18 @@ namespace quicr {
     {
     }
 
-    void SubscribeTrackHandler::StreamDataRecv(bool is_start, std::shared_ptr<const std::vector<uint8_t>> data)
+    void SubscribeTrackHandler::StreamDataRecv(bool is_start,
+                                               uint64_t stream_id,
+                                               std::shared_ptr<const std::vector<uint8_t>> data)
     {
+        if (stream_id > current_stream_id_) {
+            current_stream_id_ = stream_id;
+        } else if (stream_id < current_stream_id_) {
+            SPDLOG_DEBUG(
+              "Old stream data received, stream_id: {} is less than {}, ignoring", stream_id, current_stream_id_);
+            return;
+        }
+
         if (is_start) {
             stream_buffer_.Clear();
 

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -7,7 +7,10 @@
 
 namespace quicr {
 
-    void SubscribeTrackHandler::ObjectReceived(const ObjectHeaders& object_headers, BytesSpan data) {}
+    void SubscribeTrackHandler::ObjectReceived([[maybe_unused]] const ObjectHeaders& object_headers,
+                                               [[maybe_unused]] BytesSpan data)
+    {
+    }
 
     void SubscribeTrackHandler::StreamDataRecv(bool is_start, std::shared_ptr<const std::vector<uint8_t>> data)
     {

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -11,12 +11,59 @@ namespace quicr {
 
     void SubscribeTrackHandler::StreamDataRecv(bool is_start, std::shared_ptr<const std::vector<uint8_t>> data)
     {
-        if (is_start) { // New stream
+        if (is_start) {
             stream_buffer_.Clear();
 
-            // Parse stream header
+            stream_buffer_.InitAny<messages::MoqStreamHeaderSubGroup>();
+            stream_buffer_.Push(*data);
+            stream_buffer_.Pop(); // Remove type header
+
+            // Expect that on initial start of stream, there is enough data to process the stream headers
+
+            auto& s_hdr = stream_buffer_.GetAny<messages::MoqStreamHeaderSubGroup>();
+            if (not(stream_buffer_ >> s_hdr)) {
+                SPDLOG_ERROR("Not enough data to process new stream headers, stream is invalid");
+                // TODO: Add metrics to track this
+                return;
+            }
+        } else {
+            stream_buffer_.Push(*data);
         }
 
+        auto& s_hdr = stream_buffer_.GetAny<messages::MoqStreamHeaderSubGroup>();
+
+        if (not stream_buffer_.AnyHasValueB()) {
+            stream_buffer_.InitAnyB<messages::MoqStreamSubGroupObject>();
+        }
+
+        auto& obj = stream_buffer_.GetAnyB<messages::MoqStreamSubGroupObject>();
+        if (stream_buffer_ >> obj) {
+            SPDLOG_TRACE("Received stream_subgroup_object subscribe_id: {} priority: {} track_alias: {} "
+                         "group_id: {} subgroup_id: {} object_id: {} data size: {}",
+                         s_hdr.subscribe_id,
+                         s_hdr.priority,
+                         s_hdr.track_alias,
+                         s_hdr.group_id,
+                         s_hdr.subgroup_id,
+                         obj.object_id,
+                         obj.payload.size());
+
+            subscribe_track_metrics_.objects_received++;
+            subscribe_track_metrics_.bytes_received += obj.payload.size();
+
+            ObjectReceived({ s_hdr.group_id,
+                             obj.object_id,
+                             s_hdr.subgroup_id,
+                             obj.payload.size(),
+                             obj.object_status,
+                             s_hdr.priority,
+                             std::nullopt,
+                             TrackMode::kStream,
+                             obj.extensions },
+                           obj.payload);
+
+            stream_buffer_.ResetAnyB<messages::MoqStreamSubGroupObject>();
+        }
     }
 
     void SubscribeTrackHandler::DgramDataRecv(std::shared_ptr<const std::vector<uint8_t>> data)
@@ -24,20 +71,19 @@ namespace quicr {
         stream_buffer_.Clear();
 
         stream_buffer_.Push(*data);
-        stream_buffer_.Pop();   // Remove type header
+        stream_buffer_.Pop(); // Remove type header
 
         messages::MoqObjectDatagram msg;
         if (stream_buffer_ >> msg) {
-            SPDLOG_LOGGER_TRACE(logger_,
-                                "Received object datagram conn_id: {0} data_ctx_id: {1} subscriber_id: {2} "
-                                "track_alias: {3} group_id: {4} object_id: {5} data size: {6}",
-                                conn_id,
-                                (data_ctx_id ? *data_ctx_id : 0),
-                                msg.subscribe_id,
-                                msg.track_alias,
-                                msg.group_id,
-                                msg.object_id,
-                                msg.payload.size());
+            SPDLOG_TRACE("Received object datagram conn_id: {0} data_ctx_id: {1} subscriber_id: {2} "
+                         "track_alias: {3} group_id: {4} object_id: {5} data size: {6}",
+                         conn_id,
+                         (data_ctx_id ? *data_ctx_id : 0),
+                         msg.subscribe_id,
+                         msg.track_alias,
+                         msg.group_id,
+                         msg.object_id,
+                         msg.payload.size());
 
             subscribe_track_metrics_.objects_received++;
             subscribe_track_metrics_.bytes_received += msg.payload.size();

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1191,8 +1191,8 @@ namespace quicr {
         MoqObjectDatagram object_datagram_out;
         for (int i = 0; i < kReadLoopMaxPerStream; i++) {
             auto data = quic_transport_->Dequeue(conn_id, data_ctx_id);
-            if (data.has_value() && !data.value()->empty() && data.value()->size() > 3) {
-                auto msg_type = data.value()->front();
+            if (data && !data->empty() && data->size() > 3) {
+                auto msg_type = data->front();
 
                 if (!msg_type || static_cast<DataMessageType>(msg_type) != DataMessageType::OBJECT_DATAGRAM) {
                     SPDLOG_LOGGER_DEBUG(logger_,
@@ -1205,7 +1205,7 @@ namespace quicr {
                 uint64_t track_alais = 0;
                 try {
                     // Decode and check next header, subscribe ID
-                    auto cursor_it = std::next(data.value()->begin(), 1);
+                    auto cursor_it = std::next(data->begin(), 1);
 
                     auto track_alias_sz = quicr::UintVar::Size(*cursor_it);
                     track_alais = uint64_t(quicr::UintVar({ cursor_it, cursor_it + track_alias_sz }));
@@ -1239,8 +1239,8 @@ namespace quicr {
 
                 auto& handler = sub_it->second;
 
-                handler->DgramDataRecv(*data);
-            } else if (data.has_value()) {
+                handler->DgramDataRecv(data);
+            } else if (data) {
                 auto& conn_ctx = connections_[conn_id];
                 conn_ctx.metrics.rx_dgram_decode_failed++;
 
@@ -1248,7 +1248,7 @@ namespace quicr {
                                     "Failed to decode datagram conn_id: {} data_ctx_id: {} size: {}",
                                     conn_id,
                                     (data_ctx_id ? *data_ctx_id : 0),
-                                    data.value()->size());
+                                    data->size());
             }
         }
     }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1039,7 +1039,7 @@ namespace quicr {
                 break;
             }
 
-            auto data_opt = std::move(rx_ctx.data_queue.Pop());
+            auto data_opt = rx_ctx.data_queue.Pop();
             if (not data_opt.has_value()) {
                 break;
             }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1224,13 +1224,13 @@ namespace quicr {
                     continue;
                 }
 
-                uint64_t track_alais = 0;
+                uint64_t track_alias = 0;
                 try {
                     // Decode and check next header, subscribe ID
                     auto cursor_it = std::next(data->begin(), 1);
 
                     auto track_alias_sz = quicr::UintVar::Size(*cursor_it);
-                    track_alais = uint64_t(quicr::UintVar({ cursor_it, cursor_it + track_alias_sz }));
+                    track_alias = uint64_t(quicr::UintVar({ cursor_it, cursor_it + track_alias_sz }));
                     cursor_it += track_alias_sz;
 
                 } catch (std::invalid_argument&) {
@@ -1238,12 +1238,12 @@ namespace quicr {
                 }
 
                 auto& conn_ctx = connections_[conn_id];
-                auto sub_it = conn_ctx.sub_by_track_alias.find(track_alais);
+                auto sub_it = conn_ctx.sub_by_track_alias.find(track_alias);
                 if (sub_it == conn_ctx.sub_by_track_alias.end()) {
                     conn_ctx.metrics.rx_dgram_unknown_track_alias++;
 
                     SPDLOG_LOGGER_DEBUG(
-                      logger_, "Received datagram to unknown subscribe track track alias: {0}, ignored", track_alais);
+                      logger_, "Received datagram to unknown subscribe track track alias: {0}, ignored", track_alias);
 
                     // TODO(tievens): Should close/reset stream in this case but draft leaves this case hanging
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1179,8 +1179,8 @@ namespace quicr {
                     conn_ctx.metrics.rx_stream_unknown_track_alias++;
                     SPDLOG_LOGGER_WARN(
                       logger_,
-                      "Received stream_header_subgroup to unknown subscribe track track_alias: {}, ignored",
-                      track_alias);
+                      "Received stream_header_subgroup to unknown subscribe track track_alias: {} stream: {}, ignored",
+                      track_alias, stream_id);
 
                     // TODO(tievens): Should close/reset stream in this case but draft leaves this case hanging
                     break;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -870,6 +870,20 @@ namespace quicr {
                     subgroup_hdr.priority = priority;
                     subgroup_hdr.track_alias = *track_handler.GetTrackAlias();
                     track_handler.object_msg_buffer_ << subgroup_hdr;
+
+                    quic_transport_->Enqueue(track_handler.connection_handle_,
+                                             track_handler.publish_data_ctx_id_,
+                                             std::make_shared<std::vector<uint8_t>>(track_handler.object_msg_buffer_.begin(),
+                                                                                    track_handler.object_msg_buffer_.end()),
+                                             priority,
+                                             ttl,
+                                             0,
+                                             eflags);
+
+                    track_handler.object_msg_buffer_.clear();
+                    eflags.new_stream = false;
+                    eflags.clear_tx_queue = false;
+                    eflags.use_reset = false;
                 }
 
                 MoqStreamSubGroupObject object;

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1191,7 +1191,7 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, uint8_t* bytes_ctx, si
 
         if (obj.expired_count != 0) {
             SPDLOG_LOGGER_DEBUG(logger,
-                                "Send stream objects expired; conn_id: {} data_ctx_id: {} priority: {} expired: {}",
+                                "Send stream objects expired; conn_id: {} data_ctx_id: {} expired: {}",
                                 data_ctx->conn_id,
                                 data_ctx->data_ctx_id, obj.expired_count);
         }

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1358,19 +1358,19 @@ PicoQuicTransport::OnRecvStreamBytes(ConnectionContext* conn_ctx,
     if (rx_buf_it == conn_ctx->rx_stream_buffer.end()) {
         if (bytes.size() < kMinStreamBytesForSend) {
             SPDLOG_LOGGER_DEBUG(logger,
-                               "bytes received from picoquic stream {} len: {} IS NEW: {}",
-                               stream_id,
-                               bytes.size(),
-                               rx_buf_it->second.rx_ctx.caller_any.has_value());
+                                "bytes received from picoquic stream {} len: {} IS NEW: {}",
+                                stream_id,
+                                bytes.size(),
+                                rx_buf_it->second.rx_ctx.caller_any.has_value());
         }
         conn_ctx->rx_stream_buffer.try_emplace(stream_id);
 
     } else if (bytes.size() < kMinStreamBytesForSend) {
         SPDLOG_LOGGER_TRACE(logger,
-                           "bytes received from picoquic stream {} len: {} NOT NEW {}",
-                           stream_id,
-                           bytes.size(),
-                           rx_buf_it->second.rx_ctx.caller_any.has_value());
+                            "bytes received from picoquic stream {} len: {} NOT NEW {}",
+                            stream_id,
+                            bytes.size(),
+                            rx_buf_it->second.rx_ctx.caller_any.has_value());
     }
 
     auto& rx_buf = conn_ctx->rx_stream_buffer[stream_id];

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1354,7 +1354,27 @@ PicoQuicTransport::OnRecvStreamBytes(ConnectionContext* conn_ctx,
 
     std::lock_guard<std::mutex> l(state_mutex_);
 
+    auto rx_buf_it = conn_ctx->rx_stream_buffer.find(stream_id);
+    if (rx_buf_it == conn_ctx->rx_stream_buffer.end()) {
+        if (bytes.size() < kMinStreamBytesForSend) {
+            SPDLOG_LOGGER_DEBUG(logger,
+                               "bytes received from picoquic stream {} len: {} IS NEW: {}",
+                               stream_id,
+                               bytes.size(),
+                               rx_buf_it->second.rx_ctx.caller_any.has_value());
+        }
+        conn_ctx->rx_stream_buffer.try_emplace(stream_id);
+
+    } else if (bytes.size() < kMinStreamBytesForSend) {
+        SPDLOG_LOGGER_TRACE(logger,
+                           "bytes received from picoquic stream {} len: {} NOT NEW {}",
+                           stream_id,
+                           bytes.size(),
+                           rx_buf_it->second.rx_ctx.caller_any.has_value());
+    }
+
     auto& rx_buf = conn_ctx->rx_stream_buffer[stream_id];
+
     rx_buf.rx_ctx.data_queue.Push(std::make_shared<const std::vector<uint8_t>>(bytes.begin(), bytes.end()));
 
     if (data_ctx != nullptr) {

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -630,7 +630,7 @@ PicoQuicTransport::GetStreamRxContext(TransportConnId conn_id, uint64_t stream_i
     throw TransportError::kInvalidStreamId;
 }
 
-std::optional<std::shared_ptr<const std::vector<uint8_t>>>
+std::optional<std::shared_ptr<std::vector<uint8_t>>>
 PicoQuicTransport::Dequeue(TransportConnId conn_id, [[maybe_unused]] std::optional<DataContextId> data_ctx_id)
 {
     std::lock_guard<std::mutex> _(state_mutex_);

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -630,17 +630,22 @@ PicoQuicTransport::GetStreamRxContext(TransportConnId conn_id, uint64_t stream_i
     throw TransportError::kInvalidStreamId;
 }
 
-std::optional<std::shared_ptr<const std::vector<uint8_t>>>
+std::shared_ptr<const std::vector<uint8_t>>
 PicoQuicTransport::Dequeue(TransportConnId conn_id, [[maybe_unused]] std::optional<DataContextId> data_ctx_id)
 {
     std::lock_guard<std::mutex> _(state_mutex_);
 
     const auto conn_ctx_it = conn_context_.find(conn_id);
     if (conn_ctx_it == conn_context_.end()) {
-        return std::nullopt;
+        return {};
     }
 
-    return conn_ctx_it->second.dgram_rx_data.Pop();
+    auto data = conn_ctx_it->second.dgram_rx_data.Pop();
+    if (data.has_value()) {
+        return *data;
+    }
+
+    return {};
 }
 
 DataContextId

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1223,8 +1223,11 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, uint8_t* bytes_ctx, si
                                                              obj.value.tick_microseconds);
 
             if (StreamActionCheck(data_ctx, obj.value.stream_action)) {
-                SPDLOG_LOGGER_DEBUG(
-                  logger, "New Stream {} object size: {}", *data_ctx->current_stream_id, data_ctx->stream_tx_object->size());
+                SPDLOG_LOGGER_DEBUG(logger,
+                                    "New Stream conn_id: {} stream_id: {}, object size: {}",
+                                    data_ctx->conn_id,
+                                    *data_ctx->current_stream_id,
+                                    data_ctx->stream_tx_object->size());
                 return;
             }
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1378,6 +1378,7 @@ PicoQuicTransport::OnRecvStreamBytes(ConnectionContext* conn_ctx,
                                 rx_buf_it->second.rx_ctx.caller_any.has_value());
         }
         conn_ctx->rx_stream_buffer.try_emplace(stream_id);
+        conn_ctx->rx_stream_buffer[stream_id].rx_ctx.data_queue.SetLimit(tconfig_.time_queue_rx_size);
 
     } else if (bytes.size() < kMinStreamBytesForSend) {
         SPDLOG_LOGGER_TRACE(logger,

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1230,13 +1230,13 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, uint8_t* bytes_ctx, si
                 return;
             }
 
-            if (obj.value.data->size() > max_len) {
+            if (data_ctx->stream_tx_object->size() > max_len) {
                 data_ctx->stream_tx_object_offset = max_len;
                 data_len = max_len;
                 is_still_active = 1;
 
             } else {
-                data_len = obj.value.data->size();
+                data_len = data_ctx->stream_tx_object->size();
 
                 if (!data_ctx->tx_data->Empty()) {
                     is_still_active = 1;

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -235,7 +235,7 @@ namespace quicr {
                                uint32_t delay_ms,
                                EnqueueFlags flags) override;
 
-        std::optional<std::shared_ptr<const std::vector<uint8_t>>> Dequeue(
+        std::optional<std::shared_ptr<std::vector<uint8_t>>> Dequeue(
           TransportConnId conn_id,
           std::optional<DataContextId> data_ctx_id) override;
 

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -126,7 +126,7 @@ namespace quicr {
             std::unique_ptr<PriorityQueue<ConnData>>
               dgram_tx_data; /// Datagram pending objects to be written to the network
 
-            SafeQueue<std::shared_ptr<std::vector<uint8_t>>>
+            SafeQueue<std::shared_ptr<const std::vector<uint8_t>>>
               dgram_rx_data; /// Buffered datagrams received from the network
 
             /**
@@ -235,7 +235,7 @@ namespace quicr {
                                uint32_t delay_ms,
                                EnqueueFlags flags) override;
 
-        std::optional<std::shared_ptr<std::vector<uint8_t>>> Dequeue(TransportConnId conn_id,
+        std::optional<std::shared_ptr<const std::vector<uint8_t>>> Dequeue(TransportConnId conn_id,
                                                                      std::optional<DataContextId> data_ctx_id) override;
 
         StreamRxContext& GetStreamRxContext(TransportConnId conn_id, uint64_t stream_id) override;

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -124,9 +124,10 @@ namespace quicr {
             DataContextId next_data_ctx_id{ 1 }; /// Next data context ID; zero is reserved for default context
 
             std::unique_ptr<PriorityQueue<ConnData>>
-              dgram_tx_data;                 /// Datagram pending objects to be written to the network
+              dgram_tx_data; /// Datagram pending objects to be written to the network
 
-            SafeQueue<std::shared_ptr<std::vector<uint8_t>>> dgram_rx_data; /// Buffered datagrams received from the network
+            SafeQueue<std::shared_ptr<std::vector<uint8_t>>>
+              dgram_rx_data; /// Buffered datagrams received from the network
 
             /**
              * Active stream buffers for received unidirectional streams

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -42,7 +42,7 @@ namespace quicr {
     /**
      * Minimum bytes needed to write before considering to send. This doesn't
      */
-    constexpr int kMinStreamBytesForSend = 40;
+    constexpr int kMinStreamBytesForSend = 10;
 
     class PicoQuicTransport : public ITransport
     {
@@ -67,13 +67,6 @@ namespace quicr {
 
             DataContextId data_ctx_id{ 0 }; /// The ID of this context
             TransportConnId conn_id{ 0 };   /// The connection ID this context is under
-
-            enum class StreamAction : uint8_t
-            { /// Stream action that should be done by send/receive processing
-                kNoAction = 0,
-                kReplaceStreamUseReset,
-                kReplaceStreamUseFin,
-            } stream_action{ StreamAction::kNoAction };
 
             std::optional<uint64_t> current_stream_id; /// Current active stream if the value is >= 4
 
@@ -288,6 +281,8 @@ namespace quicr {
         void CheckConnsForCongestion();
         void EmitMetrics();
         void RemoveClosedStreams();
+
+        bool StreamActionCheck(DataContext* data_ctx, StreamAction stream_action);
 
         /**
          * @brief Function run the queue functions within the picoquic thread via the pq_loop_cb

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -240,9 +240,8 @@ namespace quicr {
                                uint32_t delay_ms,
                                EnqueueFlags flags) override;
 
-        std::optional<std::shared_ptr<const std::vector<uint8_t>>> Dequeue(
-          TransportConnId conn_id,
-          std::optional<DataContextId> data_ctx_id) override;
+        std::shared_ptr<const std::vector<uint8_t>> Dequeue(TransportConnId conn_id,
+                                                            std::optional<DataContextId> data_ctx_id) override;
 
         StreamRxContext& GetStreamRxContext(TransportConnId conn_id, uint64_t stream_id) override;
 

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -235,9 +235,8 @@ namespace quicr {
                                uint32_t delay_ms,
                                EnqueueFlags flags) override;
 
-        std::optional<std::shared_ptr<std::vector<uint8_t>>> Dequeue(
-          TransportConnId conn_id,
-          std::optional<DataContextId> data_ctx_id) override;
+        std::optional<std::shared_ptr<std::vector<uint8_t>>> Dequeue(TransportConnId conn_id,
+                                                                     std::optional<DataContextId> data_ctx_id) override;
 
         StreamRxContext& GetStreamRxContext(TransportConnId conn_id, uint64_t stream_id) override;
 

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -132,12 +132,12 @@ namespace quicr {
              */
             struct RxStreamBuffer
             {
-                std::shared_ptr<StreamRxContext> rx_ctx;     /// Stream RX context that holds data and caller info
-                bool closed{ false };       /// Indicates if stream is active or in closed state
-                bool checked_once{ false }; /// True if closed and checked once to close
+                std::shared_ptr<StreamRxContext> rx_ctx; /// Stream RX context that holds data and caller info
+                bool closed{ false };                    /// Indicates if stream is active or in closed state
+                bool checked_once{ false };              /// True if closed and checked once to close
 
                 RxStreamBuffer()
-                    : rx_ctx(std::make_shared<StreamRxContext>())
+                  : rx_ctx(std::make_shared<StreamRxContext>())
                 {
                     rx_ctx->caller_any.reset();
                     rx_ctx->data_queue.Clear();

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -39,6 +39,11 @@ namespace quicr {
     constexpr int kPqCcLowCwin = 4000;                /// Bytes less than this value are considered a low/congested CWIN
     constexpr int kCongestionCheckInterval = 100'000; /// Congestion check interval in microseconds
 
+    /**
+     * Minimum bytes needed to write before considering to send. This doesn't
+     */
+    constexpr int kMinStreamBytesForSend = 40;
+
     class PicoQuicTransport : public ITransport
     {
       public:
@@ -235,8 +240,9 @@ namespace quicr {
                                uint32_t delay_ms,
                                EnqueueFlags flags) override;
 
-        std::optional<std::shared_ptr<const std::vector<uint8_t>>> Dequeue(TransportConnId conn_id,
-                                                                     std::optional<DataContextId> data_ctx_id) override;
+        std::optional<std::shared_ptr<const std::vector<uint8_t>>> Dequeue(
+          TransportConnId conn_id,
+          std::optional<DataContextId> data_ctx_id) override;
 
         StreamRxContext& GetStreamRxContext(TransportConnId conn_id, uint64_t stream_id) override;
 

--- a/test/data_storage.cpp
+++ b/test/data_storage.cpp
@@ -64,3 +64,40 @@ TEST_CASE("DataStorage Multiples")
     CHECK_EQ(subview_v.at(1), 'w');
     CHECK_EQ(std::string{ buffer_subview.begin(), buffer_subview.end() }, "two thre");
 }
+
+TEST_CASE("DataStorage Add and Remove")
+{
+    auto buffer = quicr::DataStorage<>::Create();
+
+    std::string s1 = "one";
+    std::string s2 = " two";
+    std::string s3 = " three";
+
+    buffer->Push(quicr::AsBytes(s1));
+    buffer->Push(quicr::AsBytes(s2));
+
+    const auto buf_span = quicr::DataStorageSpan(buffer);
+    CHECK_EQ(buf_span.size(), buffer->size());
+
+    buffer->Push(quicr::AsBytes(s3));
+
+    CHECK_EQ(buf_span.size(), buffer->size());
+
+    auto size_before_erase = buffer->size();
+
+    // Shouldn't remove anything since 2 is less than first element
+    buffer->erase(2);
+    CHECK_EQ(buffer->size(), size_before_erase);
+
+    // Should remove the first element
+    buffer->erase(3);
+    CHECK_EQ(buffer->size(), size_before_erase - 3);
+
+    // Should remove the next two elements, but not the third
+    buffer->Push(quicr::AsBytes(s1));
+    buffer->Push(quicr::AsBytes(s1));
+    size_before_erase = buffer->size();
+    buffer->erase(11);
+
+    CHECK_EQ(buffer->size(), size_before_erase - 10);
+}

--- a/test/data_storage.cpp
+++ b/test/data_storage.cpp
@@ -52,17 +52,17 @@ TEST_CASE("DataStorage Multiples")
     CHECK_EQ(v.at(5), 'w');
     CHECK_EQ(std::string{ buffer->begin(), buffer->end() }, "one two three");
 
-    auto buffer_view = quicr::DataStorageSpan(buffer, 1, 11);
+    auto buffer_view = quicr::DataStorageDynView(buffer, 1, 11);
     std::vector<uint8_t> view_v(buffer_view.begin(), buffer_view.end());
-    CHECK_EQ(view_v.size(), s1.size() + s2.size() + s3.size() - 2);
+    CHECK_EQ(view_v.size(), 10);
     CHECK_EQ(view_v.at(4), 'w');
-    CHECK_EQ(std::string{ buffer_view.begin(), buffer_view.end() }, "ne two thre");
+    CHECK_EQ(std::string{ buffer_view.begin(), buffer_view.end() }, "ne two thr");
 
     auto buffer_subview = buffer_view.Subspan(3);
     std::vector<uint8_t> subview_v(buffer_subview.begin(), buffer_subview.end());
-    CHECK_EQ(subview_v.size(), s1.size() + s2.size() + s3.size() - 5);
-    CHECK_EQ(subview_v.at(1), 'w');
-    CHECK_EQ(std::string{ buffer_subview.begin(), buffer_subview.end() }, "two thre");
+    CHECK_EQ(subview_v.size(), s1.size() + s2.size() + s3.size() - 3);
+    CHECK_EQ(subview_v.at(1), 't');
+    CHECK_EQ(std::string{ buffer_subview.begin(), buffer_subview.end() }, " two three");
 }
 
 TEST_CASE("DataStorage Add and Remove")
@@ -76,28 +76,28 @@ TEST_CASE("DataStorage Add and Remove")
     buffer->Push(quicr::AsBytes(s1));
     buffer->Push(quicr::AsBytes(s2));
 
-    const auto buf_span = quicr::DataStorageSpan(buffer);
-    CHECK_EQ(buf_span.size(), buffer->size());
+    const auto buf_view = quicr::DataStorageDynView(buffer);
+    CHECK_EQ(buf_view.size(), buffer->size());
 
     buffer->Push(quicr::AsBytes(s3));
 
-    CHECK_EQ(buf_span.size(), buffer->size());
+    CHECK_EQ(buf_view.size(), buffer->size());
 
     auto size_before_erase = buffer->size();
 
     // Shouldn't remove anything since 2 is less than first element
-    buffer->erase(2);
+    buffer->EraseFront(2);
     CHECK_EQ(buffer->size(), size_before_erase);
 
     // Should remove the first element
-    buffer->erase(3);
+    buffer->EraseFront(3);
     CHECK_EQ(buffer->size(), size_before_erase - 3);
 
     // Should remove the next two elements, but not the third
     buffer->Push(quicr::AsBytes(s1));
     buffer->Push(quicr::AsBytes(s1));
     size_before_erase = buffer->size();
-    buffer->erase(11);
+    buffer->EraseFront(11);
 
     CHECK_EQ(buffer->size(), size_before_erase - 10);
 }

--- a/test/moq_messages.cpp
+++ b/test/moq_messages.cpp
@@ -591,7 +591,6 @@ ObjectDatagramEncodeDecode(bool extensions, bool empty_payload)
 
     MoqObjectDatagram object_datagram_out;
     CHECK(Verify(buffer, static_cast<uint64_t>(DataMessageType::OBJECT_DATAGRAM), object_datagram_out));
-    CHECK_EQ(object_datagram.subscribe_id, object_datagram_out.subscribe_id);
     CHECK_EQ(object_datagram.track_alias, object_datagram_out.track_alias);
     CHECK_EQ(object_datagram.group_id, object_datagram_out.group_id);
     CHECK_EQ(object_datagram.object_id, object_datagram_out.object_id);

--- a/test/moq_messages.cpp
+++ b/test/moq_messages.cpp
@@ -576,7 +576,6 @@ ObjectDatagramEncodeDecode(bool extensions, bool empty_payload)
 {
     Bytes buffer;
     auto object_datagram = MoqObjectDatagram{};
-    object_datagram.subscribe_id = 0x100;
     object_datagram.track_alias = uint64_t(kTrackAliasAliceVideo);
     object_datagram.group_id = 0x1000;
     object_datagram.object_id = 0xFF;


### PR DESCRIPTION
This PR changes transport to create a shared pointer vector upon receiving data. The shared pointer is then enqueued by move into a thread safe fifo queue.  A notification/callback is then called to inform the libquicr transport that there is data available. More data will continue to be added to the queue in the same fashion using shared pointers. 

The shared pointer vectors are referred to as **slices** of data because the data is of a stream of bytes, which does not have MoQ object bounds, hence a slice of data. 

The libquicr transport handling of received datagrams and stream data has moved to be processed under the Subscribe Handler. By default, the base subscribe handler class will do the work that was done before in libquicr transport to reassemble the slices into complete objects and to call `SubscribeHandler::ObjectReceived(...)`.  The application and API is unaffected and are unaware that the underlining base has changed. 

The underlining base change is to directly support pipeline forwarding of slices. **qclient** and **qserver** do not implement the new subscribe handler (`StreamDataRecv()` and `DgramDataRecv()`) methods to support pipelining.  [LAPS](github.com/quicr/laps) will implement the new subscribe handler methods to support pipelining of slices along with caching. 