### PR TITLE
Allow intra-range cache lookups

### DIFF
--- a/include/quicr/cache.h
+++ b/include/quicr/cache.h
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <vector>
@@ -66,7 +67,7 @@ namespace quicr {
 
         bool Contains(const K& start_key, const K& end_key) noexcept
         {
-            if (start_key >= end_key) {
+            if (start_key > end_key) {
                 return false;
             }
 

--- a/include/quicr/detail/tick_service.h
+++ b/include/quicr/detail/tick_service.h
@@ -36,6 +36,7 @@ namespace quicr {
 
         virtual TickType Milliseconds() const = 0;
         virtual TickType Microseconds() const = 0;
+        virtual ~TickService() = default;
     };
 
     /**
@@ -60,7 +61,7 @@ namespace quicr {
             tick_thread_ = std::thread(&ThreadedTickService::TickLoop, this);
         }
 
-        virtual ~ThreadedTickService()
+        ~ThreadedTickService() override
         {
             stop_ = true;
             if (tick_thread_.joinable())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(quicr_test
     tick_service.cpp
     track_namespace.cpp
     data_storage.cpp
+    cache.cpp
 )
 target_include_directories(quicr_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
 

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <doctest/doctest.h>
+
+#include <quicr/cache.h>
+
+using namespace quicr;
+
+struct MockTickService : TickService
+{
+    void SetCurrentDuration(const DurationType duration) { milliseconds_ = duration; }
+    TickType Milliseconds() const override { return milliseconds_.count(); }
+    TickType Microseconds() const override { return milliseconds_.count() * 1000; }
+
+  private:
+    DurationType milliseconds_ = DurationType(0);
+};
+
+TEST_SUITE("Cache")
+{
+    TEST_CASE("Cache Retrieval")
+    {
+        // Should be able to find objects that have been inserted.
+        auto time = std::make_shared<MockTickService>();
+        typedef std::uint64_t Key;
+        typedef std::uint64_t Value;
+        auto cache = Cache<Key, Value>(1000, 100, std::make_shared<MockTickService>());
+        constexpr Key target_key = 0;
+        cache.Insert(target_key, 0, 1000);
+        cache.Insert(target_key, 1, 1000);
+        cache.Insert(target_key + 1, 0, 1000);
+
+        // Lookup by matching key.
+        CHECK(cache.Contains(target_key));
+        // Lookup by matching intra range.
+        CHECK(cache.Contains(target_key, target_key));
+        // Lookup by matching (key+1).
+        CHECK(cache.Contains(target_key + 1));
+        // Lookup by matching range.
+        CHECK(cache.Contains(target_key, target_key + 1));
+    }
+}


### PR DESCRIPTION
Not sure if this is by design or was a bug. Should `Cache` work on inclusive or exclusive ranges?

Given the objects in cache are `[(0,0), (0,1)]` then a `Contains(0,0)` will return `false` and a `Get(0, 0)` will return nothing. We could allow intra-ranges to `Contains` like this PR does, or we can decide it's an exclusive range and then we should +1 to the end range when we query the cache in the FETCH operation. 

I have added a test to showcase this behaviour. Without the included fix, the assertion on test L:37 will fail. 

In our usage, this means that currently an intra-range FETCH where Start Group == End Group will not return anything. The corresponding draft text says:

> Fetch specifies an inclusive range of Objects starting at StartObject in StartGroup and ending at EndObject in EndGroup.

Worth noting that it also states that:

> EndObject: The end Object ID, plus 1. A value of 0 means the entire group is requested.

(to be fair, this kind of conflicts in terms of terminology but I think I get the intent, I might raise a draft issue about this. I'm assuming they mean inclusive once you've subtracted the 1 and/or dealt with the 0). 

Thus, I was expecting a FETCH message of Start Group: 0, Start Object: 0, End Group: 0, End Object : 2 would deliver (0,0) and (0,1) and not instead return an error saying no objects. 

PS. I could argue that a start > end call should throw instead of returning nothing? This behaviour would have been more obvious if it disallowed that. 