### PR TITLE
Keep compatible with old version python

### DIFF
--- a/tools/draft_parser/moqt_parser/parsers.py
+++ b/tools/draft_parser/moqt_parser/parsers.py
@@ -39,11 +39,11 @@ class ProtocolMessageParser:
         is_variable_length = parsed_field_type == ".."
 
         cpp_using_name = name.replace(" ", "")
-        comp_name = f"{message_name}::{name.replace(" ","")}"
+        comp_name = f"{message_name}::{name.replace(' ','')}"
         if comp_name in self.field_type_map:
             cpp_type = self.field_type_map[comp_name]
             # name = f"{message_name}_{name.replace(" ","")}"
-            cpp_using_name = f"{message_name}{name.replace(" ","")}"
+            cpp_using_name = f"{message_name}{name.replace(' ','')}"
         elif name in self.field_type_map:
             cpp_type = self.field_type_map[name]
         elif spec_type in self.field_type_map:


### PR DESCRIPTION
Without this fix, python 3.10 will report the following errors:
```
[ 79%] Built target picolog_t
Traceback (most recent call last):
  File "/home/lal/volume/third_party/libquicr/tools/draft_parser/cmake/../main.py", line 5, in <module>
    from moqt_parser import ProtocolMessageParser, CodeGenerator  # , TableParser
  File "/home/lal/volume/third_party/libquicr/tools/draft_parser/moqt_parser/__init__.py", line 2, in <module>
    from .parsers import ProtocolMessageParser
  File "/home/lal/volume/third_party/libquicr/tools/draft_parser/moqt_parser/parsers.py", line 42
    comp_name = f"{message_name}::{name.replace(" ","")}"
                                                         ^
SyntaxError: f-string: unmatched '('
make[2]: *** [CMakeFiles/generate_moq_messages.dir/build.make:92: include/quicr/detail/ctrl_messages.h] Error 1 
```