### PR TITLE
`std::format` fix

### DIFF
--- a/include/quicr/detail/messages.h
+++ b/include/quicr/detail/messages.h
@@ -10,6 +10,7 @@
 #include "stream_buffer.h"
 
 #include <map>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -23,10 +24,18 @@ namespace quicr::messages {
         const std::string reason;
         ProtocolViolationException(const std::string& reason,
                                    const std::source_location location = std::source_location::current())
-          : std::runtime_error(
-              std::format("Protocol violation: {} (line {}, file {})", reason, location.line(), location.file_name()))
+          : std::runtime_error(to_string(reason, location))
           , reason(reason)
         {
+        }
+
+      private:
+        static std::string to_string(const std::string& reason, const std::source_location& location)
+        {
+            std::stringstream ss;
+            ss << "Protocol violation: " << reason << " (line " << location.line() << ", file " << location.file_name()
+               << ")";
+            return ss.str();
         }
     };
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -4,18 +4,24 @@
 #include "quicr/detail/transport.h"
 #include "quicr/detail/messages.h"
 
-#include <format>
 #include <quicr/detail/joining_fetch_handler.h>
 #include <sstream>
 
 namespace quicr {
     using namespace quicr::messages;
 
+    namespace {
+        std::string to_string(TransportError error, const std::source_location& location)
+        {
+            std::stringstream ss;
+            ss << "Error in transport (error=" << static_cast<int>(error) << ", line=" << location.line()
+               << ", file=" << location.file_name() << ")";
+            return ss.str();
+        }
+    } // namespace
+
     TransportException::TransportException(TransportError error, std::source_location location)
-      : std::runtime_error(std::format("Error in transport (error={}, line={}, file={})",
-                                       static_cast<int>(error),
-                                       location.line(),
-                                       location.file_name()))
+      : std::runtime_error(to_string(error, location))
       , Error(error)
     {
     }


### PR DESCRIPTION
Something is up with this use of std::format somehow involving the `double` template specialisation - which is not available in the Xcode toolchain. I can't figure out why though - even the string format specifiers don't help. This is workaround to just use a string stream instead. /shrug. 