### PR TITLE
Even header extension support

### DIFF
--- a/include/quicr/detail/stream_buffer.h
+++ b/include/quicr/detail/stream_buffer.h
@@ -220,6 +220,25 @@ namespace quicr {
          */
         std::optional<uint64_t> DecodeUintV()
         {
+            const auto uintv = ReadUintV();
+            if (uintv) {
+                return uint64_t(*uintv);
+            }
+            return std::nullopt;
+        }
+
+        /**
+         * Reads a variable length int (uintV) from start of stream buffer
+         *
+         * @details Reads uintV from stream buffer. If all bytes are available, the
+         *      encoded uintV will be returned and the buffer
+         *      will be moved past the uintV. Nullopt will be returned if not enough
+         *      bytes are available.
+         *
+         * @return Returns uintV or nullopt if not enough bytes are available
+         */
+        std::optional<UintVar> ReadUintV()
+        {
             if (buffer_.empty()) {
                 return std::nullopt;
             }
@@ -234,7 +253,7 @@ namespace quicr {
                 auto val = UintVar(FrontInternal(uv_len));
                 PopInternal(uv_len);
 
-                return uint64_t(val);
+                return val;
             }
 
             return std::nullopt;

--- a/test/moq_messages.cpp
+++ b/test/moq_messages.cpp
@@ -21,7 +21,7 @@ FromASCII(const std::string& ascii)
 const TrackNamespace kTrackNamespaceConf{ FromASCII("conf.example.com"), FromASCII("conf"), FromASCII("1") };
 const Bytes kTrackNameAliceVideo = FromASCII("alice/video");
 const UintVar kTrackAliasAliceVideo{ 0xA11CE };
-const Extensions kExampleExtensions = { { 0x1, { 0x1, 0x2 } } };
+const Extensions kExampleExtensions = { { 0x1, { 0x1, 0x2 } }, { 0x2, { 0xFF, 0, 0, 0, 0, 0, 0, 0 } } };
 const std::optional<Extensions> kOptionalExtensions = kExampleExtensions;
 
 template<typename T>

--- a/test/moq_messages.cpp
+++ b/test/moq_messages.cpp
@@ -21,7 +21,7 @@ FromASCII(const std::string& ascii)
 const TrackNamespace kTrackNamespaceConf{ FromASCII("conf.example.com"), FromASCII("conf"), FromASCII("1") };
 const Bytes kTrackNameAliceVideo = FromASCII("alice/video");
 const UintVar kTrackAliasAliceVideo{ 0xA11CE };
-const Extensions kExampleExtensions = { { 0x1, { 0x1, 0x2 } }, { 0x2, { 0xFF, 0, 0, 0, 0, 0, 0, 0 } } };
+const Extensions kExampleExtensions = { { 0x1, { 0x1, 0x2 } }, { 0x2, { 0x3F } } };
 const std::optional<Extensions> kOptionalExtensions = kExampleExtensions;
 
 template<typename T>


### PR DESCRIPTION
This is a quick addition for interop of the "short" header extensions that consist of a single varint value when the extension type is even (`%2=0`). I would suggest we subsequently add a more advanced data structure for the `quicr::Extensions` type that can actually check the validity of extensions given these rules. Right now, it's still just a map of bytes and so the functions that accept it are naive to this change until they are put on/taken off the wire. 

I added a `ReadUintV` function to return the *encoded* varint for calls who want to inspect it. If that's not a good idea, no big deal, I'll change it back and construct in place. 