### PR TITLE
Lint for use-after-move

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: '
           readability-identifier-naming,
           -readability-make-member-function-const,
           -readability-non-const-parameter,
+          bugprone-use-after-move,
         '
 CheckOptions:
   - { key: readability-identifier-naming.ClassCase,                    value: CamelCase             }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -249,7 +249,7 @@ namespace quicr {
             // Hold onto track handler
             conn_it->second.pub_tracks_by_name[th.track_namespace_hash][th.track_name_hash] = track_handler;
             conn_it->second.pub_tracks_by_track_alias[th.track_fullname_hash] = track_handler;
-            conn_it->second.pub_tracks_by_data_ctx_id[track_handler->publish_data_ctx_id_] = std::move(track_handler);
+            conn_it->second.pub_tracks_by_data_ctx_id[track_handler->publish_data_ctx_id_] = track_handler;
         }
 
         lock.unlock();


### PR DESCRIPTION
After #629, enable use after move checking in clang-tidy. Found another one. 