### PR TITLE
Fix subscribe ok

### DIFF
--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -384,8 +384,7 @@ namespace quicr {
                              messages::RequestID request_id,
                              uint64_t track_alias,
                              uint64_t expires,
-                             bool content_exists,
-                             messages::Location largest_location);
+                             const std::optional<messages::Location>& largest_location);
         void SendUnsubscribe(ConnectionContext& conn_ctx, messages::RequestID request_id);
         void SendSubscribeDone(ConnectionContext& conn_ctx, messages::RequestID request_id, const std::string& reason);
         void SendSubscribeError(ConnectionContext& conn_ctx,

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -46,14 +46,8 @@ namespace quicr {
 
         switch (subscribe_response.reason_code) {
             case SubscribeResponse::ReasonCode::kOk: {
-                SendSubscribeOk(conn_it->second,
-                                request_id,
-                                track_alias,
-                                kSubscribeExpires,
-                                subscribe_response.largest_location.has_value(),
-                                subscribe_response.largest_location.has_value()
-                                  ? subscribe_response.largest_location.value()
-                                  : messages::Location());
+                SendSubscribeOk(
+                  conn_it->second, request_id, track_alias, kSubscribeExpires, subscribe_response.largest_location);
                 break;
             }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -110,14 +110,8 @@ namespace quicr {
                 conn_it->second.recv_req_id[request_id].largest_location = subscribe_response.largest_location;
 
                 // Send the ok.
-                SendSubscribeOk(conn_it->second,
-                                request_id,
-                                track_alias,
-                                kSubscribeExpires,
-                                subscribe_response.largest_location.has_value(),
-                                subscribe_response.largest_location.has_value()
-                                  ? subscribe_response.largest_location.value()
-                                  : messages::Location());
+                SendSubscribeOk(
+                  conn_it->second, request_id, track_alias, kSubscribeExpires, subscribe_response.largest_location);
                 break;
             }
             default:

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -447,15 +447,15 @@ namespace quicr {
                                     uint64_t expires,
                                     const std::optional<Location>& largest_location)
     try {
-        const auto subscribe_ok =
-          SubscribeOk(request_id,
-                      track_alias,
-                      expires,
-                      GroupOrder::kAscending,
-                      largest_location.has_value(),
-                      nullptr,
-                      largest_location.has_value() ? SubscribeOk::Group_0(*largest_location) : std::nullopt,
-                      {});
+        const auto subscribe_ok = SubscribeOk(
+          request_id,
+          track_alias,
+          expires,
+          GroupOrder::kAscending,
+          largest_location.has_value(),
+          nullptr,
+          largest_location.has_value() ? std::make_optional<SubscribeOk::Group_0>(*largest_location) : std::nullopt,
+          {});
 
         Bytes buffer;
         buffer << subscribe_ok;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -454,7 +454,7 @@ namespace quicr {
           GroupOrder::kAscending,
           largest_location.has_value(),
           nullptr,
-          largest_location.has_value() ? std::make_optional<SubscribeOk::Group_0>(*largest_location) : std::nullopt,
+          largest_location.has_value() ? std::make_optional(SubscribeOk::Group_0{ *largest_location }) : std::nullopt,
           {});
 
         Bytes buffer;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "quicr/detail/transport.h"
+
+#include "quicr/detail/ctrl_messages.h"
 #include "quicr/detail/messages.h"
 
 #include <format>
@@ -443,12 +445,17 @@ namespace quicr {
                                     uint64_t request_id,
                                     uint64_t track_alias,
                                     uint64_t expires,
-                                    bool content_exists,
-                                    Location largest_location)
+                                    const std::optional<Location>& largest_location)
     try {
-        const auto group_0 = std::make_optional<SubscribeOk::Group_0>() = { largest_location };
         const auto subscribe_ok =
-          SubscribeOk(request_id, track_alias, expires, GroupOrder::kAscending, content_exists, nullptr, group_0, {});
+          SubscribeOk(request_id,
+                      track_alias,
+                      expires,
+                      GroupOrder::kAscending,
+                      largest_location.has_value(),
+                      nullptr,
+                      largest_location.has_value() ? SubscribeOk::Group_0(*largest_location) : std::nullopt,
+                      {});
 
         Bytes buffer;
         buffer << subscribe_ok;


### PR DESCRIPTION
Fix bug in `SUBSCRIBE_OK` message construction, where content exists having a value of `0` would result in a location of `{0, 0}` being encoded, rather than no location at all. I have changed the API so that the type system stops a bad combo of arguments. 

However, I think this is a good example of how something like #607 would allow us to encode these rules that aren't otherwise parsed from the spec and catch them as early as possible in deserialize, and also as a last chance check on serialize. 

Some known message vectors would also be great test suite addition - and probably a good addition as a draft appendix?