### PR TITLE
Expand new group request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
 endif()
 
 project(quicr
-        VERSION 1.12.2
+        VERSION 1.12.3
         DESCRIPTION "QuicR, a Media over QUIC Library"
         LANGUAGES CXX)
 

--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -25,6 +25,7 @@ namespace qclient_vars {
     std::optional<uint64_t> track_alias; /// Track alias to use for subscribe
     bool record = false;
     bool playback = false;
+    bool new_group = false;
     std::chrono::milliseconds playback_speed_ms(20);
 }
 
@@ -158,6 +159,10 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
             case Status::kOk: {
                 if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
                     SPDLOG_INFO("Track alias: {0} is ready to read", track_alias.value());
+                    if (qclient_vars::new_group) {
+                        SPDLOG_INFO("Track alias: {0} requesting new group", track_alias.value());
+                        RequestNewGroup();
+                    }
                 }
             } break;
 
@@ -752,6 +757,10 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
         qclient_vars::playback = true;
     }
 
+    if (cli_opts.count("new_group")) {
+        qclient_vars::new_group = true;
+    }
+
     if (cli_opts.count("playback_speed_ms")) {
         qclient_vars::playback_speed_ms = std::chrono::milliseconds(cli_opts["playback_speed_ms"].as<uint64_t>());
     }
@@ -810,6 +819,7 @@ main(int argc, char* argv[])
         ("start_point", "Start point for Subscription - 0 for from the beginning, 1 from the latest object", cxxopts::value<uint64_t>())
         ("sub_announces", "Prefix namespace to subscribe announces to", cxxopts::value<std::string>())
         ("record", "Record incoming data to moq and dat files", cxxopts::value<bool>())
+        ("new_group", "Request new group on subscribe", cxxopts::value<bool>())
         ("joining_fetch", "Subscribe with a joining fetch", cxxopts::value<bool>());
 
     options.add_options("Fetcher")

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -881,10 +881,6 @@ class MyServer : public quicr::Server
         for (const auto& [pub_connection_handle, handler] : qserver_vars::pub_subscribes[track_alias]) {
             if (handler->IsPublisherInitiated()) {
                 handler->Resume();
-                SPDLOG_INFO("Sending subscription update with new group to connection: hash: {0} request: {1}",
-                            th.track_namespace_hash,
-                            request_id);
-                UpdateTrackSubscription(pub_connection_handle, handler, false);
             }
         }
 
@@ -930,7 +926,7 @@ class MyServer : public quicr::Server
                         if (sub_track_h == nullptr) {
                             return;
                         }
-                        SPDLOG_INFO("Sending subscription update with new group to connection: hash: {0} request: {1}",
+                        SPDLOG_INFO("Sending subscription update to connection: hash: {0} request: {1}",
                                     th.track_namespace_hash,
                                     request_id);
                         UpdateTrackSubscription(conn_h, sub_track_h, false);

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -303,6 +303,7 @@ class MyPublishTrackHandler : public quicr::PublishTrackHandler
                     break;
                 case Status::kPaused:
                     reason = "paused";
+                    break;
                 default:
                     break;
             }

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -44,7 +44,8 @@ namespace quicr {
             kNotSubscribed,
             kPendingResponse,
             kSendingUnsubscribe, ///< In this state, callbacks will not be called,
-            kPaused
+            kPaused,
+            kNewGroupRequested,
         };
 
         /**
@@ -192,6 +193,11 @@ namespace quicr {
          */
         void Resume() noexcept;
 
+        /**
+         * @brief Generate a new group request for this subscription
+         */
+        void RequestNewGroup() noexcept;
+
         std::chrono::milliseconds GetDeliveryTimeout() const noexcept { return delivery_timeout_; }
 
         void SetDeliveryTimeout(std::chrono::milliseconds timeout) noexcept { delivery_timeout_ = timeout; }
