### PR TITLE
Draft 12 compile

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -228,33 +228,23 @@ class MyPublishTrackHandler : public quicr::PublishTrackHandler
     {
         switch (status) {
             case Status::kOk: {
-                if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                    SPDLOG_INFO("Publish track alias: {0} is ready to send", track_alias.value());
-                }
+                SPDLOG_INFO("Publish track alias: {0} is ready to send", GetTrackAlias());
                 break;
             }
             case Status::kNoSubscribers: {
-                if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                    SPDLOG_INFO("Publish track alias: {0} has no subscribers", track_alias.value());
-                }
+                SPDLOG_INFO("Publish track alias: {0} has no subscribers", GetTrackAlias());
                 break;
             }
             case Status::kNewGroupRequested: {
-                if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                    SPDLOG_INFO("Publish track alias: {0} has new group request", track_alias.value());
-                }
+                SPDLOG_INFO("Publish track alias: {0} has new group request", GetTrackAlias());
                 break;
             }
             case Status::kSubscriptionUpdated: {
-                if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                    SPDLOG_INFO("Publish track alias: {0} has updated subscription", track_alias.value());
-                }
+                SPDLOG_INFO("Publish track alias: {0} has updated subscription", GetTrackAlias());
                 break;
             }
             default:
-                if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                    SPDLOG_INFO("Publish track alias: {0} status {1}", track_alias.value(), static_cast<int>(status));
-                }
+                SPDLOG_INFO("Publish track alias: {0} has status {1}", GetTrackAlias(), static_cast<int>(status));
                 break;
         }
     }

--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -341,13 +341,13 @@ class MyClient : public quicr::Client
     void AnnounceReceived(const quicr::TrackNamespace& track_namespace,
                           const quicr::PublishAnnounceAttributes&) override
     {
-        auto th = quicr::TrackHash({ track_namespace, {}, std::nullopt });
+        auto th = quicr::TrackHash({ track_namespace, {} });
         SPDLOG_INFO("Received announce for namespace_hash: {}", th.track_namespace_hash);
     }
 
     void UnannounceReceived(const quicr::TrackNamespace& track_namespace) override
     {
-        auto th = quicr::TrackHash({ track_namespace, {}, std::nullopt });
+        auto th = quicr::TrackHash({ track_namespace, {} });
         SPDLOG_INFO("Received unannounce for namespace_hash: {}", th.track_namespace_hash);
     }
 
@@ -355,7 +355,7 @@ class MyClient : public quicr::Client
                                          std::optional<quicr::messages::SubscribeAnnouncesErrorCode> error_code,
                                          std::optional<quicr::messages::ReasonPhrase> reason) override
     {
-        auto th = quicr::TrackHash({ track_namespace, {}, std::nullopt });
+        auto th = quicr::TrackHash({ track_namespace, {} });
         if (!error_code.has_value()) {
             SPDLOG_INFO("Subscribe announces namespace_hash: {} status changed to OK", th.track_namespace_hash);
             return;
@@ -799,8 +799,7 @@ main(int argc, char* argv[])
         std::thread fetch_thread;
 
         if (result.count("sub_announces")) {
-            const auto& prefix_ns =
-              quicr::example::MakeFullTrackName(result["sub_announces"].as<std::string>(), "", std::nullopt);
+            const auto& prefix_ns = quicr::example::MakeFullTrackName(result["sub_announces"].as<std::string>(), "");
 
             auto th = quicr::TrackHash(prefix_ns);
 
@@ -813,8 +812,7 @@ main(int argc, char* argv[])
 
         if (enable_pub) {
             const auto& pub_track_name = quicr::example::MakeFullTrackName(result["pub_namespace"].as<std::string>(),
-                                                                           result["pub_name"].as<std::string>(),
-                                                                           qclient_vars::track_alias);
+                                                                           result["pub_name"].as<std::string>());
 
             pub_thread = std::thread(DoPublisher, pub_track_name, client, std::ref(stop_threads));
         }
@@ -829,17 +827,14 @@ main(int argc, char* argv[])
             bool joining_fetch = result.count("joining_fetch") && result["joining_fetch"].as<bool>();
 
             const auto& sub_track_name = quicr::example::MakeFullTrackName(result["sub_namespace"].as<std::string>(),
-                                                                           result["sub_name"].as<std::string>(),
-                                                                           qclient_vars::track_alias);
+                                                                           result["sub_name"].as<std::string>());
 
             sub_thread =
               std::thread(DoSubscriber, sub_track_name, client, filter_type, std::ref(stop_threads), joining_fetch);
         }
         if (enable_fetch) {
-            const auto& fetch_track_name =
-              quicr::example::MakeFullTrackName(result["fetch_namespace"].as<std::string>(),
-                                                result["fetch_name"].as<std::string>(),
-                                                qclient_vars::track_alias);
+            const auto& fetch_track_name = quicr::example::MakeFullTrackName(
+              result["fetch_namespace"].as<std::string>(), result["fetch_name"].as<std::string>());
 
             fetch_thread =
               std::thread(DoFetch,

--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -226,25 +226,26 @@ class MyPublishTrackHandler : public quicr::PublishTrackHandler
 
     void StatusChanged(Status status) override
     {
+        const auto alias = GetTrackAlias(GetRequestId().value());
         switch (status) {
             case Status::kOk: {
-                SPDLOG_INFO("Publish track alias: {0} is ready to send", GetTrackAlias());
+                SPDLOG_INFO("Publish track alias: {0} is ready to send", alias);
                 break;
             }
             case Status::kNoSubscribers: {
-                SPDLOG_INFO("Publish track alias: {0} has no subscribers", GetTrackAlias());
+                SPDLOG_INFO("Publish track alias: {0} has no subscribers", alias);
                 break;
             }
             case Status::kNewGroupRequested: {
-                SPDLOG_INFO("Publish track alias: {0} has new group request", GetTrackAlias());
+                SPDLOG_INFO("Publish track alias: {0} has new group request", alias);
                 break;
             }
             case Status::kSubscriptionUpdated: {
-                SPDLOG_INFO("Publish track alias: {0} has updated subscription", GetTrackAlias());
+                SPDLOG_INFO("Publish track alias: {0} has updated subscription", alias);
                 break;
             }
             default:
-                SPDLOG_INFO("Publish track alias: {0} has status {1}", GetTrackAlias(), static_cast<int>(status));
+                SPDLOG_INFO("Publish track alias: {0} has status {1}", alias, static_cast<int>(status));
                 break;
         }
     }

--- a/cmd/examples/helper_functions.h
+++ b/cmd/examples/helper_functions.h
@@ -39,8 +39,7 @@ namespace quicr::example {
      * @return quicr::FullTrackName of the params
      */
     static FullTrackName const MakeFullTrackName(const std::string& track_namespace,
-                                                 const std::string& track_name,
-                                                 const std::optional<uint64_t> track_alias) noexcept
+                                                 const std::string& track_name) noexcept
     {
         const auto split = [](std::string str, const std::string& delimiter) {
             std::vector<std::string> tokens;
@@ -56,8 +55,7 @@ namespace quicr::example {
         };
 
         FullTrackName full_track_name{ TrackNamespace{ split(track_namespace, ",") },
-                                       { track_name.begin(), track_name.end() },
-                                       track_alias };
+                                       { track_name.begin(), track_name.end() } };
         return full_track_name;
     }
 }

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -671,7 +671,6 @@ class MyServer : public quicr::Server
                          {
                            quicr::SubscribeResponse::ReasonCode::kOk,
                            std::nullopt,
-                           std::nullopt,
                            largest_location,
                          });
 

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -660,8 +660,8 @@ class MyServer : public quicr::Server
             }
         }
 
