### PR TITLE
Correct FilterType naming / values

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -900,11 +900,11 @@ main(int argc, char* argv[])
             pub_thread = std::thread(DoPublisher, pub_track_name, client, use_announce, std::ref(stop_threads));
         }
         if (enable_sub) {
-            auto filter_type = quicr::messages::FilterType::kLatestObject;
+            auto filter_type = quicr::messages::FilterType::kLargestObject;
             if (result.count("start_point")) {
                 if (result["start_point"].as<uint64_t>() == 0) {
-                    filter_type = quicr::messages::FilterType::kLatestGroup;
-                    SPDLOG_INFO("Setting subscription filter to Latest Group");
+                    filter_type = quicr::messages::FilterType::kNextGroupStart;
+                    SPDLOG_INFO("Setting subscription filter to Next Group Start");
                 }
             }
             bool joining_fetch = result.count("joining_fetch") && result["joining_fetch"].as<bool>();

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -145,7 +145,7 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
       : SubscribeTrackHandler(full_track_name,
                               3,
                               quicr::messages::GroupOrder::kAscending,
-                              quicr::messages::FilterType::kLatestObject,
+                              quicr::messages::FilterType::kLargestObject,
                               std::nullopt,
                               is_publisher_initiated)
     {

--- a/cmd/qperf/qperf.cpp
+++ b/cmd/qperf/qperf.cpp
@@ -120,7 +120,7 @@ namespace {
           : SubscribeTrackHandler(full_track_name,
                                   3,
                                   quicr::messages::GroupOrder::kAscending,
-                                  quicr::messages::FilterType::kLatestObject)
+                                  quicr::messages::FilterType::kLargestObject)
         {
         }
 

--- a/cmd/qperf2/qperf_sub.cc
+++ b/cmd/qperf2/qperf_sub.cc
@@ -31,7 +31,7 @@ namespace qperf {
       : SubscribeTrackHandler(perf_config.full_track_name,
                               perf_config.priority,
                               quicr::messages::GroupOrder::kOriginalPublisherOrder,
-                              quicr::messages::FilterType::kLatestObject)
+                              quicr::messages::FilterType::kLargestObject)
       , terminate_(false)
       , perf_config_(perf_config)
       , first_pass_(true)

--- a/include/quicr/detail/ctrl_message_types.h
+++ b/include/quicr/detail/ctrl_message_types.h
@@ -212,8 +212,8 @@ namespace quicr::messages {
 
     enum struct FilterType : uint64_t
     {
-        kNextGroupStart = 0x2,
-        kLargestObject = 0x1,
+        kLargestObject = 0x2,
+        kNextGroupStart = 0x1,
         kAbsoluteStart = 0x3,
         kAbsoluteRange = 0x4
     };

--- a/include/quicr/detail/ctrl_message_types.h
+++ b/include/quicr/detail/ctrl_message_types.h
@@ -212,11 +212,10 @@ namespace quicr::messages {
 
     enum struct FilterType : uint64_t
     {
-        kNone = 0x0,
-        kLatestGroup,
-        kLatestObject,
-        kAbsoluteStart,
-        kAbsoluteRange
+        kNextGroupStart = 0x2,
+        kLargestObject = 0x1,
+        kAbsoluteStart = 0x3,
+        kAbsoluteRange = 0x4
     };
 
     enum class TrackStatusCode : uint64_t

--- a/include/quicr/fetch_track_handler.h
+++ b/include/quicr/fetch_track_handler.h
@@ -29,7 +29,7 @@ namespace quicr {
                           messages::GroupId end_group,
                           messages::GroupId start_object,
                           messages::GroupId end_object)
-          : SubscribeTrackHandler(full_track_name, priority, group_order, messages::FilterType::kLatestGroup)
+          : SubscribeTrackHandler(full_track_name, priority, group_order, messages::FilterType::kNextGroupStart)
           , start_group_(start_group)
           , start_object_(start_object)
           , end_group_(end_group)

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -94,7 +94,7 @@ namespace quicr {
           const FullTrackName& full_track_name,
           messages::SubscriberPriority priority,
           messages::GroupOrder group_order = messages::GroupOrder::kAscending,
-          messages::FilterType filter_type = messages::FilterType::kLatestObject)
+          messages::FilterType filter_type = messages::FilterType::kLargestObject)
         {
             return std::shared_ptr<SubscribeTrackHandler>(
               new SubscribeTrackHandler(full_track_name, priority, group_order, filter_type));

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -144,7 +144,7 @@ namespace quicr {
 
                 // Send the ok.
                 SendPublishOk(
-                  conn_it->second, request_id, forward, priority, group_order, messages::FilterType::kLatestObject);
+                  conn_it->second, request_id, forward, priority, group_order, messages::FilterType::kLargestObject);
                 break;
             }
             default:

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Integration - Subscribe")
     FullTrackName ftn;
     ftn.name_space = TrackNamespace({ "namespace" });
     ftn.name = { 1, 2, 3 };
-    constexpr auto filter_type = messages::FilterType::kLatestObject;
+    constexpr auto filter_type = messages::FilterType::kLargestObject;
     const auto handler =
       SubscribeTrackHandler::Create(ftn, 0, messages::GroupOrder::kOriginalPublisherOrder, filter_type);
 

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -170,7 +170,7 @@ TEST_CASE("Subscribe (kLatestObject) Message encode/decode")
                                                 0x10,
                                                 GroupOrder::kAscending,
                                                 1,
-                                                FilterType::kLatestObject,
+                                                FilterType::kLargestObject,
                                                 nullptr,
                                                 std::nullopt,
                                                 nullptr,
@@ -181,12 +181,12 @@ TEST_CASE("Subscribe (kLatestObject) Message encode/decode")
 
     Subscribe subscribe_out(
       [](Subscribe& msg) {
-          if (msg.filter_type == FilterType::kLatestObject) {
+          if (msg.filter_type == FilterType::kLargestObject) {
               // do nothing...
           }
       },
       [](Subscribe& msg) {
-          if (msg.filter_type == FilterType::kLatestGroup) {
+          if (msg.filter_type == FilterType::kNextGroupStart) {
               // again
           }
       });
@@ -208,7 +208,7 @@ TEST_CASE("Subscribe (kLatestGroup) Message encode/decode")
                                                 0x10,
                                                 GroupOrder::kAscending,
                                                 1,
-                                                FilterType::kLatestObject,
+                                                FilterType::kLargestObject,
                                                 nullptr,
                                                 std::nullopt,
                                                 nullptr,
@@ -219,12 +219,12 @@ TEST_CASE("Subscribe (kLatestGroup) Message encode/decode")
 
     auto subscribe_out = Subscribe(
       [](Subscribe& msg) {
-          if (msg.filter_type == FilterType::kLatestObject) {
+          if (msg.filter_type == FilterType::kLargestObject) {
               // do nothing...
           }
       },
       [](Subscribe& msg) {
-          if (msg.filter_type == FilterType::kLatestGroup) {
+          if (msg.filter_type == FilterType::kNextGroupStart) {
               // again
           }
       });
@@ -345,7 +345,7 @@ TEST_CASE("Subscribe (Params) Message encode/decode")
                                                 0x10,
                                                 GroupOrder::kAscending,
                                                 1,
-                                                FilterType::kLatestObject,
+                                                FilterType::kLargestObject,
                                                 nullptr,
                                                 std::nullopt,
                                                 nullptr,
@@ -398,7 +398,7 @@ TEST_CASE("Subscribe (Params - 2) Message encode/decode")
                                                 0x10,
                                                 GroupOrder::kAscending,
                                                 1,
-                                                FilterType::kLatestObject,
+                                                FilterType::kLargestObject,
                                                 nullptr,
                                                 std::nullopt,
                                                 nullptr,
@@ -453,8 +453,8 @@ GenerateSubscribe(FilterType filter, size_t num_params = 0, uint64_t sg = 0, uin
     out.track_name = kTrackNameAliceVideo;
     out.filter_type = filter;
     switch (filter) {
-        case FilterType::kLatestObject:
-        case FilterType::kLatestGroup:
+        case FilterType::kLargestObject:
+        case FilterType::kNextGroupStart:
             break;
         case FilterType::kAbsoluteStart:
             out.group_0 = std::make_optional<Subscribe::Group_0>();
@@ -483,10 +483,10 @@ GenerateSubscribe(FilterType filter, size_t num_params = 0, uint64_t sg = 0, uin
 TEST_CASE("Subscribe (Combo) Message encode/decode")
 {
     auto subscribes = std::vector<Subscribe>{
-        GenerateSubscribe(FilterType::kLatestObject),
-        GenerateSubscribe(FilterType::kLatestGroup),
-        GenerateSubscribe(FilterType::kLatestObject, 1),
-        GenerateSubscribe(FilterType::kLatestGroup, 2),
+        GenerateSubscribe(FilterType::kLargestObject),
+        GenerateSubscribe(FilterType::kNextGroupStart),
+        GenerateSubscribe(FilterType::kLargestObject, 1),
+        GenerateSubscribe(FilterType::kNextGroupStart, 2),
         GenerateSubscribe(FilterType::kAbsoluteStart, 0, 0x100, 0x2),
         GenerateSubscribe(FilterType::kAbsoluteStart, 2, 0x100, 0x2),
         GenerateSubscribe(FilterType::kAbsoluteRange, 0, 0x100, 0x2, 0x500),
@@ -923,7 +923,7 @@ TEST_CASE("PublishOk Message encode/decode")
                                 true,
                                 0x10,
                                 GroupOrder::kAscending,
-                                FilterType::kLatestObject,
+                                FilterType::kLargestObject,
                                 nullptr,
                                 std::nullopt,
                                 nullptr,


### PR DESCRIPTION
Noticed these names and values weren't matching v12. (The `{2,1,3,4}` order was intentional to match the order they're described in the draft). 

>   There are 4 types of filters:
> 
>    Largest Object (0x2): The filter Start Location is {Largest
>    Object.Group, Largest Object.Object + 1} and Largest Object is
>    communicated in SUBSCRIBE_OK.  If no content has been delivered yet,
>    the filter Start Location is {0, 0}. There is no End Group - the
>    subscription is open ended.  Note that due to network reordering or
>    prioritization, relays can receive Objects with Locations smaller
>    than Largest Object after the SUBSCRIBE is processed, but these
>    Objects do not pass the Largest Object filter.
> 
>    Next Group Start (0x1): The filter start Location is {Largest
>    Object.Group + 1, 0} and Largest Object is communicated in
>    SUBSCRIBE_OK.  If no content has been delivered yet, the filter Start
>    Location is {0, 0}.  There is no End Group - the subscription is open
>    ended.  For scenarios where the subscriber intends to start more than
>    one group in the future, it can use an AbsoluteStart filter instead.
> 
>    AbsoluteStart (0x3): The filter Start Location is specified
>    explicitly in the SUBSCRIBE message.  The Start specified in the
>    SUBSCRIBE message MAY be less than the Largest Object observed at the
>    publisher.  There is no End Group - the subscription is open ended.
>    To receive all Objects that are published or are received after this
>    subscription is processed, a subscriber can use an AbsoluteStart
>    filter with Start = {0, 0}.
> 
>    AbsoluteRange (0x4): The filer Start Location and End Group are
>    specified explicitly in the SUBSCRIBE message.  The Start specified
>    in the SUBSCRIBE message MAY be less than the Largest Object observed
>    at the publisher.  If the specified End Group is the same group
>    specified in Start, the remainder of that Group passes the filter.
>    End Group MUST specify the same or a larger Group than specified in
>    Start.
> 