### PR TITLE
Use atomic operations for tick service

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(quicr_benchmark
     uintvar.cpp
     hash.cpp
     data_storage.cpp
+    tick_service.cpp
 )
 
 target_link_libraries(quicr_benchmark PRIVATE quicr benchmark::benchmark_main)

--- a/benchmark/tick_service.cpp
+++ b/benchmark/tick_service.cpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <quicr/detail/tick_service.h>
+
+#include <benchmark/benchmark.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using namespace quicr;
+
+static void
+TickService_Microseconds(benchmark::State& state)
+{
+    const ThreadedTickService service(100);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    for ([[maybe_unused]] const auto& _ : state) {
+        auto ticks = service.Microseconds();
+        benchmark::DoNotOptimize(ticks);
+    }
+}
+
+static void
+TickService_Milliseconds(benchmark::State& state)
+{
+    const ThreadedTickService service(100);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    for ([[maybe_unused]] const auto& _ : state) {
+        auto ticks = service.Milliseconds();
+        benchmark::DoNotOptimize(ticks);
+    }
+}
+
+static void
+TickService_MultiThreadRead(benchmark::State& state)
+{
+    const ThreadedTickService service(100);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    std::atomic<bool> start_flag{ false };
+    std::atomic<uint64_t> total_reads{ 0 };
+
+    // Create reader threads
+    std::thread reader([&service, &start_flag, &total_reads]() {
+        while (!start_flag.load()) {
+            std::this_thread::yield();
+        }
+
+        int64_t local_reads = 0;
+        while (start_flag.load()) {
+            auto ticks = service.Microseconds();
+            benchmark::DoNotOptimize(ticks);
+            ++local_reads;
+        }
+        total_reads.fetch_add(local_reads);
+    });
+
+    for (auto _ : state) {
+        start_flag = true;
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+        start_flag = false;
+    }
+
+    // Join all threads
+    reader.join();
+
+    state.SetItemsProcessed(total_reads.load());
+}
+
+// Single-threaded use.
+BENCHMARK(TickService_Microseconds);
+BENCHMARK(TickService_Milliseconds);
+
+// Multi-threaded use.
+BENCHMARK(TickService_MultiThreadRead);


### PR DESCRIPTION
`ThreadedTickService` wasn't protecting the `uint64_t` variable from concurrent read/writes. 

Added a benchmark, which suggests on the tested hardware it's only a couple of ~ns added. 

There may be some extra thought needed for ESP32 - there are alternatives to consider if we think it's an issue.