### PR TITLE
Catch exception on internal unsubscribe

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -900,7 +900,6 @@ namespace quicr {
         handler.SetRequestId(std::nullopt);
 
         if (request_id.has_value()) {
-            // TODO: In the connection close case, we should not even try?
             try {
                 SendUnsubscribe(conn_ctx, *request_id);
             } catch (const std::exception& e) {


### PR DESCRIPTION
~~In at least one case, I think this will be called in response to a connection close. In that case, we should not even attempt to send an Unsubscribe because it can't succeed?~~