### PR TITLE
Support KVP + length based extensions

### DIFF
--- a/include/quicr/detail/messages.h
+++ b/include/quicr/detail/messages.h
@@ -18,6 +18,9 @@ namespace quicr::messages {
     using ObjectPriority = uint8_t;
     using Extensions = std::map<uint64_t, Bytes>;
 
+    Bytes& operator<<(Bytes& buffer, const std::optional<Extensions>& extensions);
+    Bytes& operator<<(Bytes& buffer, const Extensions& extensions);
+
     /**
      * Possible datagram object header types.
      */
@@ -486,7 +489,8 @@ namespace quicr::messages {
         friend bool operator>>(StreamBufferType& buffer, FetchObject& msg);
 
       private:
-        uint64_t num_extensions{ 0 };
+        std::optional<std::size_t> extension_headers_length;
+        std::size_t extension_bytes_remaining{ 0 };
         std::optional<uint64_t> current_tag{};
         uint64_t current_pos{ 0 };
         bool parse_completed{ false };
@@ -525,7 +529,8 @@ namespace quicr::messages {
 
       private:
         std::optional<DatagramHeaderType> type;
-        uint64_t num_extensions{ 0 };
+        std::optional<std::size_t> extension_headers_length;
+        std::size_t extension_bytes_left{ 0 };
         std::optional<uint64_t> current_tag{};
         uint64_t current_pos{ 0 };
         bool parse_completed{ false };
@@ -553,7 +558,8 @@ namespace quicr::messages {
 
       private:
         std::optional<DatagramStatusType> type;
-        uint64_t num_extensions{ 0 };
+        std::optional<std::size_t> extension_headers_length;
+        std::size_t extension_bytes_left{ 0 };
         std::optional<uint64_t> current_tag{};
         uint64_t current_pos{ 0 };
         bool parse_completed{ false };
@@ -592,7 +598,8 @@ namespace quicr::messages {
         friend bool operator>>(StreamBufferType& buffer, StreamSubGroupObject& msg);
 
       private:
-        uint64_t num_extensions{ 0 };
+        std::optional<std::size_t> extension_headers_length;
+        std::size_t extension_bytes_left{ 0 };
         std::optional<uint64_t> current_tag{};
         uint64_t current_pos{ 0 };
         bool parse_completed{ false };


### PR DESCRIPTION
Extensions are now a series of MoQ key-value-pairs, with the series prefixed with the byte count of the whole extensions block, rather than the count of extensions serialised. 