### PR TITLE
Fixup byte swapping

### DIFF
--- a/src/ctrl_message_types.cpp
+++ b/src/ctrl_message_types.cpp
@@ -31,9 +31,8 @@ namespace quicr::messages {
 
     Bytes& operator<<(Bytes& buffer, std::uint16_t value)
     {
-        const std::uint16_t swapped = SwapBytes(value);
-        buffer.push_back(static_cast<uint8_t>(swapped >> 8 & 0xFF));
-        buffer.push_back(static_cast<uint8_t>(swapped & 0xFF));
+        buffer.push_back(static_cast<uint8_t>(value >> 8 & 0xFF));
+        buffer.push_back(static_cast<uint8_t>(value & 0xFF));
         return buffer;
     }
 
@@ -64,9 +63,7 @@ namespace quicr::messages {
         if (buffer.size() < sizeof(value)) {
             throw std::invalid_argument("Provider buffer too small");
         }
-        const std::uint16_t high = buffer[0];
-        const std::uint16_t low = buffer[1];
-        value = high << 8 | low;
+        std::memcpy(&value, buffer.data(), sizeof(value));
         value = SwapBytes(value);
         return buffer.subspan(sizeof(std::uint16_t));
     }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1286,7 +1286,7 @@ namespace quicr {
                         break; // Not enough bytes to process control message. Try again once more.
                     }
 
-                    payload_len = (conn_ctx.ctrl_msg_buffer[0] << 8) | conn_ctx.ctrl_msg_buffer[1];
+                    std::memcpy(&payload_len, conn_ctx.ctrl_msg_buffer.data(), sizeof(payload_len));
                     payload_len = SwapBytes(payload_len);
 
                     if (conn_ctx.ctrl_msg_buffer.size() < payload_len + sizeof(payload_len)) {


### PR DESCRIPTION
Somewhere along the way our endianness swapping got confused for the fixed 16 bit network order control message lengths. 