### PR TITLE
Add draft 11 subgroup header + logic

### DIFF
--- a/include/quicr/detail/messages.h
+++ b/include/quicr/detail/messages.h
@@ -36,7 +36,7 @@ namespace quicr::messages {
      * @return True if the type will serialize extensions (even empty ones), false otherwise.
      */
     [[maybe_unused]]
-    static bool typeWillSerializeExtensions(const StreamHeaderType type)
+    static bool TypeWillSerializeExtensions(const StreamHeaderType type)
     {
         switch (type) {
             case StreamHeaderType::kSubgroupZeroWithExtensions:
@@ -56,7 +56,7 @@ namespace quicr::messages {
      * @return True if a header of this type will have a subgroup field on the wire.
      */
     [[maybe_unused]]
-    static bool typeWillSerializeSubgroup(const StreamHeaderType type)
+    static bool TypeWillSerializeSubgroup(const StreamHeaderType type)
     {
         switch (type) {
             case StreamHeaderType::kSubgroupExplicitNoExtensions:

--- a/include/quicr/detail/messages.h
+++ b/include/quicr/detail/messages.h
@@ -22,12 +22,12 @@ namespace quicr::messages {
     /// @brief Stream Header types.
     enum class StreamHeaderType : uint8_t
     {
-        kZeroNoExtensions = 0x08,          // No extensions, Subgroup ID = 0
-        kZeroWithExtensions = 0x09,        // With extensions, Subgroup ID = 0
-        kFirstObjectNoExtensions = 0x0A,   // No extensions, Subgroup ID = First Object ID
-        kFirstObjectWithExtensions = 0x0B, // With extensions, Subgroup ID = First Object ID
-        kExplicitNoExtensions = 0x0C,      // No extensions, Explicit Subgroup ID
-        kExplicitWithExtensions = 0x0D,    // With extensions, Explicit Subgroup ID
+        kSubgroupZeroNoExtensions = 0x08,          // No extensions, Subgroup ID = 0
+        kSubgroupZeroWithExtensions = 0x09,        // With extensions, Subgroup ID = 0
+        kSubgroupFirstObjectNoExtensions = 0x0A,   // No extensions, Subgroup ID = First Object ID
+        kSubgroupFirstObjectWithExtensions = 0x0B, // With extensions, Subgroup ID = First Object ID
+        kSubgroupExplicitNoExtensions = 0x0C,      // No extensions, Explicit Subgroup ID
+        kSubgroupExplicitWithExtensions = 0x0D,    // With extensions, Explicit Subgroup ID
     };
 
     /**
@@ -39,11 +39,11 @@ namespace quicr::messages {
     static bool typeWillSerializeExtensions(const StreamHeaderType type)
     {
         switch (type) {
-            case StreamHeaderType::kZeroWithExtensions:
+            case StreamHeaderType::kSubgroupZeroWithExtensions:
                 [[fallthrough]];
-            case StreamHeaderType::kFirstObjectWithExtensions:
+            case StreamHeaderType::kSubgroupFirstObjectWithExtensions:
                 [[fallthrough]];
-            case StreamHeaderType::kExplicitWithExtensions:
+            case StreamHeaderType::kSubgroupExplicitWithExtensions:
                 return true;
             default:
                 return false;
@@ -59,9 +59,9 @@ namespace quicr::messages {
     static bool typeWillSerializeSubgroup(const StreamHeaderType type)
     {
         switch (type) {
-            case StreamHeaderType::kExplicitNoExtensions:
+            case StreamHeaderType::kSubgroupExplicitNoExtensions:
                 [[fallthrough]];
-            case StreamHeaderType::kExplicitWithExtensions:
+            case StreamHeaderType::kSubgroupExplicitWithExtensions:
                 return true;
             default:
                 return false;
@@ -75,14 +75,14 @@ namespace quicr::messages {
         kFetchHeader = 0x5,
 
         // Subgroup Header Types.
-        kStreamHeaderSubGroupZeroNoExtensions = static_cast<std::uint8_t>(StreamHeaderType::kZeroNoExtensions),
-        kStreamHeaderSubGroupZeroExtensions = static_cast<std::uint8_t>(StreamHeaderType::kZeroWithExtensions),
-        kStreamHeaderSubGroupFirstObjectNoExtensions =
-          static_cast<std::uint8_t>(StreamHeaderType::kFirstObjectNoExtensions),
-        kStreamHeaderSubGroupFirstObjectExtensions =
-          static_cast<std::uint8_t>(StreamHeaderType::kFirstObjectWithExtensions),
-        kStreamHeaderSubGroupExplicitNoExtensions = static_cast<std::uint8_t>(StreamHeaderType::kExplicitNoExtensions),
-        kStreamHeaderSubGroupExplicitExtensions = static_cast<std::uint8_t>(StreamHeaderType::kExplicitWithExtensions),
+        kStreamHeaderSubgroupZeroNoExtensions = static_cast<std::uint8_t>(StreamHeaderType::kSubgroupZeroNoExtensions),
+        kStreamHeaderSubgroupZeroWithExtensions = static_cast<std::uint8_t>(StreamHeaderType::kSubgroupZeroWithExtensions),
+        kStreamHeaderSubgroupFirstObjectNoExtensions =
+          static_cast<std::uint8_t>(StreamHeaderType::kSubgroupFirstObjectNoExtensions),
+        kStreamHeaderSubgroupFirstObjectWithExtensions =
+          static_cast<std::uint8_t>(StreamHeaderType::kSubgroupFirstObjectWithExtensions),
+        kStreamHeaderSubgroupExplicitNoExtensions = static_cast<std::uint8_t>(StreamHeaderType::kSubgroupExplicitNoExtensions),
+        kStreamHeaderSubgroupExplicitWithExtensions = static_cast<std::uint8_t>(StreamHeaderType::kSubgroupExplicitWithExtensions),
     };
 
     /**
@@ -94,17 +94,17 @@ namespace quicr::messages {
     static bool typeIsStreamHeaderType(const DataMessageType type)
     {
         switch (type) {
-            case DataMessageType::kStreamHeaderSubGroupZeroNoExtensions:
+            case DataMessageType::kStreamHeaderSubgroupZeroNoExtensions:
                 [[fallthrough]];
-            case DataMessageType::kStreamHeaderSubGroupZeroExtensions:
+            case DataMessageType::kStreamHeaderSubgroupZeroWithExtensions:
                 [[fallthrough]];
-            case DataMessageType::kStreamHeaderSubGroupFirstObjectNoExtensions:
+            case DataMessageType::kStreamHeaderSubgroupFirstObjectNoExtensions:
                 [[fallthrough]];
-            case DataMessageType::kStreamHeaderSubGroupFirstObjectExtensions:
+            case DataMessageType::kStreamHeaderSubgroupFirstObjectWithExtensions:
                 [[fallthrough]];
-            case DataMessageType::kStreamHeaderSubGroupExplicitNoExtensions:
+            case DataMessageType::kStreamHeaderSubgroupExplicitNoExtensions:
                 [[fallthrough]];
-            case DataMessageType::kStreamHeaderSubGroupExplicitExtensions:
+            case DataMessageType::kStreamHeaderSubgroupExplicitWithExtensions:
                 return true;
             default:
                 return false;

--- a/include/quicr/detail/stream_buffer.h
+++ b/include/quicr/detail/stream_buffer.h
@@ -215,12 +215,12 @@ namespace quicr {
          *      unsigned 64bit integer will be returned and the buffer
          *      will be moved past the uintV. Nullopt will be returned if not enough
          *      bytes are available.
-         *
+         * @param pop True to move the buffer past the uintV.
          * @return Returns uint64 decoded value or nullopt if not enough bytes are available
          */
-        std::optional<uint64_t> DecodeUintV()
+        std::optional<uint64_t> DecodeUintV(bool pop = true)
         {
-            const auto uintv = ReadUintV();
+            const auto uintv = ReadUintV(pop);
             if (uintv) {
                 return uint64_t(*uintv);
             }
@@ -234,10 +234,10 @@ namespace quicr {
          *      encoded uintV will be returned and the buffer
          *      will be moved past the uintV. Nullopt will be returned if not enough
          *      bytes are available.
-         *
+         * @param pop True to move the buffer past the uintV.
          * @return Returns uintV or nullopt if not enough bytes are available
          */
-        std::optional<UintVar> ReadUintV()
+        std::optional<UintVar> ReadUintV(bool pop = true)
         {
             if (buffer_.empty()) {
                 return std::nullopt;
@@ -251,7 +251,9 @@ namespace quicr {
             if (Available(uv_len)) {
 
                 auto val = UintVar(FrontInternal(uv_len));
-                PopInternal(uv_len);
+                if (pop) {
+                    PopInternal(uv_len);
+                }
 
                 return val;
             }

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -386,7 +386,8 @@ namespace quicr {
 
         void RemoveAllTracksForConnectionClose(ConnectionContext& conn_ctx);
 
-        bool OnRecvSubgroup(std::vector<uint8_t>::const_iterator cursor_it,
+        bool OnRecvSubgroup(messages::StreamHeaderType type,
+                            std::vector<uint8_t>::const_iterator cursor_it,
                             StreamRxContext& rx_ctx,
                             std::uint64_t stream_id,
                             ConnectionContext& conn_ctx,

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -98,7 +98,7 @@ namespace quicr {
                 case TrackMode::kStream:
                     // TODO: Is a default acceptable, or enforce?
                     stream_mode_ =
-                      stream_mode.has_value() ? stream_mode.value() : messages::StreamHeaderType::kZeroWithExtensions;
+                      stream_mode.has_value() ? stream_mode.value() : messages::StreamHeaderType::kSubgroupZeroWithExtensions;
                     break;
             }
         }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -430,9 +430,9 @@ namespace quicr::messages {
         buffer << UintVar(msg.track_alias);
         buffer << UintVar(msg.group_id);
         switch (msg.type) {
-            case StreamHeaderType::kExplicitNoExtensions:
+            case StreamHeaderType::kSubgroupExplicitNoExtensions:
                 [[fallthrough]];
-            case StreamHeaderType::kExplicitWithExtensions:
+            case StreamHeaderType::kSubgroupExplicitWithExtensions:
                 assert(msg.subgroup_id.has_value());
                 buffer << UintVar(msg.subgroup_id.value());
                 break;
@@ -473,16 +473,16 @@ namespace quicr::messages {
             }
             case 3: {
                 switch (msg.type) {
-                    case StreamHeaderType::kZeroNoExtensions:
-                    case StreamHeaderType::kZeroWithExtensions:
+                    case StreamHeaderType::kSubgroupZeroNoExtensions:
+                    case StreamHeaderType::kSubgroupZeroWithExtensions:
                         msg.subgroup_id = 0;
                         break;
-                    case StreamHeaderType::kFirstObjectNoExtensions:
-                    case StreamHeaderType::kFirstObjectWithExtensions:
+                    case StreamHeaderType::kSubgroupFirstObjectNoExtensions:
+                    case StreamHeaderType::kSubgroupFirstObjectWithExtensions:
                         msg.subgroup_id = std::nullopt; // Will be updated by first object.
                         break;
-                    case StreamHeaderType::kExplicitNoExtensions:
-                    case StreamHeaderType::kExplicitWithExtensions:
+                    case StreamHeaderType::kSubgroupExplicitNoExtensions:
+                    case StreamHeaderType::kSubgroupExplicitWithExtensions:
                         messages::SubGroupId subgroup_id;
                         if (!ParseUintVField(buffer, subgroup_id)) {
                             return false;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -426,10 +426,20 @@ namespace quicr::messages {
 
     Bytes& operator<<(Bytes& buffer, const StreamHeaderSubGroup& msg)
     {
-        buffer << UintVar(static_cast<uint64_t>(DataMessageType::kStreamHeaderSubgroup));
+        buffer << UintVar(static_cast<uint64_t>(msg.type));
         buffer << UintVar(msg.track_alias);
         buffer << UintVar(msg.group_id);
-        buffer << UintVar(msg.subgroup_id);
+        switch (msg.type) {
+            case StreamHeaderType::kExplicitNoExtensions:
+                [[fallthrough]];
+            case StreamHeaderType::kExplicitWithExtensions:
+                assert(msg.subgroup_id.has_value());
+                buffer << UintVar(msg.subgroup_id.value());
+                break;
+            default:
+                break;
+        }
+
         buffer.push_back(msg.priority);
         return buffer;
     }
@@ -439,27 +449,51 @@ namespace quicr::messages {
     {
         switch (msg.current_pos) {
             case 0: {
+                std::uint64_t subgroup_type;
+                if (!ParseUintVField(buffer, subgroup_type)) {
+                    return false;
+                }
+                msg.type = static_cast<StreamHeaderType>(subgroup_type);
+                msg.current_pos += 1;
+                [[fallthrough]];
+            }
+            case 1: {
                 if (!ParseUintVField(buffer, msg.track_alias)) {
                     return false;
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 1: {
+            case 2: {
                 if (!ParseUintVField(buffer, msg.group_id)) {
                     return false;
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 2: {
-                if (!ParseUintVField(buffer, msg.subgroup_id)) {
-                    return false;
+            case 3: {
+                switch (msg.type) {
+                    case StreamHeaderType::kZeroNoExtensions:
+                    case StreamHeaderType::kZeroWithExtensions:
+                        msg.subgroup_id = 0;
+                        break;
+                    case StreamHeaderType::kFirstObjectNoExtensions:
+                    case StreamHeaderType::kFirstObjectWithExtensions:
+                        msg.subgroup_id = std::nullopt; // Will be updated by first object.
+                        break;
+                    case StreamHeaderType::kExplicitNoExtensions:
+                    case StreamHeaderType::kExplicitWithExtensions:
+                        messages::SubGroupId subgroup_id;
+                        if (!ParseUintVField(buffer, subgroup_id)) {
+                            return false;
+                        }
+                        msg.subgroup_id = subgroup_id;
+                        break;
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];
             }
-            case 3: {
+            case 4: {
                 auto val = buffer.Front();
                 if (!val) {
                     return false;
@@ -483,7 +517,9 @@ namespace quicr::messages {
     Bytes& operator<<(Bytes& buffer, const StreamSubGroupObject& msg)
     {
         buffer << UintVar(msg.object_id);
-        PushExtensions(buffer, msg.extensions);
+        if (msg.serialize_extensions) {
+            PushExtensions(buffer, msg.extensions);
+        }
         if (msg.payload.empty()) {
             // empty payload needs a object status to be set
             auto status = UintVar(static_cast<uint8_t>(msg.object_status));
@@ -508,8 +544,10 @@ namespace quicr::messages {
                 [[fallthrough]];
             }
             case 1: {
-                if (!ParseExtensions(buffer, msg.num_extensions, msg.extensions, msg.current_tag)) {
-                    return false;
+                if (msg.serialize_extensions) {
+                    if (!ParseExtensions(buffer, msg.num_extensions, msg.extensions, msg.current_tag)) {
+                        return false;
+                    }
                 }
                 msg.current_pos += 1;
                 [[fallthrough]];

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -63,8 +63,8 @@ namespace quicr {
 
             if (!s_hdr.subgroup_id.has_value()) {
                 // TODO(RichLogan): This is a protocol error?
-                assert(s_hdr.type == messages::StreamHeaderType::kFirstObjectNoExtensions ||
-                       s_hdr.type == messages::StreamHeaderType::kFirstObjectWithExtensions);
+                assert(s_hdr.type == messages::StreamHeaderType::kSubgroupFirstObjectNoExtensions ||
+                       s_hdr.type == messages::StreamHeaderType::kSubgroupFirstObjectWithExtensions);
                 s_hdr.subgroup_id = obj.object_id;
             }
 

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -29,7 +29,6 @@ namespace quicr {
 
             stream_buffer_.InitAny<messages::StreamHeaderSubGroup>();
             stream_buffer_.Push(*data);
-            stream_buffer_.Pop(); // Remove type header
 
             // Expect that on initial start of stream, there is enough data to process the stream headers
 
@@ -50,23 +49,31 @@ namespace quicr {
         }
 
         auto& obj = stream_buffer_.GetAnyB<messages::StreamSubGroupObject>();
+        obj.serialize_extensions = typeWillSerializeExtensions(s_hdr.type);
         if (stream_buffer_ >> obj) {
-            SPDLOG_TRACE("Received stream_subgroup_object subscribe_id: {} priority: {} track_alias: {} "
+            SPDLOG_TRACE("Received stream_subgroup_object type: {} priority: {} track_alias: {} "
                          "group_id: {} subgroup_id: {} object_id: {} data size: {}",
-                         s_hdr.subscribe_id,
+                         static_cast<std::uint8_t>(s_hdr.subgroup_type),
                          s_hdr.priority,
                          s_hdr.track_alias,
                          s_hdr.group_id,
-                         s_hdr.subgroup_id,
+                         s_hdr.subgroup_id.has_value() ? *s_hdr.subgroup_id : -1,
                          obj.object_id,
                          obj.payload.size());
+
+            if (!s_hdr.subgroup_id.has_value()) {
+                // TODO(RichLogan): This is a protocol error?
+                assert(s_hdr.type == messages::StreamHeaderType::kFirstObjectNoExtensions ||
+                       s_hdr.type == messages::StreamHeaderType::kFirstObjectWithExtensions);
+                s_hdr.subgroup_id = obj.object_id;
+            }
 
             subscribe_track_metrics_.objects_received++;
             subscribe_track_metrics_.bytes_received += obj.payload.size();
 
             ObjectReceived({ s_hdr.group_id,
                              obj.object_id,
-                             s_hdr.subgroup_id,
+                             s_hdr.subgroup_id.value(),
                              obj.payload.size(),
                              obj.object_status,
                              s_hdr.priority,

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -49,7 +49,7 @@ namespace quicr {
         }
 
         auto& obj = stream_buffer_.GetAnyB<messages::StreamSubGroupObject>();
-        obj.serialize_extensions = typeWillSerializeExtensions(s_hdr.type);
+        obj.serialize_extensions = TypeWillSerializeExtensions(s_hdr.type);
         if (stream_buffer_ >> obj) {
             SPDLOG_TRACE("Received stream_subgroup_object type: {} priority: {} track_alias: {} "
                          "group_id: {} subgroup_id: {} object_id: {} data size: {}",

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1041,7 +1041,7 @@ namespace quicr {
 
                 messages::StreamSubGroupObject object;
                 object.object_id = object_id;
-                object.serialize_extensions = typeWillSerializeExtensions(track_handler.GetStreamMode());
+                object.serialize_extensions = TypeWillSerializeExtensions(track_handler.GetStreamMode());
                 object.extensions = extensions;
                 object.payload.assign(data.begin(), data.end());
                 track_handler.object_msg_buffer_ << object;
@@ -1355,7 +1355,7 @@ namespace quicr {
             auto group_id_sz = UintVar::Size(*cursor_it);
             cursor_it += group_id_sz;
 
-            if (typeWillSerializeSubgroup(type)) {
+            if (TypeWillSerializeSubgroup(type)) {
                 auto subgroup_id_sz = UintVar::Size(*cursor_it);
                 cursor_it += subgroup_id_sz;
             }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1016,6 +1016,7 @@ namespace quicr {
                     eflags.use_reset = true;
 
                     messages::StreamHeaderSubGroup subgroup_hdr;
+                    subgroup_hdr.type = track_handler.GetStreamMode();
                     subgroup_hdr.group_id = group_id;
                     subgroup_hdr.subgroup_id = subgroup_id;
                     subgroup_hdr.priority = priority;
@@ -1040,6 +1041,7 @@ namespace quicr {
 
                 messages::StreamSubGroupObject object;
                 object.object_id = object_id;
+                object.serialize_extensions = typeWillSerializeExtensions(track_handler.GetStreamMode());
                 object.extensions = extensions;
                 object.payload.assign(data.begin(), data.end());
                 track_handler.object_msg_buffer_ << object;
@@ -1307,18 +1309,17 @@ namespace quicr {
                 auto cursor_it = std::next(data.begin(), type_sz);
 
                 bool break_loop = false;
-                switch (static_cast<messages::DataMessageType>(msg_type)) {
-                    case messages::DataMessageType::kStreamHeaderSubgroup:
-                        break_loop = OnRecvSubgroup(cursor_it, *rx_ctx, stream_id, conn_ctx, *data_opt);
-                        break;
-                    case messages::DataMessageType::kFetchHeader:
-                        break_loop = OnRecvFetch(cursor_it, *rx_ctx, stream_id, conn_ctx, *data_opt);
-                        break;
-                    default:
-                        SPDLOG_LOGGER_DEBUG(logger_, "Received start of stream with invalid header type, dropping");
-                        conn_ctx.metrics.rx_stream_invalid_type++;
-                        // TODO(tievens): Need to reset this stream as this is invalid.
-                        return;
+                const auto type = static_cast<DataMessageType>(msg_type);
+                if (typeIsStreamHeaderType(type)) {
+                    const auto stream_header_type = static_cast<StreamHeaderType>(msg_type);
+                    break_loop = OnRecvSubgroup(stream_header_type, cursor_it, *rx_ctx, stream_id, conn_ctx, *data_opt);
+                } else if (type == DataMessageType::kFetchHeader) {
+                    break_loop = OnRecvFetch(cursor_it, *rx_ctx, stream_id, conn_ctx, *data_opt);
+                } else {
+                    SPDLOG_LOGGER_DEBUG(logger_, "Received start of stream with invalid header type, dropping");
+                    conn_ctx.metrics.rx_stream_invalid_type++;
+                    // TODO(tievens): Need to reset this stream as this is invalid.
+                    return;
                 }
                 if (break_loop) {
                     break;
@@ -1335,7 +1336,8 @@ namespace quicr {
         // TODO(tievens): Add metrics to track if this happens
     }
 
-    bool Transport::OnRecvSubgroup(std::vector<uint8_t>::const_iterator cursor_it,
+    bool Transport::OnRecvSubgroup(StreamHeaderType type,
+                                   std::vector<uint8_t>::const_iterator cursor_it,
                                    StreamRxContext& rx_ctx,
                                    std::uint64_t stream_id,
                                    ConnectionContext& conn_ctx,
@@ -1353,8 +1355,10 @@ namespace quicr {
             auto group_id_sz = UintVar::Size(*cursor_it);
             cursor_it += group_id_sz;
 
-            auto subgroup_id_sz = UintVar::Size(*cursor_it);
-            cursor_it += subgroup_id_sz;
+            if (typeWillSerializeSubgroup(type)) {
+                auto subgroup_id_sz = UintVar::Size(*cursor_it);
+                cursor_it += subgroup_id_sz;
+            }
 
             priority = *cursor_it;
 

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -209,7 +209,7 @@ StreamPerSubGroupObjectEncodeDecode(StreamHeaderType type, bool extensions, bool
     // send 10 objects
     for (size_t i = 0; i < 10; i++) {
         auto obj = messages::StreamSubGroupObject{};
-        obj.serialize_extensions = typeWillSerializeExtensions(type);
+        obj.serialize_extensions = TypeWillSerializeExtensions(type);
         obj.object_id = 0x1234;
 
         if (empty_payload) {
@@ -227,7 +227,7 @@ StreamPerSubGroupObjectEncodeDecode(StreamHeaderType type, bool extensions, bool
     size_t object_count = 0;
     StreamBuffer<uint8_t> in_buffer;
     for (size_t i = 0; i < buffer.size(); i++) {
-        obj_out.serialize_extensions = typeWillSerializeExtensions(type);
+        obj_out.serialize_extensions = TypeWillSerializeExtensions(type);
         in_buffer.Push(buffer.at(i));
         bool done = in_buffer >> obj_out;
         if (!done) {

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -156,19 +156,19 @@ StreamHeaderEncodeDecode(StreamHeaderType type)
     CHECK_EQ(hdr.track_alias, hdr_out.track_alias);
     CHECK_EQ(hdr.group_id, hdr_out.group_id);
     switch (type) {
-        case StreamHeaderType::kZeroNoExtensions:
+        case StreamHeaderType::kSubgroupZeroNoExtensions:
             [[fallthrough]];
-        case StreamHeaderType::kZeroWithExtensions:
+        case StreamHeaderType::kSubgroupZeroWithExtensions:
             CHECK_EQ(hdr_out.subgroup_id, 0);
             break;
-        case StreamHeaderType::kFirstObjectNoExtensions:
+        case StreamHeaderType::kSubgroupFirstObjectNoExtensions:
             [[fallthrough]];
-        case StreamHeaderType::kFirstObjectWithExtensions:
+        case StreamHeaderType::kSubgroupFirstObjectWithExtensions:
             CHECK_EQ(hdr_out.subgroup_id, std::nullopt);
             break;
-        case StreamHeaderType::kExplicitNoExtensions:
+        case StreamHeaderType::kSubgroupExplicitNoExtensions:
             [[fallthrough]];
-        case StreamHeaderType::kExplicitWithExtensions:
+        case StreamHeaderType::kSubgroupExplicitWithExtensions:
             CHECK_EQ(hdr_out.subgroup_id, hdr.subgroup_id);
             break;
     }
@@ -176,12 +176,12 @@ StreamHeaderEncodeDecode(StreamHeaderType type)
 
 TEST_CASE("StreamHeader Message encode/decode")
 {
-    StreamHeaderEncodeDecode(StreamHeaderType::kZeroNoExtensions);
-    StreamHeaderEncodeDecode(StreamHeaderType::kZeroWithExtensions);
-    StreamHeaderEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions);
-    StreamHeaderEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions);
-    StreamHeaderEncodeDecode(StreamHeaderType::kExplicitNoExtensions);
-    StreamHeaderEncodeDecode(StreamHeaderType::kExplicitWithExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kSubgroupZeroNoExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kSubgroupZeroWithExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kSubgroupFirstObjectNoExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kSubgroupFirstObjectWithExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kSubgroupExplicitNoExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kSubgroupExplicitWithExtensions);
 }
 
 static void
@@ -259,9 +259,9 @@ StreamPerSubGroupObjectEncodeDecode(StreamHeaderType type, bool extensions, bool
 TEST_CASE("StreamPerSubGroup Object Message encode/decode")
 {
     const auto stream_headers = {
-        StreamHeaderType::kZeroNoExtensions,        StreamHeaderType::kZeroWithExtensions,
-        StreamHeaderType::kExplicitNoExtensions,    StreamHeaderType::kExplicitWithExtensions,
-        StreamHeaderType::kFirstObjectNoExtensions, StreamHeaderType::kFirstObjectWithExtensions
+        StreamHeaderType::kSubgroupZeroNoExtensions,        StreamHeaderType::kSubgroupZeroWithExtensions,
+        StreamHeaderType::kSubgroupExplicitNoExtensions,    StreamHeaderType::kSubgroupExplicitWithExtensions,
+        StreamHeaderType::kSubgroupFirstObjectNoExtensions, StreamHeaderType::kSubgroupFirstObjectWithExtensions
     };
     for (const auto& type : stream_headers) {
         CAPTURE(type);

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -256,37 +256,23 @@ StreamPerSubGroupObjectEncodeDecode(StreamHeaderType type, bool extensions, bool
     CHECK_EQ(object_count, objects.size());
 }
 
-TEST_CASE("StreamPerSubGroup Object  Message encode/decode")
+TEST_CASE("StreamPerSubGroup Object Message encode/decode")
 {
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroNoExtensions, true, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroNoExtensions, true, false);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroNoExtensions, false, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroNoExtensions, false, false);
-
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroWithExtensions, true, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroWithExtensions, true, false);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroWithExtensions, false, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroWithExtensions, false, false);
-
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitNoExtensions, true, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitNoExtensions, true, false);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitNoExtensions, false, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitNoExtensions, false, false);
-
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitWithExtensions, true, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitWithExtensions, true, false);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitWithExtensions, false, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitWithExtensions, false, false);
-
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions, true, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions, true, false);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions, false, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions, false, false);
-
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions, true, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions, true, false);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions, false, true);
-    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions, false, false);
+    const auto stream_headers = {
+        StreamHeaderType::kZeroNoExtensions,        StreamHeaderType::kZeroWithExtensions,
+        StreamHeaderType::kExplicitNoExtensions,    StreamHeaderType::kExplicitWithExtensions,
+        StreamHeaderType::kFirstObjectNoExtensions, StreamHeaderType::kFirstObjectWithExtensions
+    };
+    for (const auto& type : stream_headers) {
+        CAPTURE(type);
+        for (bool extensions : { true, false }) {
+            CAPTURE(extensions);
+            for (bool empty_payload : { true, false }) {
+                CAPTURE(empty_payload);
+                StreamPerSubGroupObjectEncodeDecode(type, extensions, empty_payload);
+            }
+        }
+    }
 }
 
 static void

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -41,7 +41,8 @@ Verify(std::vector<uint8_t>& buffer, uint64_t message_type, T& message, [[maybe_
         in_buffer.Push(v);
 
         if (!msg_type) {
-            msg_type = in_buffer.DecodeUintV();
+            bool pop = !typeNeedsTypeField(static_cast<DataMessageType>(message_type));
+            msg_type = in_buffer.DecodeUintV(pop);
             if (!msg_type) {
                 continue;
             }
@@ -139,10 +140,56 @@ TEST_CASE("ObjectDatagramStatus  Message encode/decode")
 }
 
 static void
-StreamPerSubGroupObjectEncodeDecode(bool extensions, bool empty_payload)
+StreamHeaderEncodeDecode(StreamHeaderType type)
+{
+    Bytes buffer;
+    auto hdr = StreamHeaderSubGroup{};
+    hdr.type = type;
+    hdr.track_alias = static_cast<uint64_t>(kTrackAliasAliceVideo);
+    hdr.group_id = 0x1000;
+    hdr.subgroup_id = 0x5000;
+    hdr.priority = 0xA;
+    buffer << hdr;
+    StreamHeaderSubGroup hdr_out;
+    CHECK(Verify(buffer, static_cast<uint64_t>(type), hdr_out));
+    CHECK_EQ(hdr.type, hdr_out.type);
+    CHECK_EQ(hdr.track_alias, hdr_out.track_alias);
+    CHECK_EQ(hdr.group_id, hdr_out.group_id);
+    switch (type) {
+        case StreamHeaderType::kZeroNoExtensions:
+            [[fallthrough]];
+        case StreamHeaderType::kZeroWithExtensions:
+            CHECK_EQ(hdr_out.subgroup_id, 0);
+            break;
+        case StreamHeaderType::kFirstObjectNoExtensions:
+            [[fallthrough]];
+        case StreamHeaderType::kFirstObjectWithExtensions:
+            CHECK_EQ(hdr_out.subgroup_id, std::nullopt);
+            break;
+        case StreamHeaderType::kExplicitNoExtensions:
+            [[fallthrough]];
+        case StreamHeaderType::kExplicitWithExtensions:
+            CHECK_EQ(hdr_out.subgroup_id, hdr.subgroup_id);
+            break;
+    }
+}
+
+TEST_CASE("StreamHeader Message encode/decode")
+{
+    StreamHeaderEncodeDecode(StreamHeaderType::kZeroNoExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kZeroWithExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kExplicitNoExtensions);
+    StreamHeaderEncodeDecode(StreamHeaderType::kExplicitWithExtensions);
+}
+
+static void
+StreamPerSubGroupObjectEncodeDecode(StreamHeaderType type, bool extensions, bool empty_payload)
 {
     Bytes buffer;
     auto hdr_grp = messages::StreamHeaderSubGroup{};
+    hdr_grp.type = type;
     hdr_grp.track_alias = uint64_t(kTrackAliasAliceVideo);
     hdr_grp.group_id = 0x1000;
     hdr_grp.subgroup_id = 0x5000;
@@ -151,10 +198,10 @@ StreamPerSubGroupObjectEncodeDecode(bool extensions, bool empty_payload)
     buffer << hdr_grp;
 
     messages::StreamHeaderSubGroup hdr_group_out;
-    CHECK(Verify(buffer, static_cast<uint64_t>(messages::DataMessageType::kStreamHeaderSubgroup), hdr_group_out));
+    CHECK(Verify(buffer, static_cast<uint64_t>(type), hdr_group_out));
+    CHECK_EQ(hdr_grp.type, hdr_group_out.type);
     CHECK_EQ(hdr_grp.track_alias, hdr_group_out.track_alias);
     CHECK_EQ(hdr_grp.group_id, hdr_group_out.group_id);
-    CHECK_EQ(hdr_grp.subgroup_id, hdr_group_out.subgroup_id);
 
     // stream all the objects
     buffer.clear();
@@ -162,6 +209,7 @@ StreamPerSubGroupObjectEncodeDecode(bool extensions, bool empty_payload)
     // send 10 objects
     for (size_t i = 0; i < 10; i++) {
         auto obj = messages::StreamSubGroupObject{};
+        obj.serialize_extensions = typeWillSerializeExtensions(type);
         obj.object_id = 0x1234;
 
         if (empty_payload) {
@@ -179,11 +227,13 @@ StreamPerSubGroupObjectEncodeDecode(bool extensions, bool empty_payload)
     size_t object_count = 0;
     StreamBuffer<uint8_t> in_buffer;
     for (size_t i = 0; i < buffer.size(); i++) {
+        obj_out.serialize_extensions = typeWillSerializeExtensions(type);
         in_buffer.Push(buffer.at(i));
         bool done = in_buffer >> obj_out;
         if (!done) {
             continue;
         }
+
         CHECK_EQ(obj_out.object_id, objects[object_count].object_id);
         if (empty_payload) {
             CHECK_EQ(obj_out.object_status, objects[object_count].object_status);
@@ -191,7 +241,12 @@ StreamPerSubGroupObjectEncodeDecode(bool extensions, bool empty_payload)
             CHECK(obj_out.payload.size() > 0);
             CHECK_EQ(obj_out.payload, objects[object_count].payload);
         }
-        CHECK_EQ(obj_out.extensions, objects[object_count].extensions);
+
+        if (obj_out.serialize_extensions) {
+            CHECK_EQ(obj_out.extensions, objects[object_count].extensions);
+        } else {
+            CHECK_EQ(obj_out.extensions, std::nullopt);
+        }
         // got one object
         object_count++;
         obj_out = {};
@@ -203,10 +258,35 @@ StreamPerSubGroupObjectEncodeDecode(bool extensions, bool empty_payload)
 
 TEST_CASE("StreamPerSubGroup Object  Message encode/decode")
 {
-    StreamPerSubGroupObjectEncodeDecode(false, true);
-    StreamPerSubGroupObjectEncodeDecode(false, false);
-    StreamPerSubGroupObjectEncodeDecode(true, true);
-    StreamPerSubGroupObjectEncodeDecode(true, false);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroNoExtensions, true, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroNoExtensions, true, false);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroNoExtensions, false, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroNoExtensions, false, false);
+
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroWithExtensions, true, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroWithExtensions, true, false);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroWithExtensions, false, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kZeroWithExtensions, false, false);
+
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitNoExtensions, true, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitNoExtensions, true, false);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitNoExtensions, false, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitNoExtensions, false, false);
+
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitWithExtensions, true, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitWithExtensions, true, false);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitWithExtensions, false, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kExplicitWithExtensions, false, false);
+
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions, true, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions, true, false);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions, false, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectNoExtensions, false, false);
+
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions, true, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions, true, false);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions, false, true);
+    StreamPerSubGroupObjectEncodeDecode(StreamHeaderType::kFirstObjectWithExtensions, false, false);
 }
 
 static void


### PR DESCRIPTION
Closes #550 

We could better represent the modes in a fancier way if we want. I would also prefer that setting the serialisation flag of extensions if enforced at construction time, but this would require some changes in the stream buffer to forward emplace arguments if so, so I opted to defer that. 