### PR TITLE
Upgrade switch warning to error

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ set_property(GLOBAL PROPERTY RULE_MESSAGES OFF)
 
 target_compile_options(quicr
     PRIVATE
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Wall>
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Wall -Werror=switch>
         $<$<CXX_COMPILER_ID:MSVC>: >)
 set_target_properties(quicr
     PROPERTIES


### PR DESCRIPTION
Compile time enforce switch case handling. All existing libquicr code is already compliant. I don't see why we wouldn't want this turned on anyway - but the primary driver is that #590 makes more sense with this turned on. 