### PR TITLE
Add FetchAvailability result

### DIFF
--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -806,7 +806,7 @@ class MyServer : public quicr::Server
             SPDLOG_WARN("No objects found for requested range");
             return std::nullopt;
         }
-        const auto last_cached = groups.back()->end()->headers;
+        const auto last_cached = std::prev(groups.back()->end())->headers;
         return FetchAvailability{ .end_of_track = false,
                                   .largest_group = last_cached.group_id,
                                   .largest_object = last_cached.object_id };

--- a/include/quicr/server.h
+++ b/include/quicr/server.h
@@ -46,6 +46,14 @@ namespace quicr {
             std::optional<Bytes> reason_phrase;
         };
 
+        // Availability of the track.
+        struct FetchAvailability
+        {
+            bool end_of_track;
+            messages::GroupId largest_group;
+            messages::ObjectId largest_object;
+        };
+
         /**
          * @brief MoQ Server constructor to create the MOQ server mode instance
          *
@@ -282,12 +290,12 @@ namespace quicr {
          * @param track_full_name   Track full name
          * @param attributes        Fetch attributes received.
          *
-         * @returns true if user defined conditions of Fetch are satisfied, false otherwise.
+         * @returns Availability for FETCH_OK, if possible. If the fetch cannot be served, return std::nullopt.
          */
-        virtual bool FetchReceived(ConnectionHandle connection_handle,
-                                   uint64_t subscribe_id,
-                                   const FullTrackName& track_full_name,
-                                   const FetchAttributes& attributes);
+        virtual std::optional<FetchAvailability> FetchReceived(ConnectionHandle connection_handle,
+                                                               uint64_t subscribe_id,
+                                                               const FullTrackName& track_full_name,
+                                                               const FetchAttributes& attributes);
 
         /**
          * @brief Event to run on sending FetchOk.

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -551,8 +551,8 @@ namespace quicr {
                     .end_object = msg.end_object,
                 };
 
-                const auto availability = FetchReceived(conn_ctx.connection_handle, msg.subscribe_id, tfn, attrs);
-                if (!availability) {
+                const auto available = FetchReceived(conn_ctx.connection_handle, msg.subscribe_id, tfn, attrs);
+                if (!available) {
                     SendFetchError(
                       conn_ctx, msg.subscribe_id, messages::FetchErrorCode::kTrackDoesNotExist, "Track does not exist");
 
@@ -569,9 +569,9 @@ namespace quicr {
                 SendFetchOk(conn_ctx,
                             msg.subscribe_id,
                             msg.group_order,
-                            availability->end_of_track,
-                            availability->largest_group,
-                            availability->largest_object);
+                            available->end_of_track,
+                            available->largest_group,
+                            available->largest_object);
                 OnFetchOk(conn_ctx.connection_handle, msg.subscribe_id, tfn, attrs);
 
                 return true;


### PR DESCRIPTION
This is 50% a proposal and 50% a PR. 

FETCH_OK requires some attributes that an implementation needs to provide:

> End Of Track: 1 if all objects have been published on this track, so the Largest Group ID and Object Id indicate the last Object in the track, 0 if not.
> Largest Group ID: The largest Group ID available for this track.
> Largest Object ID: The largest Object ID available within the largest Group ID for this track.

This allows the FetchReceived implementor to provide them, if the fetch can be resolved. 

A similar API will be needed for JoiningFetch (for matching subscription lookup that needs to be implementor provided), so wanted to float this separately. 