### PR TITLE
Added SSL keylog, for easier tracing with wireshark

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -703,9 +703,14 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
         qclient_vars::playback_speed_ms = std::chrono::milliseconds(cli_opts["playback_speed_ms"].as<uint64_t>());
     }
 
+    if (cli_opts.count("ssl_keylog") && cli_opts["ssl_keylog"].as<bool>() == true) {
+        SPDLOG_INFO("SSL Keylog enabled");
+    }
+
     config.endpoint_id = cli_opts["endpoint_id"].as<std::string>();
     config.connect_uri = cli_opts["url"].as<std::string>();
     config.transport_config.debug = cli_opts["debug"].as<bool>();
+    config.transport_config.ssl_keylog = cli_opts["ssl_keylog"].as<bool>();
 
     config.transport_config.use_reset_wait_strategy = false;
     config.transport_config.time_queue_max_duration = 5000;
@@ -734,7 +739,8 @@ main(int argc, char* argv[])
         ("v,version", "QuicR Version")                                        // a bool parameter
         ("r,url", "Relay URL", cxxopts::value<std::string>()->default_value("moq://localhost:1234"))
         ("e,endpoint_id", "This client endpoint ID", cxxopts::value<std::string>()->default_value("moq-client"))
-        ("q,qlog", "Enable qlog using path", cxxopts::value<std::string>());
+        ("q,qlog", "Enable qlog using path", cxxopts::value<std::string>())
+        ("s,ssl_keylog", "Enable SSL Keylog for transport debugging");
 
     options.add_options("Publisher")
         ("pub_namespace", "Track namespace", cxxopts::value<std::string>())

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -886,12 +886,17 @@ InitConfig(cxxopts::ParseResult& cli_opts)
         qserver_vars::force_track_alias = false;
     }
 
+    if (cli_opts.count("ssl_keylog") && cli_opts["ssl_keylog"].as<bool>() == true) {
+        SPDLOG_INFO("SSL Keylog enabled");
+    }
+
     config.endpoint_id = cli_opts["endpoint_id"].as<std::string>();
 
     config.server_bind_ip = cli_opts["bind_ip"].as<std::string>();
     config.server_port = cli_opts["port"].as<uint16_t>();
 
     config.transport_config.debug = cli_opts["debug"].as<bool>();
+    config.transport_config.ssl_keylog = cli_opts["ssl_keylog"].as<bool>();
     config.transport_config.tls_cert_filename = cli_opts["cert"].as<std::string>();
     config.transport_config.tls_key_filename = cli_opts["key"].as<std::string>();
     config.transport_config.use_reset_wait_strategy = false;
@@ -918,7 +923,8 @@ main(int argc, char* argv[])
         "e,endpoint_id", "This relay/server endpoint ID", cxxopts::value<std::string>()->default_value("moq-server"))(
         "c,cert", "Certificate file", cxxopts::value<std::string>()->default_value("./server-cert.pem"))(
         "k,key", "Certificate key file", cxxopts::value<std::string>()->default_value("./server-key.pem"))(
-        "q,qlog", "Enable qlog using path", cxxopts::value<std::string>()); // end of options
+        "q,qlog", "Enable qlog using path", cxxopts::value<std::string>())(
+        "s,ssl_keylog", "Enable SSL Keylog for transport debugging"); // end of options
 
     auto result = options.parse(argc, argv);
 

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -106,6 +106,7 @@ namespace quicr {
         std::string quic_qlog_path;            /// If present, log QUIC LOG file to this path
         uint8_t quic_priority_limit{ 0 };      /// Lowest priority that will not be bypassed from pacing/CC in picoquic
         std::size_t max_connections{ 1 };
+        bool ssl_keylog{ false }; ///< Enable SSL key logging for QUIC connections
     };
 
     /// Stream action that should be done by send/receive processing

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -460,6 +460,8 @@ PicoQuicTransport::Start()
         (void)picoquic_config_set_option(&config_, picoquic_option_CC_ALGO, "reno");
     }
 
+    picoquic_config_set_option(&config_, picoquic_option_SSLKEYLOG, "1");
+
     (void)picoquic_config_set_option(&config_, picoquic_option_ALPN, quicr_alpn);
     (void)picoquic_config_set_option(
       &config_, picoquic_option_CWIN_MIN, std::to_string(tconfig_.quic_cwin_minimum).c_str());
@@ -472,6 +474,8 @@ PicoQuicTransport::Start()
         SPDLOG_LOGGER_CRITICAL(logger, "Unable to create picoquic context, check certificate and key filenames");
         throw PicoQuicException("Unable to create picoquic context");
     }
+
+    picoquic_set_key_log_file_from_env(quic_ctx_);
 
     /*
      * TODO doc: Apparently need to set some value to send datagrams. If not set,

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -460,8 +460,6 @@ PicoQuicTransport::Start()
         (void)picoquic_config_set_option(&config_, picoquic_option_CC_ALGO, "reno");
     }
 
-    picoquic_config_set_option(&config_, picoquic_option_SSLKEYLOG, "1");
-
     (void)picoquic_config_set_option(&config_, picoquic_option_ALPN, quicr_alpn);
     (void)picoquic_config_set_option(
       &config_, picoquic_option_CWIN_MIN, std::to_string(tconfig_.quic_cwin_minimum).c_str());
@@ -475,7 +473,9 @@ PicoQuicTransport::Start()
         throw PicoQuicException("Unable to create picoquic context");
     }
 
-    picoquic_set_key_log_file_from_env(quic_ctx_);
+    if (config_.enable_sslkeylog) {
+        picoquic_set_key_log_file_from_env(quic_ctx_);
+    }
 
     /*
      * TODO doc: Apparently need to set some value to send datagrams. If not set,
@@ -915,6 +915,9 @@ PicoQuicTransport::PicoQuicTransport(const TransportRemote& server,
         } else {
             throw InvalidConfigException("Missing cert key filename");
         }
+    }
+    if (tcfg.ssl_keylog == true) {
+        (void)picoquic_config_set_option(&config_, picoquic_option_SSLKEYLOG, "1");
     }
 }
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -474,6 +474,9 @@ PicoQuicTransport::Start()
     }
 
     if (config_.enable_sslkeylog) {
+        if (std::getenv("SSLKEYLOGFILE") == nullptr) {
+            SPDLOG_LOGGER_WARN(logger, "Key log enabled but $SSLKEYLOGFILE not set");
+        }
         picoquic_set_key_log_file_from_env(quic_ctx_);
     }
 


### PR DESCRIPTION
This pull request introduces changes to enhance debugging capabilities for the `PicoQuicTransport` by enabling SSL key logging. The updates include configuring SSL key logging in the PicoQUIC library and setting the key log file from the environment.

Format is the same  as in picoquic: SSLKEYLOGFILE=<path_to_keylogfile>