-        const auto pub_track_h = std::make_shared<MyPublishTrackHandler>(
-          track_full_name, quicr::TrackMode::kStream, attrs.priority, 50000);
+        const auto pub_track_h =
+          std::make_shared<MyPublishTrackHandler>(track_full_name, quicr::TrackMode::kStream, attrs.priority, 50000);
         const auto track_alias = pub_track_h->GetTrackAlias();
 
         ResolveSubscribe(connection_handle,
@@ -673,7 +673,6 @@ class MyServer : public quicr::Server
                            std::nullopt,
                            largest_location,
                          });
-
 
         qserver_vars::subscribes[track_alias][connection_handle] = pub_track_h;
         qserver_vars::subscribe_alias_sub_id[connection_handle][subscribe_id] = track_alias;

--- a/cmd/qperf/qperf.cpp
+++ b/cmd/qperf/qperf.cpp
@@ -95,11 +95,10 @@ namespace {
         {
             switch (status) {
                 case Status::kOk: {
-                    if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                        SPDLOG_INFO("Track alias: {0} is ready to read", track_alias.value());
-                        cv.notify_one();
-                    }
-                } break;
+                    SPDLOG_INFO("Track alias: {0} is ready to read", GetTrackAlias());
+                    cv.notify_one();
+                    break;
+                }
                 default:
                     break;
             }

