### PR TITLE
Implement new KVP MoQ structure

### DIFF
--- a/include/quicr/detail/ctrl_message_types.h
+++ b/include/quicr/detail/ctrl_message_types.h
@@ -68,8 +68,8 @@ namespace quicr::messages {
             UintVar uvar(buffer);
             buffer = buffer.subspan(uvar.size());
             std::uint64_t val(uvar);
-            param.value.resize(sizeof(std::uint64_t));
-            std::memcpy(param.value.data(), &val, sizeof(std::uint64_t));
+            param.value.resize(uvar.size());
+            std::memcpy(param.value.data(), &val, uvar.size());
         } else {
             // Odd, decode bytes.
             uint64_t size = 0;

--- a/include/quicr/detail/ctrl_message_types.h
+++ b/include/quicr/detail/ctrl_message_types.h
@@ -55,8 +55,9 @@ namespace quicr::messages {
         param.type = static_cast<T>(type);
         if (type % 2 == 0) {
             // Even, single varint of value.
-            std::uint64_t val;
-            buffer = buffer >> val;
+            UintVar uvar(buffer);
+            buffer = buffer.subspan(uvar.size());
+            std::uint64_t val(uvar);
             param.value.resize(sizeof(std::uint64_t));
             std::memcpy(param.value.data(), &val, sizeof(std::uint64_t));
         } else {
@@ -64,6 +65,7 @@ namespace quicr::messages {
             uint64_t size = 0;
             buffer = buffer >> size;
             param.value.assign(buffer.begin(), std::next(buffer.begin(), size));
+            buffer = buffer.subspan(size);
         }
         return buffer;
     }
@@ -88,7 +90,7 @@ namespace quicr::messages {
     {
         kPath = 0x1,
         kMaxSubscribeId = 0x2, // version specific, unused
-        kEndpointId = 0xF0,    // Endpoint ID, using temp value for now
+        kEndpointId = 0xF1,    // Endpoint ID, using temp value for now
         kInvalid = 0xFF,       // used internally.
     };
 

--- a/include/quicr/detail/ctrl_messages.h
+++ b/include/quicr/detail/ctrl_messages.h
@@ -956,7 +956,4 @@ namespace quicr::messages {
     BytesSpan operator>>(BytesSpan buffer, TrackNamespace& msg);
     Bytes& operator<<(Bytes& buffer, const TrackNamespace& msg);
 
-    BytesSpan operator>>(BytesSpan buffer, Parameter& msg);
-    Bytes& operator<<(Bytes& buffer, const Parameter& msg);
-
 } // namespace

--- a/src/ctrl_message_types.cpp
+++ b/src/ctrl_message_types.cpp
@@ -58,20 +58,6 @@ namespace quicr::messages {
         return buffer.subspan(value_uv.size());
     }
 
-    Bytes& operator<<(Bytes& buffer, ParameterType value)
-    {
-        buffer << UintVar(static_cast<std::uint64_t>(value));
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, ParameterType& value)
-    {
-        std::uint64_t uvalue;
-        buffer = buffer >> uvalue;
-        value = static_cast<ParameterType>(uvalue);
-        return buffer;
-    }
-
     Bytes& operator<<(Bytes& buffer, GroupOrder value)
     {
         buffer << static_cast<std::uint64_t>(value);
@@ -83,20 +69,6 @@ namespace quicr::messages {
         std::uint64_t uvalue;
         buffer = buffer >> uvalue;
         value = static_cast<GroupOrder>(uvalue);
-        return buffer;
-    }
-
-    Bytes& operator<<(Bytes& buffer, FilterType value)
-    {
-        buffer << static_cast<std::uint64_t>(value);
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, FilterType& value)
-    {
-        std::uint64_t uvalue;
-        buffer = buffer >> uvalue;
-        value = static_cast<FilterType>(uvalue);
         return buffer;
     }
 
@@ -114,34 +86,6 @@ namespace quicr::messages {
         return buffer;
     }
 
-    Bytes& operator<<(Bytes& buffer, AnnounceErrorCode value)
-    {
-        buffer << static_cast<std::uint64_t>(value);
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, AnnounceErrorCode& value)
-    {
-        std::uint64_t uvalue;
-        buffer = buffer >> uvalue;
-        value = static_cast<AnnounceErrorCode>(uvalue);
-        return buffer;
-    }
-
-    Bytes& operator<<(Bytes& buffer, SubscribeAnnouncesErrorCode value)
-    {
-        buffer << static_cast<std::uint64_t>(value);
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, SubscribeAnnouncesErrorCode& value)
-    {
-        std::uint64_t uvalue;
-        buffer = buffer >> uvalue;
-        value = static_cast<SubscribeAnnouncesErrorCode>(uvalue);
-        return buffer;
-    }
-
     Bytes& operator<<(Bytes& buffer, FetchErrorCode value)
     {
         buffer << static_cast<std::uint64_t>(value);
@@ -153,34 +97,6 @@ namespace quicr::messages {
         std::uint64_t uvalue;
         buffer = buffer >> uvalue;
         value = static_cast<FetchErrorCode>(uvalue);
-        return buffer;
-    }
-
-    Bytes& operator<<(Bytes& buffer, SubscribeDoneStatusCode value)
-    {
-        buffer << static_cast<std::uint64_t>(value);
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, SubscribeDoneStatusCode& value)
-    {
-        std::uint64_t uvalue;
-        buffer = buffer >> uvalue;
-        value = static_cast<SubscribeDoneStatusCode>(uvalue);
-        return buffer;
-    }
-
-    Bytes& operator<<(Bytes& buffer, SubscribeErrorCode value)
-    {
-        buffer << static_cast<std::uint64_t>(value);
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, SubscribeErrorCode& value)
-    {
-        std::uint64_t uvalue;
-        buffer = buffer >> uvalue;
-        value = static_cast<SubscribeErrorCode>(uvalue);
         return buffer;
     }
 

--- a/src/ctrl_messages.cpp
+++ b/src/ctrl_messages.cpp
@@ -981,18 +981,4 @@ namespace quicr::messages {
         return buffer;
     }
 
-    Bytes& operator<<(Bytes& buffer, const quicr::messages::Parameter& param)
-    {
-        buffer << param.type;
-        buffer << param.value;
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, quicr::messages::Parameter& param)
-    {
-        buffer = buffer >> param.type;
-        buffer = buffer >> param.value;
-        return buffer;
-    }
-
 } // namespace

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -115,23 +115,6 @@ namespace quicr::messages {
     }
 
     template<class StreamBufferType>
-    bool operator>>(StreamBufferType& buffer, quicr::messages::Parameter& param)
-    {
-        if (!ParseUintVField(buffer, param.type)) {
-            return false;
-        }
-
-        auto val = buffer.DecodeBytes();
-        if (!val) {
-            return false;
-        }
-
-        param.value = std::move(val.value());
-
-        return true;
-    }
-
-    template<class StreamBufferType>
     bool operator>>(StreamBufferType& buffer, FetchHeader& msg)
     {
         switch (msg.current_pos) {

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -472,8 +472,7 @@ GenerateSubscribe(FilterType filter, size_t num_params = 0, uint64_t sg = 0, uin
 
     while (num_params > 0) {
         Parameter param1;
-        param1.type = ParameterType::kMaxSubscribeId;
-        // param1.length = 0x2;
+        param1.type = ParameterType::kPath;
         param1.value = { 0x1, 0x2 };
         out.subscribe_parameters.push_back(param1);
         num_params--;
@@ -519,7 +518,6 @@ TEST_CASE("Subscribe (Combo) Message encode/decode")
         CHECK_EQ(subscribes[i].subscribe_parameters.size(), subscribe_out.subscribe_parameters.size());
         for (size_t j = 0; j < subscribes[i].subscribe_parameters.size(); j++) {
             CHECK_EQ(subscribes[i].subscribe_parameters[j].type, subscribe_out.subscribe_parameters[j].type);
-            // CHECK_EQ(subscribes[i].subscribe_parameters[j].length, subscribe_out.subscribe_parameters[j].length);
             CHECK_EQ(subscribes[i].subscribe_parameters[j].value, subscribe_out.subscribe_parameters[j].value);
         }
     }
@@ -903,7 +901,7 @@ enum class ExampleEnum : std::uint64_t
 };
 using TestKVPEnum = KeyValuePair<ExampleEnum>;
 Bytes
-kvp64(const std::uint64_t type, const Bytes& value)
+KVP64(const std::uint64_t type, const Bytes& value)
 {
     TestKVP64 test;
     test.type = type;
@@ -913,7 +911,7 @@ kvp64(const std::uint64_t type, const Bytes& value)
     return buffer;
 }
 Bytes
-kvpEnum(const ExampleEnum type, const Bytes& value)
+KVPEnum(const ExampleEnum type, const Bytes& value)
 {
     TestKVPEnum test;
     test.type = type;
@@ -933,7 +931,7 @@ TEST_CASE("Key Value Pair encode/decode")
         {
             CAPTURE("EVEN");
             std::size_t type = 2;
-            Bytes serialized = kvp64(type, value);
+            Bytes serialized = KVP64(type, value);
             CHECK_EQ(serialized.size(), 2); // Minimal size, 1 byte for type and 1 byte for value.
             TestKVP64 out;
             serialized >> out;
@@ -943,7 +941,7 @@ TEST_CASE("Key Value Pair encode/decode")
         {
             CAPTURE("ODD");
             std::size_t type = 1;
-            Bytes serialized = kvp64(type, value);
+            Bytes serialized = KVP64(type, value);
             CHECK_EQ(serialized.size(),
                      value.size() + 1 + 1); // 1 byte for type, 1 byte for length, and the value bytes.
             TestKVP64 out;
@@ -957,7 +955,7 @@ TEST_CASE("Key Value Pair encode/decode")
         {
             CAPTURE("EVEN");
             auto type = ExampleEnum::kEven;
-            Bytes serialized = kvpEnum(type, value);
+            Bytes serialized = KVPEnum(type, value);
             CHECK_EQ(serialized.size(), 2); // Minimal size, 1 byte for type and 1 byte for value.
             TestKVPEnum out;
             serialized >> out;
@@ -967,7 +965,7 @@ TEST_CASE("Key Value Pair encode/decode")
         {
             CAPTURE("ODD");
             auto type = ExampleEnum::kOdd;
-            Bytes serialized = kvpEnum(type, value);
+            Bytes serialized = KVPEnum(type, value);
             CHECK_EQ(serialized.size(),
                      value.size() + 1 + 1); // 1 byte for type, 1 byte for length, and the value bytes.
             TestKVPEnum out;

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -329,7 +329,7 @@ TEST_CASE("Subscribe (Params) Message encode/decode")
 {
     Bytes buffer;
     Parameter param;
-    param.type = ParameterType::kMaxSubscribeId;
+    param.type = ParameterType::kInvalid;
     param.value = { 0x1, 0x2 };
     SubscribeParameters params = { param };
 
@@ -378,13 +378,11 @@ TEST_CASE("Subscribe (Params - 2) Message encode/decode")
 {
     Bytes buffer;
     Parameter param1;
-    param1.type = ParameterType::kMaxSubscribeId;
-    // param1.length = 0x2;
+    param1.type = ParameterType::kPath;
     param1.value = { 0x1, 0x2 };
 
     Parameter param2;
-    param2.type = ParameterType::kMaxSubscribeId;
-    // param2.length = 0x3;
+    param2.type = ParameterType::kPath;
     param2.value = { 0x1, 0x2, 0x3 };
 
     SubscribeParameters params = { param1, param2 };

--- a/tools/draft_parser/moqt_parser/templates/cpp/MessageSpec_Source_End_tmpl.jinja2
+++ b/tools/draft_parser/moqt_parser/templates/cpp/MessageSpec_Source_End_tmpl.jinja2
@@ -35,19 +35,5 @@
         return buffer;
     } 
 
-    Bytes& operator<<(Bytes& buffer, const quicr::messages::Parameter& param)
-    {
-        buffer << param.type;
-        buffer << param.value;
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, quicr::messages::Parameter& param)
-    {
-        buffer = buffer >> param.type;
-        buffer = buffer >> param.value;
-        return buffer;
-    }    
-
 } // namespace
 


### PR DESCRIPTION
- Add for parameters
- Consolidate uint64_t enum coding
- Move parameters to new structure
- Alter some of our parameters to be odd, so the encoding doesn't change. 

Will migrate extensions later. I know that test case is horrible. 