### PR TITLE
Subscribe Update starts new stream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
 endif()
 
 project(quicr
-        VERSION 1.12.0
+        VERSION 1.12.1
         DESCRIPTION "QuicR, a Media over QUIC Library"
         LANGUAGES CXX)
 

--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -502,14 +502,7 @@ DoPublisher(const quicr::FullTrackName& full_track_name,
 
                 break;
             case MyPublishTrackHandler::Status::kSubscriptionUpdated:
-                /*
-                                if (object_id) {
-                                    group_id++;
-                                    object_id = 0;
-                                    subgroup_id = 0;
-                                    SPDLOG_INFO("Subscription Updated: Restarting a new group {0}", group_id);
-                                }
-                */
+                SPDLOG_INFO("subscribe updated");
                 break;
             case MyPublishTrackHandler::Status::kNoSubscribers:
                 // Start a new group when a subscriber joins

--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -502,13 +502,14 @@ DoPublisher(const quicr::FullTrackName& full_track_name,
 
                 break;
             case MyPublishTrackHandler::Status::kSubscriptionUpdated:
-                if (object_id) {
-                    group_id++;
-                    object_id = 0;
-                    subgroup_id = 0;
-                    SPDLOG_INFO("Subscription Updated: Restarting a new group {0}", group_id);
-                }
-
+                /*
+                                if (object_id) {
+                                    group_id++;
+                                    object_id = 0;
+                                    subgroup_id = 0;
+                                    SPDLOG_INFO("Subscription Updated: Restarting a new group {0}", group_id);
+                                }
+                */
                 break;
             case MyPublishTrackHandler::Status::kNoSubscribers:
                 // Start a new group when a subscriber joins

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -645,8 +645,10 @@ namespace quicr {
                 messages::NewGroupRequest msg;
                 msg_bytes >> msg;
 
-                SPDLOG_LOGGER_DEBUG(logger_, "Received new group request conn_id: {} request_id: {}",
-                    conn_ctx.client_version, msg.request_id);
+                SPDLOG_LOGGER_DEBUG(logger_,
+                                    "Received new group request conn_id: {} request_id: {}",
+                                    conn_ctx.client_version,
+                                    msg.request_id);
 
                 try {
                     if (auto handler = conn_ctx.pub_tracks_by_track_alias.at(msg.track_alias)) {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -283,10 +283,6 @@ namespace quicr {
                     return true;
                 }
 
-                // SendSubscribeOk(
-                //   conn_ctx, msg.request_id, ptd->GetTrackAlias(msg.request_id), kSubscribeExpires, false, { 0, 0
-                //   });std::to_string(
-
                 SPDLOG_LOGGER_DEBUG(logger_,
                                     "Received subscribe_update to track alias: {0} recv request_id: {1} forward: {2}",
                                     th.track_fullname_hash,
@@ -649,13 +645,16 @@ namespace quicr {
                 messages::NewGroupRequest msg;
                 msg_bytes >> msg;
 
+                SPDLOG_LOGGER_DEBUG(logger_, "Received new group request conn_id: {} request_id: {}",
+                    conn_ctx.client_version, msg.request_id);
+
                 try {
                     if (auto handler = conn_ctx.pub_tracks_by_track_alias.at(msg.track_alias)) {
                         handler->SetStatus(PublishTrackHandler::Status::kNewGroupRequested);
                     }
                 } catch (const std::exception& e) {
                     SPDLOG_LOGGER_ERROR(
-                      logger_, "Failed to fins publisher by alias: {} error: {}", msg.track_alias, e.what());
+                      logger_, "Failed to find publisher by alias: {} error: {}", msg.track_alias, e.what());
                 }
 
                 return true;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -284,14 +284,16 @@ namespace quicr {
                 }
 
                 // SendSubscribeOk(
-                //   conn_ctx, msg.request_id, ptd->GetTrackAlias(msg.request_id), kSubscribeExpires, false, { 0, 0 });
+                //   conn_ctx, msg.request_id, ptd->GetTrackAlias(msg.request_id), kSubscribeExpires, false, { 0, 0
+                //   });std::to_string(
 
                 SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Received subscribe_update to track alias: {0} recv request_id: {1}",
+                                    "Received subscribe_update to track alias: {0} recv request_id: {1} forward: {2}",
                                     th.track_fullname_hash,
-                                    msg.request_id);
+                                    msg.request_id,
+                                    msg.forward);
 
-                if (msg.forward) {
+                if (not msg.forward) {
                     ptd->SetStatus(PublishTrackHandler::Status::kPaused);
                 } else {
                     ptd->SetStatus(PublishTrackHandler::Status::kSubscriptionUpdated);

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -89,12 +89,19 @@ namespace quicr {
                 publish_track_metrics_.objects_dropped_not_ok++;
                 return PublishObjectStatus::kNotAuthorized;
             case Status::kNewGroupRequested:
-                [[fallthrough]];
-            case Status::kSubscriptionUpdated:
                 // reset the status to ok to imply change
                 if (!is_stream_header_needed) {
                     break;
                 }
+                publish_status_ = Status::kOk;
+                break;
+            case Status::kSubscriptionUpdated:
+
+                /*
+                 * Always start a new stream on subscription update to support peering/pipelining
+                 */
+                is_stream_header_needed = true;
+
                 publish_status_ = Status::kOk;
                 break;
             default:

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -144,7 +144,7 @@ namespace quicr {
     {
         if (status_ != Status::kPaused) {
             status_ = Status::kPaused;
-            set_forwarding_func_(true);
+            set_forwarding_func_(false);
         }
     }
 
@@ -152,7 +152,7 @@ namespace quicr {
     {
         if (status_ == Status::kPaused) {
             status_ = Status::kOk;
-            set_forwarding_func_(false);
+            set_forwarding_func_(true);
         }
     }
 } // namespace quicr

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -446,7 +446,7 @@ namespace quicr {
                                         bool forward)
     try {
         auto subscribe_update =
-          messages::SubscribeUpdate(request_id, start_location, end_group_id, priority, forward ? 1 : 0, {});
+          messages::SubscribeUpdate(request_id, start_location, end_group_id, priority, static_cast<int>(forward), {});
 
         Bytes buffer;
         buffer << subscribe_update;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -446,18 +446,19 @@ namespace quicr {
                                         bool forward)
     try {
         auto subscribe_update =
-          messages::SubscribeUpdate(request_id, start_location, end_group_id, priority, forward, {});
+          messages::SubscribeUpdate(request_id, start_location, end_group_id, priority, forward ? 1 : 0, {});
 
         Bytes buffer;
         buffer << subscribe_update;
 
-        SPDLOG_LOGGER_DEBUG(
-          logger_,
-          "Sending SUBSCRIBE_UPDATE to conn_id: {0} request_id: {1} track namespace hash: {2} name hash: {3}",
-          conn_ctx.connection_handle,
-          request_id,
-          th.track_namespace_hash,
-          th.track_name_hash);
+        SPDLOG_LOGGER_DEBUG(logger_,
+                            "Sending SUBSCRIBE_UPDATE to conn_id: {0} request_id: {1} track namespace hash: {2} name "
+                            "hash: {3} forward: {4}",
+                            conn_ctx.connection_handle,
+                            request_id,
+                            th.track_namespace_hash,
+                            th.track_name_hash,
+                            forward);
 
         SendCtrlMsg(conn_ctx, buffer);
     } catch (const std::exception& e) {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -772,6 +772,7 @@ namespace quicr {
             return;
         }
 
+        SPDLOG_LOGGER_DEBUG(logger_, "Sending new group request track conn_id: {} request_id: {}", conn_id, request_id);
         SendCtrlMsg(conn_it->second, buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending NewGroupRequest (error={})", e.what());


### PR DESCRIPTION
Change subscribe update to start a new stream on `SendObject()`.  This is required to support peering/pipelining with mid-group joins. 

This change fixes pause/resume to correctly set forward value. 
