### PR TITLE
Fix subscribe update reference cycle

### DIFF
--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -383,7 +383,7 @@ namespace quicr {
                            messages::GroupOrder group_order,
                            messages::FilterType filter_type,
                            std::chrono::milliseconds delivery_timeout);
-        void SendSubscribeUpdate(ConnectionContext& conn_ctx,
+        void SendSubscribeUpdate(const ConnectionContext& conn_ctx,
                                  messages::RequestID request_id,
                                  TrackHash th,
                                  messages::Location start_location,

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -99,6 +99,9 @@ TEST_CASE("Integration - Subscribe")
 
     // Test is complete, unsubscribe while we are connected.
     CHECK_NOTHROW(client->UnsubscribeTrack(handler));
+
+    // Check track handler cleanup / strong reference cycles.
+    CHECK_EQ(handler.use_count(), 1);
 }
 
 TEST_CASE("Integration - Fetch")


### PR DESCRIPTION
Fix strong reference cycle. The first commit adds a test to ensure a track handler has been cleaned up after unsubscribe. This should fail to show the existing issue of a use-count of `2` post-unsubscribe (the test plus the leaked ref in the lambda) instead of `1` (just the test owner). 

The second commit fixes the strong reference, makes the capture list more explicit, and fixes up a missing `const` that is needed to avoid marking the capture as mutable. I capture a weak_ptr here because the priority may have changed. The request ID probably not, but it's not const so...in theory...and we've already had to get the weak_ptr for priority anyway.