@@ -293,7 +299,7 @@ namespace quicr {
          * @brief Function pointer to send subscribe update with forward setting
          * @param forward       True or False
          */
-        using SetForwardingFunction = std::function<void(bool forward)>;
+        using UpdateFunction = std::function<void(bool forward, bool new_group)>;
 
       protected:
         /**
@@ -320,7 +326,7 @@ namespace quicr {
         std::optional<uint64_t> received_track_alias_; ///< Received track alias from publisher client or relay
         std::chrono::milliseconds delivery_timeout_{ 0 };
 
-        SetForwardingFunction set_forwarding_func_; // set by the transport
+        UpdateFunction update_func_; // set by the transport
 
         bool publisher_initiated_{ false };
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -865,12 +865,13 @@ namespace quicr {
                 auto th = TrackHash(req_id_it->second.track_full_name);
                 auto ptd = GetPubTrackHandler(conn_ctx, th);
                 if (ptd == nullptr) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received subscribe update to unknown publish track conn_id: {0} namespace hash: {1} "
-                                       "name hash: {2}",
-                                       conn_ctx.connection_handle,
-                                       th.track_namespace_hash,
-                                       th.track_name_hash);
+                    SPDLOG_LOGGER_WARN(
+                      logger_,
+                      "Received subscribe update to unknown publish track conn_id: {0} namespace hash: {1} "
+                      "name hash: {2}",
+                      conn_ctx.connection_handle,
+                      th.track_namespace_hash,
+                      th.track_name_hash);
 
                     SendSubscribeError(conn_ctx,
                                        msg.request_id,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -852,14 +852,21 @@ namespace quicr {
                     return true;
                 }
 
-                auto tfn = conn_ctx.recv_req_id[msg.request_id].track_full_name;
-                auto th = TrackHash(tfn);
+                auto req_id_it = conn_ctx.recv_req_id.find(msg.request_id);
+                if (req_id_it == conn_ctx.recv_req_id.end()) {
+                    SPDLOG_LOGGER_WARN(
+                      logger_,
+                      "Received subscribe update to unknown publish track conn_id: {0} request_id: {1}",
+                      conn_ctx.connection_handle,
+                      msg.request_id);
+                    return true;
+                }
 
-                // For client/publisher, notify track that there is a subscriber
+                auto th = TrackHash(req_id_it->second.track_full_name);
                 auto ptd = GetPubTrackHandler(conn_ctx, th);
                 if (ptd == nullptr) {
                     SPDLOG_LOGGER_WARN(logger_,
-                                       "Received subscribe unknown publish track conn_id: {0} namespace hash: {1} "
+                                       "Received subscribe update to unknown publish track conn_id: {0} namespace hash: {1} "
                                        "name hash: {2}",
                                        conn_ctx.connection_handle,
                                        th.track_namespace_hash,
@@ -873,14 +880,24 @@ namespace quicr {
                 }
 
                 SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Received subscribe_update to track alias: {0} recv request_id: {1}",
+                                    "Received subscribe_update to track alias: {0} recv request_id: {1} forward: {2}",
                                     th.track_fullname_hash,
-                                    msg.request_id);
+                                    msg.request_id,
+                                    msg.forward);
 
-                if (msg.forward) {
+                if (not msg.forward) {
                     ptd->SetStatus(PublishTrackHandler::Status::kPaused);
                 } else {
-                    ptd->SetStatus(PublishTrackHandler::Status::kSubscriptionUpdated);
+                    bool new_group_request = false;
+                    for (const auto& param : msg.subscribe_parameters) {
+                        if (param.type == messages::ParameterType::kNewGroupRequest) {
+                            new_group_request = true;
+                            break;
+                        }
+                    }
+
+                    ptd->SetStatus(new_group_request ? PublishTrackHandler::Status::kNewGroupRequested
+                                                     : PublishTrackHandler::Status::kSubscriptionUpdated);
                 }
 
                 return true;

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -137,7 +137,7 @@ namespace quicr {
     {
         if (status_ != Status::kPaused) {
             status_ = Status::kPaused;
-            set_forwarding_func_(false);
+            update_func_(false, false);
         }
     }
 
@@ -145,7 +145,14 @@ namespace quicr {
     {
         if (status_ == Status::kPaused) {
             status_ = Status::kOk;
-            set_forwarding_func_(true);
+            update_func_(true, false);
+        }
+    }
+
+    void SubscribeTrackHandler::RequestNewGroup() noexcept
+    {
+        if (status_ == Status::kOk) {
+            update_func_(true, true);
         }
     }
 } // namespace quicr

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -812,9 +812,15 @@ namespace quicr {
         auto filter_type = track_handler->GetFilterType();
         auto delivery_timeout = track_handler->GetDeliveryTimeout();
 
-        track_handler->set_forwarding_func_ = [=, this](bool forward) {
-            SendSubscribeUpdate(
-              conn_it->second, *track_handler->GetRequestId(), th, {}, 0, track_handler->GetPriority(), forward);
+        track_handler->update_func_ = [=, this](bool forward, bool new_group) {
+            SendSubscribeUpdate(conn_it->second,
+                                *track_handler->GetRequestId(),
+                                th,
+                                {},
+                                0,
+                                track_handler->GetPriority(),
+                                forward,
+                                new_group);
         };
 
         // Set the track handler for tracking by request ID


### PR DESCRIPTION
This adds back `SubscribeTrackHandler::RequestNewGroup()` method and implements it so that the server can forward it to  the publishers. qserver/qclient have been updated and support this.

Run qclient with the option `--new_group` when subscribing to test out the publisher seeing the new group request. 