### PR TITLE
Remove unneeded stream operators

### DIFF
--- a/src/ctrl_message_types.cpp
+++ b/src/ctrl_message_types.cpp
@@ -36,13 +36,6 @@ namespace quicr::messages {
         return buffer;
     }
 
-    Bytes& operator<<(Bytes& buffer, std::uint64_t value)
-    {
-        UintVar varint = value;
-        buffer << varint;
-        return buffer;
-    }
-
     BytesSpan operator>>(BytesSpan buffer, Bytes& value)
     {
         uint64_t size = 0;
@@ -71,13 +64,6 @@ namespace quicr::messages {
         return buffer.subspan(sizeof(std::uint16_t));
     }
 
-    BytesSpan operator>>(BytesSpan buffer, uint64_t& value)
-    {
-        UintVar value_uv(buffer);
-        value = static_cast<uint64_t>(value_uv);
-        return buffer.subspan(value_uv.size());
-    }
-
     Bytes& operator<<(Bytes& buffer, GroupOrder value)
     {
         buffer << static_cast<std::uint64_t>(value);
@@ -103,48 +89,6 @@ namespace quicr::messages {
         std::uint8_t uvalue;
         buffer = buffer >> uvalue;
         value = static_cast<FetchType>(uvalue);
-        return buffer;
-    }
-
-    Bytes& operator<<(Bytes& buffer, FetchErrorCode value)
-    {
-        buffer << static_cast<std::uint64_t>(value);
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, FetchErrorCode& value)
-    {
-        std::uint64_t uvalue;
-        buffer = buffer >> uvalue;
-        value = static_cast<FetchErrorCode>(uvalue);
-        return buffer;
-    }
-
-    Bytes& operator<<(Bytes& buffer, SubscribeDoneStatusCode value)
-    {
-        buffer << static_cast<std::uint64_t>(value);
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, SubscribeDoneStatusCode& value)
-    {
-        std::uint64_t uvalue;
-        buffer = buffer >> uvalue;
-        value = static_cast<SubscribeDoneStatusCode>(uvalue);
-        return buffer;
-    }
-
-    Bytes& operator<<(Bytes& buffer, SubscribeErrorCode value)
-    {
-        buffer << static_cast<std::uint64_t>(value);
-        return buffer;
-    }
-
-    BytesSpan operator>>(BytesSpan buffer, SubscribeErrorCode& value)
-    {
-        std::uint64_t uvalue;
-        buffer = buffer >> uvalue;
-        value = static_cast<SubscribeErrorCode>(uvalue);
         return buffer;
     }
 

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -1304,3 +1304,26 @@ TEST_CASE("uint16_t encode/decode")
 {
     IntegerEncodeDecode<std::uint16_t>(true);
 }
+
+TEST_CASE("Varint backed enum encode/decode")
+{
+    enum class Example : std::uint64_t
+    {
+        kOneByteVarint = 63,
+        kTwoByteVarint = 16383,
+        kFourByteVarint = 1073741823,
+        kEightByteVarint = 4611686018427387903
+    };
+    constexpr auto varint_values = std::array{
+        Example::kOneByteVarint, Example::kTwoByteVarint, Example::kFourByteVarint, Example::kEightByteVarint
+    };
+    for (const auto& value : varint_values) {
+        Bytes buffer;
+        buffer << value;
+        UintVar out{ buffer };
+        Example code;
+        buffer >> code;
+        CHECK_EQ(out.Get(), static_cast<std::underlying_type_t<Example>>(value));
+        CHECK_EQ(code, value);
+    }
+}


### PR DESCRIPTION
- Single templated operator for all varint backed types

This was "accidentally" already the case, because the KVP templating would pick up all stream operators for `uint64_t` backed types already. So if we're continuing with that approach, we can remove a number of existing operators.

Renamed the `concept` to make it more obvious. 

The FETCH enums were specified as `uint8_t` which means they were encoding to `(8)` not `(i)` as they should have been - but for these low values they're (luckily) equivalent. Fixed that. 