### PR TITLE
Set missing fetch type

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -507,6 +507,7 @@ namespace quicr {
     {
         Fetch fetch;
         fetch.subscribe_id = subscribe_id;
+        fetch.fetch_type = FetchType::kStandalone;
         fetch.track_namespace = tfn.name_space;
         fetch.track_name.assign(tfn.name.begin(), tfn.name.end());
         fetch.priority = priority;


### PR DESCRIPTION
This was causing messed up FETCH messages due to the uninitialised value. The parsing tests didn't catch this because they correctly initialise their structure with this field. Maybe there's a case for some consistent initialisation of these messages (especially as their structure changes in the draft and fields get added/removed). Maybe all the message fields could be const with buffer constructors and no default ctor?