--- a/cmd/qperf/qperf.cpp
+++ b/cmd/qperf/qperf.cpp
@@ -93,7 +93,7 @@ namespace {
         {
             switch (status) {
                 case Status::kOk: {
-                    SPDLOG_INFO("Track alias: {0} is ready to read", GetTrackAlias());
+                    SPDLOG_INFO("Track alias: {0} is ready to read", GetTrackAlias(this->GetRequestId().value()));
                     cv.notify_one();
                     break;
                 }

--- a/cmd/qperf/qperf.cpp
+++ b/cmd/qperf/qperf.cpp
@@ -56,14 +56,12 @@ namespace {
     }
 
     inline quicr::FullTrackName MakeFullTrackName(const std::string& track_namespace,
-                                                  const std::string& track_name,
-                                                  const std::optional<uint64_t> track_alias = std::nullopt) noexcept
+                                                  const std::string& track_name) noexcept
     {
 
         return {
             quicr::TrackNamespace{ quicr::Bytes{ track_namespace.begin(), track_namespace.end() } },
             { track_name.begin(), track_name.end() },
-            track_alias,
         };
     }
 

--- a/cmd/qperf2/qperf.hpp
+++ b/cmd/qperf2/qperf.hpp
@@ -60,14 +60,9 @@ namespace qperf {
     };
 
     inline quicr::FullTrackName MakeFullTrackName(const std::string& track_namespace,
-                                                  const std::string& track_name,
-                                                  const std::optional<uint64_t> track_alias = std::nullopt) noexcept
+                                                  const std::string& track_name) noexcept
     {
-        return {
-            quicr::TrackNamespace{ track_namespace },
-            { track_name.begin(), track_name.end() },
-            track_alias,
-        };
+        return { quicr::TrackNamespace{ track_namespace }, { track_name.begin(), track_name.end() } };
     }
 
     static bool PopulateScenarioFields(const std::string section_name, ini::IniFile& inif, PerfConfig& perf_config)

--- a/cmd/qperf2/qperf_pub.cc
+++ b/cmd/qperf2/qperf_pub.cc
@@ -40,7 +40,7 @@ namespace qperf {
         switch (status) {
             case Status::kOk: {
                 SPDLOG_INFO("PerfPublishTrackeHandler - status kOk");
-                auto track_alias = GetTrackAlias();
+                auto track_alias = GetTrackAlias(GetRequestId().value());
                 SPDLOG_INFO("Track alias: {0} is ready to write", track_alias);
                 write_thread_ = SpawnWriter();
             } break;

--- a/cmd/qperf2/qperf_pub.cc
+++ b/cmd/qperf2/qperf_pub.cc
@@ -41,10 +41,8 @@ namespace qperf {
             case Status::kOk: {
                 SPDLOG_INFO("PerfPublishTrackeHandler - status kOk");
                 auto track_alias = GetTrackAlias();
-                if (track_alias.has_value()) {
-                    SPDLOG_INFO("Track alias: {0} is ready to write", track_alias.value());
-                    write_thread_ = SpawnWriter();
-                }
+                SPDLOG_INFO("Track alias: {0} is ready to write", track_alias);
+                write_thread_ = SpawnWriter();
             } break;
             case Status::kNotConnected:
                 SPDLOG_INFO("PerfPublishTrackeHandler - status kNotConnected");

--- a/include/quicr/client.h
+++ b/include/quicr/client.h
@@ -139,10 +139,12 @@ namespace quicr {
          *
          * @param connection_handle        source connection ID
          * @param request_id               request ID
+         * @param track_alias              track alias for this track
          * @param subscribe_response       response to for the subscribe
          */
         virtual void ResolveSubscribe(ConnectionHandle connection_handle,
                                       uint64_t request_id,
+                                      uint64_t track_alias,
                                       const SubscribeResponse& subscribe_response);
 
         /**

--- a/include/quicr/detail/base_track_handler.h
+++ b/include/quicr/detail/base_track_handler.h
@@ -39,12 +39,10 @@ namespace quicr {
             kOk = 0,
             kInternalError,
             kInvalidRange,
-            kRetryTrackAlias,
         };
         ReasonCode reason_code;
 
         std::optional<std::string> error_reason = std::nullopt;
-        std::optional<uint64_t> track_alias = std::nullopt; ///< Set only when ResponseCode is kRetryTrackAlias
 
         std::optional<messages::Location> largest_location = std::nullopt;
     };

--- a/include/quicr/detail/base_track_handler.h
+++ b/include/quicr/detail/base_track_handler.h
@@ -79,27 +79,12 @@ namespace quicr {
         {
         }
 
+        FullTrackName full_track_name_;
+
         // --------------------------------------------------------------------------
         // Public Virtual API callback event methods to be overridden
         // --------------------------------------------------------------------------
       public:
-        /**
-         * @brief Set the track alias
-         * @details MOQ transport instance will set the track alias when the track has
-         *   been assigned.
-         *
-         * @param track_alias       MoQ track alias for track namespace+name that
-         *                          is relative to the QUIC connection session
-         */
-        void SetTrackAlias(uint64_t track_alias) { full_track_name_.track_alias = track_alias; }
-
-        /**
-         * @brief Get the track alias
-         * @returns Track alias as an optional. Track alias may not be set yet. If not
-         *   set, nullopt will be returned.
-         */
-        std::optional<uint64_t> GetTrackAlias() const noexcept { return full_track_name_.track_alias; }
-
         /**
          * @brief Sets the reqeust ID
          * @details MoQ instance sets the request id based on subscribe track method call. Request
@@ -144,8 +129,6 @@ namespace quicr {
         // --------------------------------------------------------------------------
         // Member variables
         // --------------------------------------------------------------------------
-
-        FullTrackName full_track_name_;
 
         ConnectionHandle connection_handle_; // QUIC transport connection ID
 

--- a/include/quicr/detail/ctrl_message_types.h
+++ b/include/quicr/detail/ctrl_message_types.h
@@ -37,6 +37,16 @@ namespace quicr::messages {
     {
         GroupId group{ 0 };
         ObjectId object{ 0 };
+
+        auto operator<=>(const Location& other) const
+        {
+            if (const auto cmp = group <=> other.group; cmp != 0) {
+                return cmp;
+            }
+            return object <=> other.object;
+        }
+
+        bool operator==(const Location& other) const = default;
     };
     Bytes& operator<<(Bytes& buffer, const Location& location);
     BytesSpan operator>>(BytesSpan buffer, Location& location);

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -336,6 +336,7 @@ namespace quicr {
 
         void SendSubscribeOk(ConnectionContext& conn_ctx,
                              messages::RequestID request_id,
+                             uint64_t track_alias,
                              uint64_t expires,
                              bool content_exists,
                              messages::Location largest_location);
@@ -343,7 +344,6 @@ namespace quicr {
         void SendSubscribeDone(ConnectionContext& conn_ctx, messages::RequestID request_id, const std::string& reason);
         void SendSubscribeError(ConnectionContext& conn_ctx,
                                 messages::RequestID request_id,
-                                uint64_t track_alias,
                                 messages::SubscribeErrorCode error,
                                 const std::string& reason);
 

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -121,6 +121,12 @@ namespace quicr {
               new PublishTrackHandler(full_track_name, track_mode, default_priority, default_ttl));
         }
 
+        /**
+         * @brief Get the track alias
+         * @returns Track alias
+         */
+        uint64_t GetTrackAlias() const noexcept { return full_track_name_.track_alias.value(); }
+
         // --------------------------------------------------------------------------
         // Public Virtual API callback event methods
         // --------------------------------------------------------------------------

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -122,6 +122,7 @@ namespace quicr {
         }
 
         /**
+         * TODO: Support per SUBSCRIBE track alias here?
          * @brief Produce a track alias for the given subscribe response.
          * @details This method can be overridden to control track alias generation.
          * @returns Track alias
@@ -137,7 +138,7 @@ namespace quicr {
 
         /**
          * @brief Notification of publish track status change
-         * @details Notification of a change to publish track status, such as
+         * @details Notification of a change to  publish track status, such as
          *      when it's ready to publish or not ready to publish
          *
          * @param status        Indicates the status of being able to publish

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -89,10 +89,6 @@ namespace quicr {
           , default_priority_(default_priority)
           , default_ttl_(default_ttl)
         {
-            if (!full_track_name.track_alias.has_value()) {
-                throw std::invalid_argument("Track alias must be specified");
-            }
-
             switch (track_mode) {
                 case TrackMode::kDatagram:
                     if (stream_mode.has_value()) {
@@ -126,10 +122,11 @@ namespace quicr {
         }
 
         /**
-         * @brief Get the track alias
+         * @brief Produce a track alias for the given subscribe response.
+         * @details This method can be overridden to control track alias generation.
          * @returns Track alias
          */
-        uint64_t GetTrackAlias() const noexcept { return full_track_name_.track_alias.value(); }
+        virtual uint64_t GetTrackAlias() const noexcept { return TrackHash(full_track_name_).track_fullname_hash; }
 
         // --------------------------------------------------------------------------
         // Public Virtual API callback event methods

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -89,6 +89,10 @@ namespace quicr {
           , default_priority_(default_priority)
           , default_ttl_(default_ttl)
         {
+            if (!full_track_name.track_alias.has_value()) {
+                throw std::invalid_argument("Track alias must be specified");
+            }
+
             switch (track_mode) {
                 case TrackMode::kDatagram:
                     if (stream_mode.has_value()) {

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -121,13 +121,18 @@ namespace quicr {
               new PublishTrackHandler(full_track_name, track_mode, default_priority, default_ttl));
         }
 
+        // TODO: Is this all the info needed for an alias calculation?
+
         /**
-         * TODO: Support per SUBSCRIBE track alias here?
          * @brief Produce a track alias for the given subscribe response.
          * @details This method can be overridden to control track alias generation.
-         * @returns Track alias
+         * @param request_id Request ID of the incoming subscribe requesting an alias.
+         * @returns Track alias to use.
          */
-        virtual uint64_t GetTrackAlias() const noexcept { return TrackHash(full_track_name_).track_fullname_hash; }
+        virtual uint64_t GetTrackAlias([[maybe_unused]] uint64_t request_id) const noexcept
+        {
+            return TrackHash(full_track_name_).track_fullname_hash;
+        }
 
         // --------------------------------------------------------------------------
         // Public Virtual API callback event methods

--- a/include/quicr/server.h
+++ b/include/quicr/server.h
@@ -130,10 +130,12 @@ namespace quicr {
          *
          * @param connection_handle        source connection ID
          * @param request_id               Request ID
+         * @param track_alias              Track alias the subscriber should use.
          * @param subscribe_response       response to for the subscribe
          */
         virtual void ResolveSubscribe(ConnectionHandle connection_handle,
                                       uint64_t request_id,
+                                      uint64_t track_alias,
                                       const SubscribeResponse& subscribe_response);
 
         // --BEGIN CALLBACKS ----------------------------------------------------------------------------------
@@ -273,13 +275,12 @@ namespace quicr {
          *
          * @param connection_handle     Source connection ID
          * @param request_id            Request ID received
-         * @param proposed_track_alias  The proposed track alias the subscriber would like to use
+         * @param filter_type           Filter type received
          * @param track_full_name       Track full name
          * @param subscribe_attributes  Subscribe attributes received
          */
         virtual void SubscribeReceived(ConnectionHandle connection_handle,
                                        uint64_t request_id,
-                                       uint64_t proposed_track_alias,
                                        messages::FilterType filter_type,
                                        const FullTrackName& track_full_name,
                                        const messages::SubscribeAttributes& subscribe_attributes);

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -148,7 +148,7 @@ namespace quicr {
          * @param track_alias       MoQ track alias for track namespace+name that
          *                          is relative to the QUIC connection session
          */
-        void SetTrackAlias(uint64_t track_alias) { full_track_name_.track_alias = track_alias; }
+        void SetTrackAlias(uint64_t track_alias) { track_alias_ = track_alias; }
 
         /**
          * @brief Get the track alias
@@ -157,7 +157,7 @@ namespace quicr {
          *
          * @return Track alias if set, otherwise std::nullopt.
          */
-        std::optional<uint64_t> GetTrackAlias() const noexcept { return full_track_name_.track_alias; }
+        std::optional<uint64_t> GetTrackAlias() const noexcept { return track_alias_; }
 
         // --------------------------------------------------------------------------
         // Public Virtual API callback event methods
@@ -271,6 +271,7 @@ namespace quicr {
         uint64_t current_stream_id_{ 0 };
         std::optional<messages::Location> latest_location_;
         std::optional<JoiningFetch> joining_fetch_;
+        std::optional<uint64_t> track_alias_;
 
         friend class Transport;
         friend class Client;

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -142,6 +142,23 @@ namespace quicr {
          */
         std::optional<JoiningFetch> GetJoiningFetch() const noexcept { return joining_fetch_; }
 
+        /**
+         * @brief Set the track alias
+         *
+         * @param track_alias       MoQ track alias for track namespace+name that
+         *                          is relative to the QUIC connection session
+         */
+        void SetTrackAlias(uint64_t track_alias) { full_track_name_.track_alias = track_alias; }
+
+        /**
+         * @brief Get the track alias
+         *
+         * @details If the track alias is set, it will be returned, otherwise std::nullopt.
+         *
+         * @return Track alias if set, otherwise std::nullopt.
+         */
+        std::optional<uint64_t> GetTrackAlias() const noexcept { return full_track_name_.track_alias; }
+
         // --------------------------------------------------------------------------
         // Public Virtual API callback event methods
         // --------------------------------------------------------------------------

--- a/include/quicr/track_name.h
+++ b/include/quicr/track_name.h
@@ -266,7 +266,6 @@ namespace quicr {
     {
         TrackNamespace name_space;
         std::vector<uint8_t> name;
-        std::optional<uint64_t> track_alias;
     };
 
     struct TrackHash

--- a/include/quicr/track_name.h
+++ b/include/quicr/track_name.h
@@ -261,7 +261,6 @@ namespace quicr {
      * @brief Full track name struct
      *
      * @details Struct of the full track name, which includes the namespace tuple, name, and track alias
-     *   Track alias will be set by the Transport.
      */
     struct FullTrackName
     {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -96,7 +96,7 @@ namespace quicr {
 
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, msg.track_name, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, msg.track_name };
                 auto th = TrackHash(tfn);
 
                 if (msg.request_id > conn_ctx.next_request_id) {
@@ -257,7 +257,7 @@ namespace quicr {
                 messages::Announce msg;
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, {}, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, {} };
 
                 AnnounceReceived(tfn.name_space, {});
                 return true;
@@ -267,7 +267,7 @@ namespace quicr {
                 messages::Unannounce msg;
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, {}, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, {} };
                 UnannounceReceived(tfn.name_space);
 
                 return true;
@@ -421,7 +421,7 @@ namespace quicr {
                 messages::AnnounceCancel msg;
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, {}, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, {} };
                 auto th = TrackHash(tfn);
 
                 SPDLOG_LOGGER_INFO(
@@ -433,7 +433,7 @@ namespace quicr {
                 messages::TrackStatusRequest msg;
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, msg.track_name, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, msg.track_name };
                 auto th = TrackHash(tfn);
 
                 SPDLOG_LOGGER_INFO(logger_,

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -36,6 +36,7 @@ namespace quicr {
 
     void Client::ResolveSubscribe(ConnectionHandle connection_handle,
                                   uint64_t request_id,
+                                  uint64_t track_alias,
                                   const SubscribeResponse& subscribe_response)
     {
         auto conn_it = connections_.find(connection_handle);
@@ -47,6 +48,7 @@ namespace quicr {
             case SubscribeResponse::ReasonCode::kOk: {
                 SendSubscribeOk(conn_it->second,
                                 request_id,
+                                track_alias,
                                 kSubscribeExpires,
                                 subscribe_response.largest_location.has_value(),
                                 subscribe_response.largest_location.has_value()
@@ -57,7 +59,7 @@ namespace quicr {
 
             default:
                 SendSubscribeError(
-                  conn_it->second, request_id, {}, messages::SubscribeErrorCode::kInternalError, "Internal error");
+                  conn_it->second, request_id, messages::SubscribeErrorCode::kInternalError, "Internal error");
                 break;
         }
     }
@@ -115,24 +117,25 @@ namespace quicr {
 
                     SendSubscribeError(conn_ctx,
                                        msg.request_id,
-                                       msg.track_alias,
                                        messages::SubscribeErrorCode::kTrackNotExist,
                                        "Published track not found");
                     return true;
                 }
 
-                ResolveSubscribe(conn_ctx.connection_handle, msg.request_id, { SubscribeResponse::ReasonCode::kOk });
+                ResolveSubscribe(conn_ctx.connection_handle,
+                                 msg.request_id,
+                                 ptd->GetTrackAlias(),
+                                 { SubscribeResponse::ReasonCode::kOk });
 
                 SPDLOG_LOGGER_DEBUG(logger_,
                                     "Received subscribe to announced track alias: {0} recv request_id: {1}, setting "
                                     "send state to ready",
-                                    msg.track_alias,
+                                    ptd->GetTrackAlias(),
                                     msg.request_id);
 
                 // Indicate send is ready upon subscribe
                 // TODO(tievens): Maybe needs a delay as subscriber may have not received ok before data is sent
                 ptd->SetRequestId(msg.request_id);
-                ptd->SetTrackAlias(msg.track_alias);
                 ptd->SetStatus(PublishTrackHandler::Status::kOk);
 
                 conn_ctx.recv_sub_id[msg.request_id] = { tfn };
@@ -149,11 +152,8 @@ namespace quicr {
                                        msg.request_id,
                                        conn_ctx.connection_handle);
 
-                    SendSubscribeError(conn_ctx,
-                                       msg.request_id,
-                                       0x0,
-                                       messages::SubscribeErrorCode::kTrackNotExist,
-                                       "Subscription not found");
+                    SendSubscribeError(
+                      conn_ctx, msg.request_id, messages::SubscribeErrorCode::kTrackNotExist, "Subscription not found");
                     return true;
                 }
 
@@ -172,13 +172,12 @@ namespace quicr {
 
                     SendSubscribeError(conn_ctx,
                                        msg.request_id,
-                                       th.track_fullname_hash,
                                        messages::SubscribeErrorCode::kTrackNotExist,
                                        "Published track not found");
                     return true;
                 }
 
-                SendSubscribeOk(conn_ctx, msg.request_id, kSubscribeExpires, false, { 0, 0 });
+                SendSubscribeOk(conn_ctx, msg.request_id, ptd->GetTrackAlias(), kSubscribeExpires, false, { 0, 0 });
 
                 SPDLOG_LOGGER_DEBUG(logger_,
                                     "Received subscribe_update to track alias: {0} recv request_id: {1}",
@@ -242,14 +241,12 @@ namespace quicr {
                     return true;
                 }
 
-                SPDLOG_LOGGER_INFO(
-                  logger_,
-                  "Received subscribe error conn_id: {} request_id: {} reason: {} code: {} requested track_alias: {}",
-                  conn_ctx.connection_handle,
-                  msg.request_id,
-                  std::string(msg.error_reason.begin(), msg.error_reason.end()),
-                  static_cast<std::uint64_t>(msg.error_code),
-                  msg.track_alias);
+                SPDLOG_LOGGER_INFO(logger_,
+                                   "Received subscribe error conn_id: {} request_id: {} reason: {} code: {}",
+                                   conn_ctx.connection_handle,
+                                   msg.request_id,
+                                   std::string(msg.error_reason.begin(), msg.error_reason.end()),
+                                   static_cast<std::uint64_t>(msg.error_code));
 
                 sub_it->second.get()->SetStatus(SubscribeTrackHandler::Status::kError);
                 RemoveSubscribeTrack(conn_ctx, *sub_it->second);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -124,13 +124,13 @@ namespace quicr {
 
                 ResolveSubscribe(conn_ctx.connection_handle,
                                  msg.request_id,
-                                 ptd->GetTrackAlias(),
+                                 ptd->GetTrackAlias(msg.request_id),
                                  { SubscribeResponse::ReasonCode::kOk });
 
                 SPDLOG_LOGGER_DEBUG(logger_,
                                     "Received subscribe to announced track alias: {0} recv request_id: {1}, setting "
                                     "send state to ready",
-                                    ptd->GetTrackAlias(),
+                                    ptd->GetTrackAlias(msg.request_id),
                                     msg.request_id);
 
                 // Indicate send is ready upon subscribe
@@ -177,7 +177,8 @@ namespace quicr {
                     return true;
                 }
 
-                SendSubscribeOk(conn_ctx, msg.request_id, ptd->GetTrackAlias(), kSubscribeExpires, false, { 0, 0 });
+                SendSubscribeOk(
+                  conn_ctx, msg.request_id, ptd->GetTrackAlias(msg.request_id), kSubscribeExpires, false, { 0, 0 });
 
                 SPDLOG_LOGGER_DEBUG(logger_,
                                     "Received subscribe_update to track alias: {0} recv request_id: {1}",

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -115,19 +115,6 @@ namespace quicr {
                                   : messages::Location());
                 break;
             }
-            case SubscribeResponse::ReasonCode::kRetryTrackAlias: {
-                if (subscribe_response.track_alias.has_value()) {
-                    SendSubscribeError(conn_it->second,
-                                       request_id,
-                                       messages::SubscribeErrorCode::kRetryTrackAlias,
-                                       subscribe_response.error_reason.has_value() ? *subscribe_response.error_reason
-                                                                                   : "internal error");
-                } else {
-                    SendSubscribeError(
-                      conn_it->second, request_id, messages::SubscribeErrorCode::kInternalError, "Missing track alias");
-                }
-                break;
-            }
             default:
                 SendSubscribeError(
                   conn_it->second, request_id, messages::SubscribeErrorCode::kInternalError, "Internal error");

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -377,7 +377,7 @@ namespace quicr {
                   });
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, msg.track_name, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, msg.track_name };
 
                 conn_ctx.recv_sub_id[msg.request_id] = { tfn };
 
@@ -447,7 +447,7 @@ namespace quicr {
                 auto msg = messages::Announce{};
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, {}, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, {}};
 
                 AnnounceReceived(conn_ctx.connection_handle, tfn.name_space, { msg.request_id });
                 return true;
@@ -498,7 +498,7 @@ namespace quicr {
                 messages::Unannounce msg;
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, {}, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, {}};
                 auto th = TrackHash(tfn);
 
                 SPDLOG_LOGGER_INFO(logger_, "Received unannounce for namespace_hash: {0}", th.track_namespace_hash);
@@ -585,7 +585,7 @@ namespace quicr {
                 messages::AnnounceCancel msg;
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, {}, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, {} };
                 auto th = TrackHash(tfn);
 
                 SPDLOG_LOGGER_INFO(
@@ -596,7 +596,7 @@ namespace quicr {
                 messages::TrackStatusRequest msg;
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, msg.track_name, std::nullopt };
+                auto tfn = FullTrackName{ msg.track_namespace, msg.track_name };
                 auto th = TrackHash(tfn);
 
                 SPDLOG_LOGGER_INFO(logger_,
@@ -681,7 +681,7 @@ namespace quicr {
                 switch (msg.fetch_type) {
                     case messages::FetchType::kStandalone: {
                         // Standalone fetch is self-containing.
-                        tfn = FullTrackName{ msg.group_0->track_namespace, msg.group_0->track_name, std::nullopt };
+                        tfn = FullTrackName{ msg.group_0->track_namespace, msg.group_0->track_name };
                         const auto largest_available = GetLargestAvailable(tfn);
                         if (!largest_available.has_value()) {
                             SendFetchError(conn_ctx,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -447,7 +447,7 @@ namespace quicr {
                 auto msg = messages::Announce{};
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, {}};
+                auto tfn = FullTrackName{ msg.track_namespace, {} };
 
                 AnnounceReceived(conn_ctx.connection_handle, tfn.name_space, { msg.request_id });
                 return true;
@@ -498,7 +498,7 @@ namespace quicr {
                 messages::Unannounce msg;
                 msg_bytes >> msg;
 
-                auto tfn = FullTrackName{ msg.track_namespace, {}};
+                auto tfn = FullTrackName{ msg.track_namespace, {} };
                 auto th = TrackHash(tfn);
 
                 SPDLOG_LOGGER_INFO(logger_, "Received unannounce for namespace_hash: {0}", th.track_namespace_hash);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -70,7 +70,6 @@ namespace quicr {
 
     void Server::SubscribeReceived(ConnectionHandle,
                                    uint64_t,
-                                   uint64_t,
                                    messages::FilterType,
                                    const FullTrackName&,
                                    const messages::SubscribeAttributes&)
@@ -91,6 +90,7 @@ namespace quicr {
 
     void Server::ResolveSubscribe(ConnectionHandle connection_handle,
                                   uint64_t request_id,
+                                  uint64_t track_alias,
                                   const SubscribeResponse& subscribe_response)
     {
         auto conn_it = connections_.find(connection_handle);
@@ -107,6 +107,7 @@ namespace quicr {
                 // Send the ok.
                 SendSubscribeOk(conn_it->second,
                                 request_id,
+                                track_alias,
                                 kSubscribeExpires,
                                 subscribe_response.largest_location.has_value(),
                                 subscribe_response.largest_location.has_value()
@@ -118,22 +119,18 @@ namespace quicr {
                 if (subscribe_response.track_alias.has_value()) {
                     SendSubscribeError(conn_it->second,
                                        request_id,
-                                       *subscribe_response.track_alias,
                                        messages::SubscribeErrorCode::kRetryTrackAlias,
                                        subscribe_response.error_reason.has_value() ? *subscribe_response.error_reason
                                                                                    : "internal error");
                 } else {
-                    SendSubscribeError(conn_it->second,
-                                       request_id,
-                                       {},
-                                       messages::SubscribeErrorCode::kInternalError,
-                                       "Missing track alias");
+                    SendSubscribeError(
+                      conn_it->second, request_id, messages::SubscribeErrorCode::kInternalError, "Missing track alias");
                 }
                 break;
             }
             default:
                 SendSubscribeError(
-                  conn_it->second, request_id, {}, messages::SubscribeErrorCode::kInternalError, "Internal error");
+                  conn_it->second, request_id, messages::SubscribeErrorCode::kInternalError, "Internal error");
                 break;
         }
     }
@@ -180,18 +177,7 @@ namespace quicr {
     {
         // Generate track alias
         const auto& tfn = track_handler->GetFullTrackName();
-
-        // Track hash is the track alias for now.
         auto th = TrackHash(tfn);
-
-        if (not track_handler->GetTrackAlias().has_value()) {
-            track_handler->SetTrackAlias(th.track_fullname_hash);
-        }
-
-        SPDLOG_LOGGER_INFO(logger_,
-                           "Bind subscribe track handler conn_id: {0} hash: {1}",
-                           conn_id,
-                           track_handler->GetTrackAlias().value());
 
         std::unique_lock<std::mutex> lock(state_mutex_);
         auto conn_it = connections_.find(conn_id);
@@ -402,7 +388,6 @@ namespace quicr {
                 // TODO(tievens): add filter type when caching supports it
                 SubscribeReceived(conn_ctx.connection_handle,
                                   msg.request_id,
-                                  msg.track_alias,
                                   msg.filter_type,
                                   tfn,
                                   { msg.subscriber_priority, static_cast<messages::GroupOrder>(msg.group_order) });
@@ -687,7 +672,9 @@ namespace quicr {
 
                 // Prepare for fetch lookups, which differ by type.
                 FullTrackName tfn;
-                messages::FetchAttributes attrs = { msg.subscriber_priority, msg.group_order, 0, 0, 0, std::nullopt };
+                messages::FetchAttributes attrs = {
+                    msg.subscriber_priority, msg.group_order, { 0, 0 }, 0, std::nullopt
+                };
                 bool end_of_track = false; // TODO: Need to query this as part of the GetLargestAvailable call.
                 messages::Location largest_location;
 
@@ -706,17 +693,17 @@ namespace quicr {
 
                         largest_location = largest_available.value();
 
-                        attrs.start_group = msg.group_0->start_group;
-                        attrs.start_object = msg.group_0->start_object;
-                        attrs.end_group = msg.group_0->end_group;
-                        attrs.end_object =
-                          msg.group_0->end_object > 0 ? std::optional(msg.group_0->end_object - 1) : std::nullopt;
+                        attrs.start_location = msg.group_0->start_location;
+                        attrs.end_group = msg.group_0->end_location.group;
+                        attrs.end_object = msg.group_0->end_location.object > 0
+                                             ? std::optional(msg.group_0->end_location.object - 1)
+                                             : std::nullopt;
                         break;
                     }
                     case messages::FetchType::kJoiningFetch: {
                         // Joining fetch needs to look up its joining subscribe.
                         // TODO: Need a new error code for subscribe doesn't exist.
-                        const auto subscribe_state = conn_ctx.recv_sub_id.find(msg.group_1->joining_subscribe_id);
+                        const auto subscribe_state = conn_ctx.recv_sub_id.find(msg.group_1->joining_request_id);
                         if (subscribe_state == conn_ctx.recv_sub_id.end()) {
                             SendFetchError(conn_ctx,
                                            msg.request_id,
@@ -738,10 +725,10 @@ namespace quicr {
                         largest_location = *opt_largest_location;
 
                         // TODO(RichLogan): Check this when FETCH v11 checked.
-                        attrs.start_group = msg.group_1->joining_start <= largest_location.group
-                                              ? largest_location.group - msg.group_1->joining_start
-                                              : largest_location.group;
-                        attrs.start_object = 0;
+                        const auto start_group = msg.group_1->joining_start <= largest_location.group
+                                                   ? largest_location.group - msg.group_1->joining_start
+                                                   : largest_location.group;
+                        attrs.start_location = messages::Location{ start_group, 0 };
                         attrs.end_group = largest_location.group;
                         attrs.end_object = largest_location.object;
                         break;
@@ -756,9 +743,9 @@ namespace quicr {
                 // TODO: This only covers it being below largest, not what's in cache.
                 // Availability check.
                 bool valid_range = true;
-                valid_range &= attrs.start_group <= largest_location.group;
-                if (largest_location.group == attrs.start_group) {
-                    valid_range &= attrs.start_object <= largest_location.object;
+                valid_range &= attrs.start_location.group <= largest_location.group;
+                if (largest_location.group == attrs.start_location.group) {
+                    valid_range &= attrs.start_location.object <= largest_location.object;
                 }
                 valid_range &= attrs.end_group <= largest_location.group;
                 if (largest_location.group == attrs.end_group && attrs.end_object.has_value()) {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -223,7 +223,7 @@ namespace quicr {
         Bytes buffer;
         buffer << announce;
 
-        auto th = TrackHash({ track_namespace, {}, std::nullopt });
+        auto th = TrackHash({ track_namespace, {} });
         SPDLOG_LOGGER_DEBUG(logger_,
                             "Sending ANNOUNCE to conn_id: {} request_id: {} namespace_hash: {}",
                             conn_ctx.connection_handle,
@@ -387,7 +387,7 @@ namespace quicr {
         Bytes buffer;
         buffer << msg;
 
-        auto th = TrackHash({ prefix_namespace, {}, std::nullopt });
+        auto th = TrackHash({ prefix_namespace, {} });
 
         SPDLOG_LOGGER_DEBUG(logger_,
                             "Sending Subscribe announces to conn_id: {} request_id: {} prefix_hash: {}",
@@ -455,7 +455,7 @@ namespace quicr {
         Bytes buffer;
         buffer << msg;
 
-        auto th = TrackHash({ prefix_namespace, {}, std::nullopt });
+        auto th = TrackHash({ prefix_namespace, {} });
 
         SPDLOG_LOGGER_DEBUG(logger_,
                             "Sending Unsubscribe announces to conn_id: {} prefix_hash: {}",

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -11,14 +11,15 @@ TestServer::TestServer(const ServerConfig& config)
 void
 TestServer::SubscribeReceived(ConnectionHandle connection_handle,
                               uint64_t request_id,
-                              uint64_t proposed_track_alias,
                               messages::FilterType filter_type,
                               const FullTrackName& track_full_name,
                               const messages::SubscribeAttributes& subscribe_attributes)
 {
     if (subscribe_promise_.has_value()) {
         subscribe_promise_->set_value(
-          { connection_handle, request_id, proposed_track_alias, filter_type, track_full_name, subscribe_attributes });
+          { connection_handle, request_id, filter_type, track_full_name, subscribe_attributes });
     }
-    ResolveSubscribe(connection_handle, request_id, { .reason_code = SubscribeResponse::ReasonCode::kOk });
+    const auto th = TrackHash(track_full_name);
+    ResolveSubscribe(
+      connection_handle, request_id, th.track_fullname_hash, { .reason_code = SubscribeResponse::ReasonCode::kOk });
 }

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -13,7 +13,6 @@ namespace quicr_test {
         {
             quicr::ConnectionHandle connection_handle;
             uint64_t request_id;
-            uint64_t proposed_track_alias;
             quicr::messages::FilterType filter_type;
             quicr::FullTrackName track_full_name;
             quicr::messages::SubscribeAttributes subscribe_attributes;
@@ -44,7 +43,6 @@ namespace quicr_test {
 
         void SubscribeReceived(quicr::ConnectionHandle connection_handle,
                                uint64_t request_id,
-                               uint64_t proposed_track_alias,
                                quicr::messages::FilterType filter_type,
                                const quicr::FullTrackName& track_full_name,
                                const quicr::messages::SubscribeAttributes& subscribe_attributes) override;

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -150,7 +150,6 @@ TEST_CASE("Subscribe (kLatestObject) Message encode/decode")
 {
     Bytes buffer;
     auto subscribe = quicr::messages::Subscribe(0x1,
-                                                uint64_t(kTrackAliasAliceVideo),
                                                 kTrackNamespaceConf,
                                                 kTrackNameAliceVideo,
                                                 0x10,
@@ -180,7 +179,6 @@ TEST_CASE("Subscribe (kLatestObject) Message encode/decode")
     CHECK_EQ(kTrackNamespaceConf, subscribe_out.track_namespace);
     CHECK_EQ(kTrackNameAliceVideo, subscribe_out.track_name);
     CHECK_EQ(subscribe.request_id, subscribe_out.request_id);
-    CHECK_EQ(subscribe.track_alias, subscribe_out.track_alias);
     CHECK_EQ(subscribe.subscriber_priority, subscribe_out.subscriber_priority);
     CHECK_EQ(subscribe.group_order, subscribe_out.group_order);
     CHECK_EQ(subscribe.filter_type, subscribe_out.filter_type);
@@ -190,7 +188,6 @@ TEST_CASE("Subscribe (kLatestGroup) Message encode/decode")
 {
     Bytes buffer;
     auto subscribe = quicr::messages::Subscribe(0x1,
-                                                uint64_t(kTrackAliasAliceVideo),
                                                 kTrackNamespaceConf,
                                                 kTrackNameAliceVideo,
                                                 0x10,
@@ -221,7 +218,6 @@ TEST_CASE("Subscribe (kLatestGroup) Message encode/decode")
     CHECK_EQ(kTrackNamespaceConf, subscribe_out.track_namespace);
     CHECK_EQ(kTrackNameAliceVideo, subscribe_out.track_name);
     CHECK_EQ(subscribe.request_id, subscribe_out.request_id);
-    CHECK_EQ(subscribe.track_alias, subscribe_out.track_alias);
     CHECK_EQ(subscribe.filter_type, subscribe_out.filter_type);
 }
 
@@ -233,7 +229,6 @@ TEST_CASE("Subscribe (kAbsoluteStart) Message encode/decode")
     group_0->start_location = { 0x1000, 0xFF };
 
     auto subscribe = quicr::messages::Subscribe(0x1,
-                                                uint64_t(kTrackAliasAliceVideo),
                                                 kTrackNamespaceConf,
                                                 kTrackNameAliceVideo,
                                                 0x10,
@@ -265,7 +260,6 @@ TEST_CASE("Subscribe (kAbsoluteStart) Message encode/decode")
     CHECK_EQ(kTrackNamespaceConf, subscribe_out.track_namespace);
     CHECK_EQ(kTrackNameAliceVideo, subscribe_out.track_name);
     CHECK_EQ(subscribe.request_id, subscribe_out.request_id);
-    CHECK_EQ(subscribe.track_alias, subscribe_out.track_alias);
     CHECK_EQ(subscribe.filter_type, subscribe_out.filter_type);
     CHECK_EQ(subscribe.group_0->start_location.group, subscribe_out.group_0->start_location.group);
     CHECK_EQ(subscribe.group_0->start_location.object, subscribe_out.group_0->start_location.object);
@@ -285,7 +279,6 @@ TEST_CASE("Subscribe (kAbsoluteRange) Message encode/decode")
     }
 
     auto subscribe = quicr::messages::Subscribe(0x1,
-                                                uint64_t(kTrackAliasAliceVideo),
                                                 kTrackNamespaceConf,
                                                 kTrackNameAliceVideo,
                                                 0x10,
@@ -317,7 +310,6 @@ TEST_CASE("Subscribe (kAbsoluteRange) Message encode/decode")
     CHECK_EQ(kTrackNamespaceConf, subscribe_out.track_namespace);
     CHECK_EQ(kTrackNameAliceVideo, subscribe_out.track_name);
     CHECK_EQ(subscribe.request_id, subscribe_out.request_id);
-    CHECK_EQ(subscribe.track_alias, subscribe_out.track_alias);
     CHECK_EQ(subscribe.filter_type, subscribe_out.filter_type);
     CHECK_EQ(subscribe.group_0->start_location.group, subscribe_out.group_0->start_location.group);
     CHECK_EQ(subscribe.group_0->start_location.object, subscribe_out.group_0->start_location.object);
@@ -333,7 +325,6 @@ TEST_CASE("Subscribe (Params) Message encode/decode")
     SubscribeParameters params = { param };
 
     auto subscribe = quicr::messages::Subscribe(0x1,
-                                                uint64_t(kTrackAliasAliceVideo),
                                                 kTrackNamespaceConf,
                                                 kTrackNameAliceVideo,
                                                 0x10,
@@ -367,7 +358,6 @@ TEST_CASE("Subscribe (Params) Message encode/decode")
     CHECK_EQ(kTrackNamespaceConf, subscribe_out.track_namespace);
     CHECK_EQ(kTrackNameAliceVideo, subscribe_out.track_name);
     CHECK_EQ(subscribe.request_id, subscribe_out.request_id);
-    CHECK_EQ(subscribe.track_alias, subscribe_out.track_alias);
     CHECK_EQ(subscribe.filter_type, subscribe_out.filter_type);
     CHECK_EQ(subscribe.subscribe_parameters.size(), subscribe_out.subscribe_parameters.size());
     CHECK_EQ(subscribe.subscribe_parameters[0].type, subscribe_out.subscribe_parameters[0].type);
@@ -388,7 +378,6 @@ TEST_CASE("Subscribe (Params - 2) Message encode/decode")
     SubscribeParameters params = { param1, param2 };
 
     auto subscribe = quicr::messages::Subscribe(0x1,
-                                                uint64_t(kTrackAliasAliceVideo),
                                                 kTrackNamespaceConf,
                                                 kTrackNameAliceVideo,
                                                 0x10,
@@ -422,7 +411,6 @@ TEST_CASE("Subscribe (Params - 2) Message encode/decode")
     CHECK_EQ(kTrackNamespaceConf, subscribe_out.track_namespace);
     CHECK_EQ(kTrackNameAliceVideo, subscribe_out.track_name);
     CHECK_EQ(subscribe.request_id, subscribe_out.request_id);
-    CHECK_EQ(subscribe.track_alias, subscribe_out.track_alias);
     CHECK_EQ(subscribe.filter_type, subscribe_out.filter_type);
     CHECK_EQ(subscribe.subscribe_parameters.size(), subscribe_out.subscribe_parameters.size());
     CHECK_EQ(subscribe.subscribe_parameters[0].type, subscribe_out.subscribe_parameters[0].type);
@@ -447,7 +435,6 @@ GenerateSubscribe(FilterType filter, size_t num_params = 0, uint64_t sg = 0, uin
           }
       });
     out.request_id = 0xABCD;
-    out.track_alias = uint64_t(kTrackAliasAliceVideo);
     out.track_namespace = kTrackNamespaceConf;
     out.track_name = kTrackNameAliceVideo;
     out.filter_type = filter;
@@ -513,7 +500,6 @@ TEST_CASE("Subscribe (Combo) Message encode/decode")
         CHECK_EQ(kTrackNamespaceConf, subscribe_out.track_namespace);
         CHECK_EQ(kTrackNameAliceVideo, subscribe_out.track_name);
         CHECK_EQ(subscribes[i].request_id, subscribe_out.request_id);
-        CHECK_EQ(subscribes[i].track_alias, subscribe_out.track_alias);
         CHECK_EQ(subscribes[i].filter_type, subscribe_out.filter_type);
         CHECK_EQ(subscribes[i].subscribe_parameters.size(), subscribe_out.subscribe_parameters.size());
         for (size_t j = 0; j < subscribes[i].subscribe_parameters.size(); j++) {
@@ -547,7 +533,8 @@ TEST_CASE("SubscribeUpdate Message encode/decode")
 TEST_CASE("SubscribeOk Message encode/decode")
 {
     Bytes buffer;
-    auto subscribe_ok = SubscribeOk(0x1, 0x100, GroupOrder::kAscending, false, nullptr, std::nullopt, {});
+    const auto track_alias = uint64_t(kTrackAliasAliceVideo);
+    auto subscribe_ok = SubscribeOk(0x1, track_alias, 0, GroupOrder::kAscending, false, nullptr, std::nullopt, {});
 
     buffer << subscribe_ok;
 
@@ -559,6 +546,7 @@ TEST_CASE("SubscribeOk Message encode/decode")
 
     CHECK(VerifyCtrl(buffer, static_cast<uint64_t>(ControlMessageType::kSubscribeOk), subscribe_ok_out));
     CHECK_EQ(subscribe_ok.request_id, subscribe_ok_out.request_id);
+    CHECK_EQ(subscribe_ok.track_alias, subscribe_ok_out.track_alias);
     CHECK_EQ(subscribe_ok.expires, subscribe_ok_out.expires);
     CHECK_EQ(subscribe_ok.group_order, subscribe_ok_out.group_order);
     CHECK_EQ(subscribe_ok.content_exists, subscribe_ok_out.content_exists);
@@ -571,7 +559,7 @@ TEST_CASE("SubscribeOk (content-exists) Message encode/decode")
     auto group_0 = std::make_optional<SubscribeOk::Group_0>();
     group_0->largest_location = { 100, 200 };
 
-    auto subscribe_ok = SubscribeOk(0x01, 0x100, GroupOrder::kAscending, 0x01, nullptr, group_0, {});
+    auto subscribe_ok = SubscribeOk(0x01, 0x1000, 0, GroupOrder::kAscending, 1, nullptr, group_0, {});
 
     buffer << subscribe_ok;
 
@@ -598,7 +586,6 @@ TEST_CASE("Error  Message encode/decode")
     subscribe_err.request_id = 0x1;
     subscribe_err.error_code = quicr::messages::SubscribeErrorCode::kTrackDoesNotExist;
     subscribe_err.error_reason = Bytes{ 0x0, 0x1 };
-    subscribe_err.track_alias = uint64_t(kTrackAliasAliceVideo);
     buffer << subscribe_err;
 
     SubscribeError subscribe_err_out;
@@ -606,7 +593,6 @@ TEST_CASE("Error  Message encode/decode")
     CHECK_EQ(subscribe_err.request_id, subscribe_err_out.request_id);
     CHECK_EQ(subscribe_err.error_code, subscribe_err_out.error_code);
     CHECK_EQ(subscribe_err.error_reason, subscribe_err_out.error_reason);
-    CHECK_EQ(subscribe_err.track_alias, subscribe_err_out.track_alias);
 }
 
 TEST_CASE("Unsubscribe  Message encode/decode")
@@ -717,10 +703,10 @@ TEST_CASE("Fetch Message encode/decode")
     if (group_0.has_value()) {
         group_0->track_namespace = kTrackNamespaceConf;
         group_0->track_name = kTrackNameAliceVideo;
-        group_0->start_group = 0x1000;
-        group_0->start_object = 0x0;
-        group_0->end_group = 0x2000;
-        group_0->end_object = 0x100;
+        group_0->start_location.group = 0x1000;
+        group_0->start_location.object = 0x0;
+        group_0->end_location.group = 0x2000;
+        group_0->end_location.object = 0x100;
     }
     auto fetch =
       Fetch(0x10, 1, GroupOrder::kAscending, FetchType::kStandalone, nullptr, group_0, nullptr, std::nullopt, {});
@@ -745,17 +731,15 @@ TEST_CASE("Fetch Message encode/decode")
 
         CHECK_EQ(fetch.group_0->track_namespace, fetch_out.group_0->track_namespace);
         CHECK_EQ(fetch.group_0->track_name, fetch_out.group_0->track_name);
-        CHECK_EQ(fetch.group_0->start_group, fetch_out.group_0->start_group);
-        CHECK_EQ(fetch.group_0->start_object, fetch_out.group_0->start_object);
-        CHECK_EQ(fetch.group_0->end_group, fetch_out.group_0->end_group);
-        CHECK_EQ(fetch.group_0->end_object, fetch_out.group_0->end_object);
+        CHECK_EQ(fetch.group_0->start_location, fetch_out.group_0->start_location);
+        CHECK_EQ(fetch.group_0->end_location, fetch_out.group_0->end_location);
     }
 
     buffer.clear();
 
     auto group_1 = std::make_optional<Fetch::Group_1>();
     if (group_1.has_value()) {
-        group_1->joining_subscribe_id = 0x0;
+        group_1->joining_request_id = 0x0;
         group_1->joining_start = 0x0;
     }
 
@@ -775,7 +759,7 @@ TEST_CASE("Fetch Message encode/decode")
           nullptr);
 
         CHECK(VerifyCtrl(buffer, static_cast<uint64_t>(ControlMessageType::kFetch), fetch_out));
-        CHECK_EQ(fetch.group_1->joining_subscribe_id, fetch_out.group_1->joining_subscribe_id);
+        CHECK_EQ(fetch.group_1->joining_request_id, fetch_out.group_1->joining_request_id);
         CHECK_EQ(fetch.group_1->joining_start, fetch_out.group_1->joining_start);
     }
 }
@@ -998,4 +982,66 @@ TEST_CASE("ControlMessage encode/decode")
     buffer >> out;
     CHECK_EQ(out.type, msg.type);
     CHECK_EQ(out.payload, msg.payload);
+}
+
+TEST_CASE("Location Equality / Comparison")
+{
+    // Test equality
+    Location loc1{ 1, 2 };
+    Location loc2{ 1, 2 };
+    Location loc3{ 1, 3 };
+    Location loc4{ 2, 1 };
+
+    // Test equality operator
+    CHECK(loc1 == loc2);
+    CHECK_FALSE(loc1 == loc3);
+    CHECK_FALSE(loc1 == loc4);
+
+    // Test inequality operator
+    CHECK_FALSE(loc1 != loc2);
+    CHECK(loc1 != loc3);
+    CHECK(loc1 != loc4);
+
+    // Test less than operator
+    // Same group, different objects
+    CHECK(loc1 < loc3);       // {1,2} < {1,3}
+    CHECK_FALSE(loc3 < loc1); // {1,3} not < {1,2}
+
+    // Different groups
+    CHECK(loc1 < loc4);       // {1,2} < {2,1}
+    CHECK_FALSE(loc4 < loc1); // {2,1} not < {1,2}
+
+    // Test greater than operator
+    CHECK(loc3 > loc1);       // {1,3} > {1,2}
+    CHECK_FALSE(loc1 > loc3); // {1,2} not > {1,3}
+
+    CHECK(loc4 > loc1);       // {2,1} > {1,2}
+    CHECK_FALSE(loc1 > loc4); // {1,2} not > {2,1}
+
+    // Test less than or equal
+    CHECK(loc1 <= loc2);       // Equal case
+    CHECK(loc1 <= loc3);       // Less than case
+    CHECK_FALSE(loc3 <= loc1); // Greater than case
+
+    // Test greater than or equal
+    CHECK(loc1 >= loc2);       // Equal case
+    CHECK(loc3 >= loc1);       // Greater than case
+    CHECK_FALSE(loc1 >= loc3); // Less than case
+
+    // Test edge cases with zero values
+    Location loc_zero{ 0, 0 };
+    Location loc_group_zero{ 0, 1 };
+    Location loc_object_zero{ 1, 0 };
+
+    CHECK(loc_zero < loc_group_zero);        // {0,0} < {0,1}
+    CHECK(loc_zero < loc_object_zero);       // {0,0} < {1,0}
+    CHECK(loc_group_zero < loc_object_zero); // {0,1} < {1,0}
+
+    // Test comparison with large values
+    Location loc_large1{ UINT64_MAX, UINT64_MAX };
+    Location loc_large2{ UINT64_MAX, UINT64_MAX - 1 };
+
+    CHECK(loc_large2 < loc_large1);
+    CHECK(loc_large1 > loc_large2);
+    CHECK_FALSE(loc_large1 == loc_large2);
 }

--- a/test/track_handlers.cpp
+++ b/test/track_handlers.cpp
@@ -12,7 +12,7 @@
 class TestPublishTrackHandler : public quicr::PublishTrackHandler
 {
     TestPublishTrackHandler()
-      : PublishTrackHandler({ {}, {}, 1 }, quicr::TrackMode::kDatagram, 0, 0)
+      : PublishTrackHandler({ {}, {} }, quicr::TrackMode::kDatagram, 0, 0)
     {
     }
 
@@ -25,11 +25,6 @@ class TestPublishTrackHandler : public quicr::PublishTrackHandler
 
 TEST_CASE("Create Track Handler")
 {
-    CHECK_NOTHROW(quicr::PublishTrackHandler::Create({ {}, {}, 1 }, quicr::TrackMode::kDatagram, 0, 0));
+    CHECK_NOTHROW(quicr::PublishTrackHandler::Create({ {}, {} }, quicr::TrackMode::kDatagram, 0, 0));
     CHECK_NOTHROW(TestPublishTrackHandler::Create());
-}
-
-TEST_CASE("Create Track Handler - Missing Alias")
-{
-    CHECK_THROWS(quicr::PublishTrackHandler::Create({ {}, {}, std::nullopt }, quicr::TrackMode::kDatagram, 0, 0));
 }

--- a/test/track_handlers.cpp
+++ b/test/track_handlers.cpp
@@ -12,7 +12,7 @@
 class TestPublishTrackHandler : public quicr::PublishTrackHandler
 {
     TestPublishTrackHandler()
-      : PublishTrackHandler({ {}, {}, std::nullopt }, quicr::TrackMode::kDatagram, 0, 0)
+      : PublishTrackHandler({ {}, {}, 1 }, quicr::TrackMode::kDatagram, 0, 0)
     {
     }
 
@@ -25,6 +25,11 @@ class TestPublishTrackHandler : public quicr::PublishTrackHandler
 
 TEST_CASE("Create Track Handler")
 {
-    CHECK_NOTHROW(quicr::PublishTrackHandler::Create({ {}, {}, std::nullopt }, quicr::TrackMode::kDatagram, 0, 0));
+    CHECK_NOTHROW(quicr::PublishTrackHandler::Create({ {}, {}, 1 }, quicr::TrackMode::kDatagram, 0, 0));
     CHECK_NOTHROW(TestPublishTrackHandler::Create());
+}
+
+TEST_CASE("Create Track Handler - Missing Alias")
+{
+    CHECK_THROWS(quicr::PublishTrackHandler::Create({ {}, {}, std::nullopt }, quicr::TrackMode::kDatagram, 0, 0));
 }

--- a/test/track_namespace.cpp
+++ b/test/track_namespace.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Hash namespace")
     auto h = hash({ ns.begin(), ns.end() });
     CHECK_EQ(15211761882639286592ull, h);
 
-    TrackHash th({ ns, {}, std::nullopt });
+    TrackHash th({ ns, {} });
     CHECK_EQ(h, th.track_namespace_hash);
 
     auto ns_hash = std::hash<TrackNamespace>{}(ns);


### PR DESCRIPTION
I've altered track alias quite a bit here. I've removed the optional from the FTN structure, in lots of places it doesn't apply and gets set to null anyway, which I think is just cause for confusion. Instead, the alias is queried from the publish track handler with the request ID of the subscribe, and cannot be optional. The default implementation uses the full track hash regardless of request ID, keeping our existing behaviour. 