### PR TITLE
Fixup various warnings

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -389,7 +389,7 @@ class MyClient : public quicr::Client
     bool FetchReceived(quicr::ConnectionHandle connection_handle,
                        uint64_t request_id,
                        const quicr::FullTrackName& track_full_name,
-                       const quicr::messages::FetchAttributes& attributes)
+                       const quicr::messages::FetchAttributes& attributes) override
     {
         auto pub_fetch_h = quicr::PublishFetchHandler::Create(
           track_full_name, attributes.priority, request_id, attributes.group_order, 50000);

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -507,7 +507,7 @@ class MyServer : public quicr::Server
     void PublishReceived(quicr::ConnectionHandle connection_handle,
                          uint64_t request_id,
                          const quicr::FullTrackName& track_full_name,
-                         const quicr::messages::SubscribeAttributes& subscribe_attributes) override
+                         const quicr::messages::PublishAttributes& publish_attributes) override
     {
         auto th = quicr::TrackHash(track_full_name);
 
@@ -523,8 +523,8 @@ class MyServer : public quicr::Server
         auto sub_track_handler = std::make_shared<MySubscribeTrackHandler>(track_full_name, true);
 
         sub_track_handler->SetRequestId(request_id);
-        sub_track_handler->SetReceivedTrackAlias(subscribe_attributes.track_alias.value());
-        sub_track_handler->SetPriority(subscribe_attributes.priority);
+        sub_track_handler->SetReceivedTrackAlias(publish_attributes.track_alias);
+        sub_track_handler->SetPriority(publish_attributes.priority);
 
         SubscribeTrack(connection_handle, sub_track_handler);
         qserver_vars::pub_subscribes[th.track_fullname_hash][connection_handle] = sub_track_handler;
@@ -533,8 +533,8 @@ class MyServer : public quicr::Server
         ResolvePublish(connection_handle,
                        request_id,
                        true,
-                       subscribe_attributes.priority,
-                       subscribe_attributes.group_order,
+                       publish_attributes.priority,
+                       publish_attributes.group_order,
                        publish_response);
 
         // Check if there are any subscribers

--- a/include/quicr/client.h
+++ b/include/quicr/client.h
@@ -162,7 +162,7 @@ namespace quicr {
         bool FetchReceived(quicr::ConnectionHandle connection_handle,
                            uint64_t request_id,
                            const quicr::FullTrackName& track_full_name,
-                           const quicr::messages::FetchAttributes& attributes);
+                           const quicr::messages::FetchAttributes& attributes) override;
 
         /**
          * @brief Bind a server fetch publisher track handler.

--- a/include/quicr/detail/attributes.h
+++ b/include/quicr/detail/attributes.h
@@ -17,7 +17,11 @@ namespace quicr::messages {
         GroupOrder group_order;                     ///< Subscriber group order
         std::chrono::milliseconds delivery_timeout; ///< Subscriber delivery timeout
         std::uint8_t forward;                       ///< True to Resume/forward data, False to pause/stop data
-        std::optional<TrackAlias> track_alias;      ///< Track alias for subscribe
+    };
+
+    struct PublishAttributes : SubscribeAttributes
+    {
+        TrackAlias track_alias;
     };
 
     /**

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -396,7 +396,6 @@ namespace quicr {
                          messages::RequestID request_id,
                          const FullTrackName& tfn,
                          uint64_t track_alias,
-                         messages::SubscriberPriority priority,
                          messages::GroupOrder group_order,
                          std::optional<messages::Location> largest_location,
                          bool forward);

--- a/include/quicr/server.h
+++ b/include/quicr/server.h
@@ -367,12 +367,12 @@ namespace quicr {
          * @param connection_handle     Source connection ID
          * @param request_id            Request ID received
          * @param track_full_name       Track full name
-         * @param subscribe_attributes  Subscribe attributes received
+         * @param publish_attributes    Publish attributes received
          */
         virtual void PublishReceived(ConnectionHandle connection_handle,
                                      uint64_t request_id,
                                      const FullTrackName& track_full_name,
-                                     const messages::SubscribeAttributes& subscribe_attributes) = 0;
+                                     const messages::PublishAttributes& publish_attributes) = 0;
 
         /**
          * @brief Callback notification on Subscribe Done received

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -673,7 +673,9 @@ namespace quicr {
                 msg_bytes >> msg;
 
                 FullTrackName tfn;
-                messages::FetchAttributes attrs = { msg.subscriber_priority, msg.group_order, 0, 0, 0, std::nullopt };
+                messages::FetchAttributes attrs = {
+                    msg.subscriber_priority, msg.group_order, { 0, 0 }, 0, std::nullopt
+                };
 
                 switch (msg.fetch_type) {
                     case messages::FetchType::kStandalone: {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -417,11 +417,10 @@ namespace quicr {
                                   msg.request_id,
                                   msg.filter_type,
                                   tfn,
-                                  {
-                                    msg.subscriber_priority,
+                                  { msg.subscriber_priority,
                                     static_cast<messages::GroupOrder>(msg.group_order),
                                     std::chrono::milliseconds{ delivery_timeout },
-                                  });
+                                    msg.forward });
 
                 return true;
             }
@@ -843,7 +842,7 @@ namespace quicr {
                 PublishReceived(conn_ctx.connection_handle,
                                 msg.request_id,
                                 tfn,
-                                { 0, msg.group_order, std::chrono::milliseconds(0), 0, msg.track_alias });
+                                { { 0, msg.group_order, std::chrono::milliseconds(0), 0 }, msg.track_alias });
 
                 return true;
             }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -350,7 +350,6 @@ namespace quicr {
                                 messages::RequestID request_id,
                                 const FullTrackName& tfn,
                                 uint64_t track_alias,
-                                messages::SubscriberPriority priority,
                                 messages::GroupOrder group_order,
                                 std::optional<Location> largest_location,
                                 bool forward)
@@ -1077,7 +1076,6 @@ namespace quicr {
               *track_handler->GetRequestId(),
               tfn,
               track_handler->GetTrackAlias().value(),
-              track_handler->GetDefaultPriority(),
               GroupOrder::kAscending,
               std::make_optional(Location{ track_handler->latest_group_id_, track_handler->latest_object_id_ }),
               true);
@@ -1261,7 +1259,6 @@ namespace quicr {
         if (!track_handler.GetRequestId().has_value()) {
             return PublishTrackHandler::PublishObjectStatus::kNoSubscribers;
         }
-        const auto request_id = track_handler.GetRequestId().value();
 
         ITransport::EnqueueFlags eflags;
 

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -9,25 +9,26 @@ TestServer::TestServer(const ServerConfig& config)
 }
 
 void
-SubscribeDoneReceived(quicr::ConnectionHandle connection_handle, uint64_t request_id)
+SubscribeDoneReceived([[maybe_unused]] quicr::ConnectionHandle connection_handle, [[maybe_unused]] uint64_t request_id)
 {
 }
 
 void
-PublishReceived(quicr::ConnectionHandle connection_handle, uint64_t request_id)
+PublishReceived([[maybe_unused]] quicr::ConnectionHandle connection_handle, [[maybe_unused]] uint64_t request_id)
 {
 }
 
 void
-TestServer::PublishReceived(quicr::ConnectionHandle connection_handle,
-                            uint64_t request_id,
-                            const quicr::FullTrackName& track_full_name,
-                            const quicr::messages::SubscribeAttributes& subscribe_attributes)
+TestServer::PublishReceived([[maybe_unused]] quicr::ConnectionHandle connection_handle,
+                            [[maybe_unused]] uint64_t request_id,
+                            [[maybe_unused]] const quicr::FullTrackName& track_full_name,
+                            [[maybe_unused]] const quicr::messages::PublishAttributes& publish_attributes)
 {
 }
 
 void
-TestServer::SubscribeDoneReceived(quicr::ConnectionHandle connection_handle, uint64_t request_id)
+TestServer::SubscribeDoneReceived([[maybe_unused]] quicr::ConnectionHandle connection_handle,
+                                  [[maybe_unused]] uint64_t request_id)
 {
 }
 

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -50,7 +50,7 @@ namespace quicr_test {
         void PublishReceived(quicr::ConnectionHandle connection_handle,
                              uint64_t request_id,
                              const quicr::FullTrackName& track_full_name,
-                             const quicr::messages::SubscribeAttributes& subscribe_attributes) override;
+                             const quicr::messages::PublishAttributes& publish_attributes) override;
         void SubscribeDoneReceived(quicr::ConnectionHandle connection_handle, uint64_t request_id) override;
 
       private:


### PR DESCRIPTION
- Few compile warnings from missing overrides / braces. 
- Break out `PublishAttributes` from `SubscribeAttributes` to remove the need for `TrackAlias` to be optional. 