### PR TITLE
Fetch track cleanup on cancel

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1183,6 +1183,7 @@ namespace quicr {
 
         track_handler->SetRequestId(std::nullopt);
         track_handler->SetStatus(FetchTrackHandler::Status::kNotConnected);
+        conn_it->second.sub_tracks_by_request_id.erase(*sub_id);
     }
 
     PublishTrackHandler::PublishObjectStatus Transport::SendData(PublishTrackHandler& track_handler,

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -113,4 +113,8 @@ TEST_CASE("Integration - Fetch")
     ftn.name = { 1, 2, 3 };
     const auto handler = FetchTrackHandler::Create(ftn, 0, messages::GroupOrder::kOriginalPublisherOrder, 0, 0, 0, 0);
     client->FetchTrack(handler);
+
+    // Check track handler cleanup / strong reference cycles.
+    client->CancelFetchTrack(handler);
+    CHECK_EQ(handler.use_count(), 1);
 }


### PR DESCRIPTION
Am I correct in thinking that we should be cleaning up our `FetchTrackHandler`s on a requested FETCH_CANCEL? My understanding is that this can *immediately* close as the publisher will immediately cease publishing of any further objects. There's no confirmation, and we generally aren't introspecting stream state, so we may as well immediately drop it on request?