### PR TITLE
Ensure shared transport

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -329,11 +329,16 @@ class MyFetchTrackHandler : public quicr::FetchTrackHandler
  */
 class MyClient : public quicr::Client
 {
-  public:
     MyClient(const quicr::ClientConfig& cfg, bool& stop_threads)
       : quicr::Client(cfg)
       , stop_threads_(stop_threads)
     {
+    }
+
+  public:
+    static std::shared_ptr<MyClient> Create(const quicr::ClientConfig& cfg, bool& stop_threads)
+    {
+        return std::shared_ptr<MyClient>(new MyClient(cfg, stop_threads));
     }
 
     void StatusChanged(Status status) override
@@ -855,7 +860,7 @@ main(int argc, char* argv[])
 
     try {
         bool stop_threads{ false };
-        auto client = std::make_shared<MyClient>(config, stop_threads);
+        auto client = MyClient::Create(config, stop_threads);
 
         if (client->Connect() != quicr::Transport::Status::kConnecting) {
             SPDLOG_ERROR("Failed to connect to server due to invalid params, check URI");

--- a/include/quicr/client.h
+++ b/include/quicr/client.h
@@ -21,7 +21,7 @@ namespace quicr {
      */
     class Client : public Transport
     {
-      public:
+      protected:
         /**
          * @brief MoQ Client Constructor to create the client mode instance
          *
@@ -32,7 +32,13 @@ namespace quicr {
         {
         }
 
+      public:
         ~Client() = default;
+
+        static std::shared_ptr<Client> Create(const ClientConfig& cfg)
+        {
+            return std::shared_ptr<Client>(new Client(cfg));
+        }
 
         /**
          * @brief Starts a client connection via a transport thread

--- a/include/quicr/detail/base_track_handler.h
+++ b/include/quicr/detail/base_track_handler.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 namespace quicr {
+    class Transport;
 
     /**
      * @brief Track mode object of object published or received
@@ -137,6 +138,15 @@ namespace quicr {
          */
         uint64_t GetConnectionId() const noexcept { return connection_handle_; };
 
+      protected:
+        /**
+         * Set the transport to use.
+         * @param transport The new transport for the handler to use.
+         */
+        void SetTransport(std::shared_ptr<Transport> transport);
+
+        const std::weak_ptr<Transport>& GetTransport() const noexcept;
+
         // --------------------------------------------------------------------------
         // Internal
         // --------------------------------------------------------------------------
@@ -161,6 +171,8 @@ namespace quicr {
          *   or the next one that increments from last received ID.
          */
         std::optional<uint64_t> request_id_;
+
+        std::weak_ptr<Transport> transport_;
     };
 
 } // namespace moq

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -352,13 +352,6 @@ namespace quicr {
 
         void Init();
 
-        PublishTrackHandler::PublishObjectStatus SendData(PublishTrackHandler& track_handler,
-                                                          uint8_t priority,
-                                                          uint64_t group_id,
-                                                          uint32_t ttl,
-                                                          bool stream_header_needed,
-                                                          std::shared_ptr<const std::vector<uint8_t>> data);
-
         void SendCtrlMsg(const ConnectionContext& conn_ctx, BytesSpan data);
         void SendClientSetup();
         void SendServerSetup(ConnectionContext& conn_ctx);

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -31,7 +31,9 @@ namespace quicr {
      * @details MoQ implementation is the handler for either a client or server. It can run
      *   in only one mode, client or server.
      */
-    class Transport : public ITransport::TransportDelegate
+    class Transport
+      : public ITransport::TransportDelegate
+      , public std::enable_shared_from_this<Transport>
     {
       public:
         Transport() = delete;
@@ -357,16 +359,6 @@ namespace quicr {
                                                           bool stream_header_needed,
                                                           std::shared_ptr<const std::vector<uint8_t>> data);
 
-        PublishTrackHandler::PublishObjectStatus SendObject(PublishTrackHandler& track_handler,
-                                                            uint8_t priority,
-                                                            uint32_t ttl,
-                                                            bool stream_header_needed,
-                                                            uint64_t group_id,
-                                                            uint64_t subgroup_id,
-                                                            uint64_t object_id,
-                                                            std::optional<Extensions> extensions,
-                                                            BytesSpan data);
-
         void SendCtrlMsg(const ConnectionContext& conn_ctx, BytesSpan data);
         void SendClientSetup();
         void SendServerSetup(ConnectionContext& conn_ctx);
@@ -500,6 +492,9 @@ namespace quicr {
         // -------------------------------------------------------------------------------------------------
         virtual void MetricsSampled(const ConnectionMetrics&) {}
 
+      protected:
+        std::shared_ptr<Transport> GetSharedPtr();
+
         // -------------------------------------------------------------------------------------------------
 
       private:
@@ -508,6 +503,15 @@ namespace quicr {
         // ------------------------------------------------------------------------------------------------
 
         virtual bool ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan msg_bytes) = 0;
+
+        TransportError Enqueue(const TransportConnId& conn_id,
+                               const DataContextId& data_ctx_id,
+                               std::uint64_t group_id,
+                               std::shared_ptr<const std::vector<uint8_t>> bytes,
+                               const uint8_t priority,
+                               const uint32_t ttl_ms,
+                               const uint32_t delay_ms,
+                               const ITransport::EnqueueFlags flags);
 
       private:
         // -------------------------------------------------------------------------------------------------
@@ -529,6 +533,9 @@ namespace quicr {
 
         friend class Client;
         friend class Server;
+        friend class PublishTrackHandler;
+        friend class PublishFetchHandler;
+        friend class SubscribeTrackHandler;
     };
 
 } // namespace quicr

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -495,6 +495,8 @@ namespace quicr {
       protected:
         std::shared_ptr<Transport> GetSharedPtr();
 
+        const ConnectionContext& GetConnectionContext(ConnectionHandle conn) const;
+
         // -------------------------------------------------------------------------------------------------
 
       private:

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -317,50 +317,6 @@ namespace quicr {
         // --------------------------------------------------------------------------
       protected:
         /**
-         * @brief Publish Object function via the MoQ instance
-         *
-         * @details This is set by the MoQInstance.
-         *   Publish object function provides direct access to the MoQInstance that will publish
-         *   the object based on the track mode.
-         *
-         * @param priority              Priority to use for object; set on next track change
-         * @param ttl                   Expire time to live in milliseconds
-         * @param stream_header_needed  Indicates if group or track header is needed before this data object
-         * @param group_id              The ID of the group the message belongs to
-         * @param object_id             The ID of the object this message represents
-         * @param extensions            Extensions to send along with the message
-         * @param data                  Raw data/object that should be transmitted - MoQInstance serializes the data
-         */
-        using PublishObjFunction = std::function<PublishObjectStatus(uint8_t priority,
-                                                                     uint32_t ttl,
-                                                                     bool stream_header_needed,
-                                                                     uint64_t group_id,
-                                                                     uint64_t subgroup_id,
-                                                                     uint64_t object_id,
-                                                                     std::optional<Extensions> extensions,
-                                                                     BytesSpan data)>;
-
-        /**
-         * @brief Forward data function via the MoQ instance
-         *
-         * @details This is set by the MoQInstance.
-         *   Forward data function provides direct access to the MoQInstance that will forward data
-         *   based on the parameters passed.
-         *
-         * @param priority              Priority to use for object; set on next track change
-         * @param group_id              Group ID to use for priority group queue
-         * @param ttl                   Expire time to live in milliseconds
-         * @param stream_header_needed  Indicates if group or track header is needed before this data object
-         * @param data                  MoQ Serialized data to write to the remote connection/stream
-         */
-        using ForwardDataFunction =
-          std::function<PublishObjectStatus(uint8_t priority,
-                                            uint64_t group_id,
-                                            uint32_t ttl,
-                                            bool stream_header_needed,
-                                            std::shared_ptr<const std::vector<uint8_t>> data)>;
-
-        /**
          * @brief Set the Data context ID
          *
          * @details The MOQ Handler sets the data context ID
@@ -391,9 +347,7 @@ namespace quicr {
         uint8_t default_priority_; // Set by caller and is used when priority is not specified
         uint32_t default_ttl_;     // Set by caller and is used when TTL is not specified
 
-        uint64_t publish_data_ctx_id_;                  // set byte the transport; publishing data context ID
-        PublishObjFunction publish_object_func_;        // set by the transport
-        ForwardDataFunction forward_publish_data_func_; // set by the transport
+        uint64_t publish_data_ctx_id_; // set byte the transport; publishing data context ID
 
         uint64_t latest_group_id_{ 0 };
         uint64_t latest_sub_group_id_{ 0 };

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -295,12 +295,6 @@ namespace quicr {
          */
         SubscribeTrackMetrics subscribe_track_metrics_;
 
-        /**
-         * @brief Function pointer to send subscribe update with forward setting
-         * @param forward       True or False
-         */
-        using UpdateFunction = std::function<void(bool forward, bool new_group)>;
-
       protected:
         /**
          * @brief Set the subscribe status
@@ -325,8 +319,6 @@ namespace quicr {
         std::optional<uint64_t> track_alias_;
         std::optional<uint64_t> received_track_alias_; ///< Received track alias from publisher client or relay
         std::chrono::milliseconds delivery_timeout_{ 0 };
-
-        UpdateFunction update_func_; // set by the transport
 
         bool publisher_initiated_{ false };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ else()
     add_library(quicr)
 endif()
 target_sources (quicr PRIVATE
+    base_track_handler.cpp
     client.cpp
     ctrl_message_types.cpp
     ${ctrl_messages_SOURCE}

--- a/src/base_track_handler.cpp
+++ b/src/base_track_handler.cpp
@@ -1,0 +1,14 @@
+#include "quicr/detail/base_track_handler.h"
+#include "quicr/detail/transport.h"
+
+namespace quicr {
+    void BaseTrackHandler::SetTransport(std::shared_ptr<Transport> transport)
+    {
+        transport_ = transport;
+    }
+
+    const std::weak_ptr<Transport>& BaseTrackHandler::GetTransport() const noexcept
+    {
+        return transport_;
+    }
+}

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -86,25 +86,7 @@ namespace quicr {
         track_handler->publish_data_ctx_id_ =
           quic_transport_->CreateDataContext(conn_id, true, track_handler->GetDefaultPriority(), false);
 
-        // Setup the function for the track handler to use to send objects with thread safety
-        std::weak_ptr weak_handler(track_handler);
-        track_handler->publish_object_func_ =
-          [&, weak_handler](uint8_t priority,
-                            uint32_t ttl,
-                            bool stream_header_needed,
-                            uint64_t group_id,
-                            uint64_t subgroup_id,
-                            uint64_t object_id,
-                            std::optional<Extensions> extensions,
-                            std::span<const uint8_t> data) -> PublishTrackHandler::PublishObjectStatus {
-            const auto handler = weak_handler.lock();
-            if (!handler) {
-                return PublishTrackHandler::PublishObjectStatus::kInternalError;
-            }
-
-            return SendFetchObject(
-              *handler, priority, ttl, stream_header_needed, group_id, subgroup_id, object_id, extensions, data);
-        };
+        track_handler->SetTransport(GetSharedPtr());
 
         // Hold ref to track handler
         conn_it->second.pub_fetch_tracks_by_sub_id[request_id] = std::move(track_handler);

--- a/src/publish_fetch_handler.cpp
+++ b/src/publish_fetch_handler.cpp
@@ -1,26 +1,113 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
-#include <quicr/publish_fetch_handler.h>
+#include "quicr/publish_fetch_handler.h"
+
+#include "quicr/detail/transport.h"
 
 namespace quicr {
     PublishTrackHandler::PublishObjectStatus PublishFetchHandler::PublishObject(const ObjectHeaders& object_headers,
                                                                                 const BytesSpan data)
     {
-        bool is_stream_header_needed{ !sent_first_header_ };
-        sent_first_header_ = true;
-        if (publish_object_func_ == nullptr) {
+        auto transport = GetTransport().lock();
+
+        if (!transport) {
             return PublishObjectStatus::kInternalError;
         }
 
-        return publish_object_func_(object_headers.priority.has_value() ? object_headers.priority.value()
-                                                                        : default_priority_,
-                                    object_headers.ttl.has_value() ? object_headers.ttl.value() : default_ttl_,
-                                    is_stream_header_needed,
-                                    object_headers.group_id,
-                                    object_headers.subgroup_id,
-                                    object_headers.object_id,
-                                    object_headers.extensions,
-                                    data);
+        bool is_stream_header_needed{ !sent_first_header_ };
+        sent_first_header_ = true;
+
+        if (!GetRequestId().has_value()) {
+            return PublishTrackHandler::PublishObjectStatus::kNoSubscribers;
+        }
+
+        ITransport::EnqueueFlags eflags;
+
+        std::uint64_t group_id = object_headers.group_id;
+        std::uint64_t object_id = object_headers.object_id;
+        std::uint16_t ttl = object_headers.ttl.has_value() ? object_headers.ttl.value() : default_ttl_;
+        std::uint8_t priority =
+          object_headers.priority.has_value() ? object_headers.priority.value() : default_priority_;
+
+        object_msg_buffer_.clear();
+
+        switch (default_track_mode_) {
+            case TrackMode::kDatagram: {
+                messages::ObjectDatagram object;
+                object.group_id = group_id;
+                object.object_id = object_headers.object_id;
+                object.priority = priority;
+                object.track_alias = GetTrackAlias().value();
+                object.extensions = object_headers.extensions;
+                object.payload.assign(data.begin(), data.end());
+                object_msg_buffer_ << object;
+                break;
+            }
+            default: {
+                // use stream per subgroup, group change
+                eflags.use_reliable = true;
+
+                if (is_stream_header_needed) {
+                    eflags.new_stream = true;
+                    eflags.clear_tx_queue = true;
+                    eflags.use_reset = true;
+
+                    messages::StreamHeaderSubGroup subgroup_hdr;
+                    subgroup_hdr.type = GetStreamMode();
+                    subgroup_hdr.group_id = object_headers.group_id;
+                    auto properties = messages::StreamHeaderProperties(subgroup_hdr.type);
+                    if (properties.subgroup_id_type == messages::SubgroupIdType::kExplicit) {
+                        subgroup_hdr.subgroup_id = object_headers.subgroup_id;
+                    }
+                    subgroup_hdr.priority = priority;
+                    subgroup_hdr.track_alias = GetTrackAlias().value();
+                    object_msg_buffer_ << subgroup_hdr;
+
+                    auto result = transport->Enqueue(
+                      GetConnectionId(),
+                      publish_data_ctx_id_,
+                      group_id,
+                      std::make_shared<std::vector<uint8_t>>(object_msg_buffer_.begin(), object_msg_buffer_.end()),
+                      priority,
+                      ttl,
+                      0,
+                      eflags);
+
+                    object_msg_buffer_.clear();
+                    eflags.new_stream = false;
+                    eflags.clear_tx_queue = false;
+                    eflags.use_reset = false;
+
+                    if (result != TransportError::kNone) {
+                        throw TransportException(result);
+                    }
+                }
+
+                messages::StreamSubGroupObject object;
+                object.object_id = object_id;
+                object.stream_type = GetStreamMode();
+                object.extensions = object_headers.extensions;
+                object.payload.assign(data.begin(), data.end());
+                object_msg_buffer_ << object;
+                break;
+            }
+        }
+
+        auto result = transport->Enqueue(
+          GetConnectionId(),
+          publish_data_ctx_id_,
+          group_id,
+          std::make_shared<std::vector<uint8_t>>(object_msg_buffer_.begin(), object_msg_buffer_.end()),
+          priority,
+          ttl,
+          0,
+          eflags);
+
+        if (result != TransportError::kNone) {
+            throw TransportException(result);
+        }
+
+        return PublishTrackHandler::PublishObjectStatus::kOk;
     }
 }

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -3,6 +3,8 @@
 
 #include <quicr/publish_track_handler.h>
 
+#include "quicr/detail/transport.h"
+
 namespace quicr {
     void PublishTrackHandler::StatusChanged(Status) {}
     void PublishTrackHandler::MetricsSampled(const PublishTrackMetrics&) {}
@@ -11,6 +13,12 @@ namespace quicr {
       bool is_new_stream,
       std::shared_ptr<const std::vector<uint8_t>> data)
     {
+        auto transport = GetTransport().lock();
+
+        if (!transport) {
+            return PublishObjectStatus::kInternalError;
+        }
+
         switch (publish_status_) {
             case Status::kOk:
                 break;
@@ -49,16 +57,49 @@ namespace quicr {
 
         publish_track_metrics_.bytes_published += data->size();
 
-        if (forward_publish_data_func_ != nullptr) {
-            return forward_publish_data_func_(default_priority_, latest_group_id_, default_ttl_, is_new_stream, data);
+        if (!GetRequestId().has_value()) {
+            return PublishTrackHandler::PublishObjectStatus::kNoSubscribers;
         }
 
-        return PublishObjectStatus::kInternalError;
+        ITransport::EnqueueFlags eflags;
+
+        switch (default_track_mode_) {
+            case TrackMode::kDatagram: {
+                eflags.use_reliable = false;
+                break;
+            }
+            default: {
+                eflags.use_reliable = true;
+
+                if (is_new_stream) {
+                    eflags.new_stream = true;
+                    eflags.clear_tx_queue = true;
+                    eflags.use_reset = true;
+                }
+
+                break;
+            }
+        }
+
+        auto result = transport->Enqueue(
+          GetConnectionId(), publish_data_ctx_id_, latest_group_id_, data, default_priority_, default_ttl_, 0, eflags);
+
+        if (result != TransportError::kNone) {
+            throw TransportException(result);
+        }
+
+        return PublishTrackHandler::PublishObjectStatus::kOk;
     }
 
     PublishTrackHandler::PublishObjectStatus PublishTrackHandler::PublishObject(const ObjectHeaders& object_headers,
                                                                                 BytesSpan data)
     {
+        auto transport = GetTransport().lock();
+
+        if (!transport) {
+            return PublishObjectStatus::kInternalError;
+        }
+
         bool is_stream_header_needed{ false };
 
         // change in subgroups and groups require a new stream
@@ -120,19 +161,97 @@ namespace quicr {
         publish_track_metrics_.bytes_published += data.size();
         publish_track_metrics_.objects_published++;
 
-        if (publish_object_func_ != nullptr) {
-            return publish_object_func_(object_headers.priority.has_value() ? object_headers.priority.value()
-                                                                            : default_priority_,
-                                        object_headers.ttl.has_value() ? object_headers.ttl.value() : default_ttl_,
-                                        is_stream_header_needed,
-                                        object_headers.group_id,
-                                        object_headers.subgroup_id,
-                                        object_headers.object_id,
-                                        object_headers.extensions,
-                                        data);
+        if (!GetRequestId().has_value()) {
+            return PublishTrackHandler::PublishObjectStatus::kNoSubscribers;
         }
 
-        return PublishObjectStatus::kInternalError;
+        ITransport::EnqueueFlags eflags;
+
+        std::uint64_t group_id = object_headers.group_id;
+        std::uint64_t object_id = object_headers.object_id;
+        std::uint16_t ttl = object_headers.ttl.has_value() ? object_headers.ttl.value() : default_ttl_;
+        std::uint8_t priority =
+          object_headers.priority.has_value() ? object_headers.priority.value() : default_priority_;
+
+        object_msg_buffer_.clear();
+
+        switch (default_track_mode_) {
+            case TrackMode::kDatagram: {
+                messages::ObjectDatagram object;
+                object.group_id = group_id;
+                object.object_id = object_headers.object_id;
+                object.priority = priority;
+                object.track_alias = GetTrackAlias().value();
+                object.extensions = object_headers.extensions;
+                object.payload.assign(data.begin(), data.end());
+                object_msg_buffer_ << object;
+                break;
+            }
+            default: {
+                // use stream per subgroup, group change
+                eflags.use_reliable = true;
+
+                if (is_stream_header_needed) {
+                    eflags.new_stream = true;
+                    eflags.clear_tx_queue = true;
+                    eflags.use_reset = true;
+
+                    messages::StreamHeaderSubGroup subgroup_hdr;
+                    subgroup_hdr.type = GetStreamMode();
+                    subgroup_hdr.group_id = object_headers.group_id;
+                    auto properties = messages::StreamHeaderProperties(subgroup_hdr.type);
+                    if (properties.subgroup_id_type == messages::SubgroupIdType::kExplicit) {
+                        subgroup_hdr.subgroup_id = object_headers.subgroup_id;
+                    }
+                    subgroup_hdr.priority = priority;
+                    subgroup_hdr.track_alias = GetTrackAlias().value();
+                    object_msg_buffer_ << subgroup_hdr;
+
+                    auto result = transport->Enqueue(
+                      GetConnectionId(),
+                      publish_data_ctx_id_,
+                      group_id,
+                      std::make_shared<std::vector<uint8_t>>(object_msg_buffer_.begin(), object_msg_buffer_.end()),
+                      priority,
+                      ttl,
+                      0,
+                      eflags);
+
+                    object_msg_buffer_.clear();
+                    eflags.new_stream = false;
+                    eflags.clear_tx_queue = false;
+                    eflags.use_reset = false;
+
+                    if (result != TransportError::kNone) {
+                        throw TransportException(result);
+                    }
+                }
+
+                messages::StreamSubGroupObject object;
+                object.object_id = object_id;
+                object.stream_type = GetStreamMode();
+                object.extensions = object_headers.extensions;
+                object.payload.assign(data.begin(), data.end());
+                object_msg_buffer_ << object;
+                break;
+            }
+        }
+
+        auto result = transport->Enqueue(
+          GetConnectionId(),
+          publish_data_ctx_id_,
+          group_id,
+          std::make_shared<std::vector<uint8_t>>(object_msg_buffer_.begin(), object_msg_buffer_.end()),
+          priority,
+          ttl,
+          0,
+          eflags);
+
+        if (result != TransportError::kNone) {
+            throw TransportException(result);
+        }
+
+        return PublishTrackHandler::PublishObjectStatus::kOk;
     }
 
 } // namespace quicr

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -163,6 +163,7 @@ namespace quicr {
             return;
         }
 
+        status_ = Status::kOk;
         transport->SendSubscribeUpdate(transport->GetConnectionContext(GetConnectionId()),
                                        GetRequestId().value(),
                                        GetFullTrackName(),

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -73,7 +73,8 @@ namespace quicr {
     }
 
     Transport::Transport(const ClientConfig& cfg, std::shared_ptr<TickService> tick_service)
-      : client_mode_(true)
+      : std::enable_shared_from_this<Transport>()
+      , client_mode_(true)
       , logger_(spdlog::stderr_color_mt("MTC"))
       , server_config_({})
       , client_config_(cfg)
@@ -85,7 +86,8 @@ namespace quicr {
     }
 
     Transport::Transport(const ServerConfig& cfg, std::shared_ptr<TickService> tick_service)
-      : client_mode_(false)
+      : std::enable_shared_from_this<Transport>()
+      , client_mode_(false)
       , logger_(spdlog::stderr_color_mt("MTS"))
       , server_config_(cfg)
       , client_config_({})
@@ -121,6 +123,10 @@ namespace quicr {
 
     Transport::Status Transport::Start()
     {
+        if (!weak_from_this().lock()) {
+            throw std::runtime_error("Transport is not shared_ptr");
+        }
+
         if (client_mode_) {
             TransportRemote relay;
             auto parse_result = ParseConnectUri(client_config_.connect_uri);
@@ -1077,38 +1083,8 @@ namespace quicr {
                                              track_handler->default_priority_,
                                              false);
 
-        // Setup the function for the track handler to use to send objects with thread safety
-        std::weak_ptr<PublishTrackHandler> weak_handler(track_handler);
-        track_handler->publish_object_func_ =
-          [&, weak_handler](uint8_t priority,
-                            uint32_t ttl,
-                            bool stream_header_needed,
-                            uint64_t group_id,
-                            uint64_t subgroup_id,
-                            uint64_t object_id,
-                            std::optional<Extensions> extensions,
-                            std::span<const uint8_t> data) -> PublishTrackHandler::PublishObjectStatus {
-            auto handler = weak_handler.lock();
-            if (!handler) {
-                return PublishTrackHandler::PublishObjectStatus::kInternalError;
-            }
-            return SendObject(
-              *handler, priority, ttl, stream_header_needed, group_id, subgroup_id, object_id, extensions, data);
-        };
-
-        track_handler->forward_publish_data_func_ =
-          [&,
-           weak_handler](uint8_t priority,
-                         uint64_t group_id,
-                         uint32_t ttl,
-                         bool stream_header_needed,
-                         std::shared_ptr<const std::vector<uint8_t>> data) -> PublishTrackHandler::PublishObjectStatus {
-            auto handler = weak_handler.lock();
-            if (!handler) {
-                return PublishTrackHandler::PublishObjectStatus::kInternalError;
-            }
-            return SendData(*handler, priority, group_id, ttl, stream_header_needed, data);
-        };
+        // Set this transport as the one for the publisher to use.
+        track_handler->SetTransport(GetSharedPtr());
 
         // Hold ref to track handler
         conn_it->second.pub_tracks_by_request_id[*track_handler->GetRequestId()] = track_handler;
@@ -1221,105 +1197,6 @@ namespace quicr {
                                                ttl,
                                                0,
                                                eflags);
-
-        if (result != TransportError::kNone) {
-            throw TransportException(result);
-        }
-
-        return PublishTrackHandler::PublishObjectStatus::kOk;
-    }
-
-    PublishTrackHandler::PublishObjectStatus Transport::SendObject(PublishTrackHandler& track_handler,
-                                                                   uint8_t priority,
-                                                                   uint32_t ttl,
-                                                                   bool stream_header_needed,
-                                                                   uint64_t group_id,
-                                                                   uint64_t subgroup_id,
-                                                                   uint64_t object_id,
-                                                                   std::optional<Extensions> extensions,
-                                                                   BytesSpan data)
-    {
-        if (!track_handler.GetRequestId().has_value()) {
-            return PublishTrackHandler::PublishObjectStatus::kNoSubscribers;
-        }
-
-        ITransport::EnqueueFlags eflags;
-
-        track_handler.object_msg_buffer_.clear();
-
-        switch (track_handler.default_track_mode_) {
-            case TrackMode::kDatagram: {
-                messages::ObjectDatagram object;
-                object.group_id = group_id;
-                object.object_id = object_id;
-                object.priority = priority;
-                object.track_alias = track_handler.GetTrackAlias().value();
-                object.extensions = extensions;
-                object.payload.assign(data.begin(), data.end());
-                track_handler.object_msg_buffer_ << object;
-                break;
-            }
-            default: {
-                // use stream per subgroup, group change
-                eflags.use_reliable = true;
-
-                if (stream_header_needed) {
-                    eflags.new_stream = true;
-                    eflags.clear_tx_queue = true;
-                    eflags.use_reset = true;
-
-                    messages::StreamHeaderSubGroup subgroup_hdr;
-                    subgroup_hdr.type = track_handler.GetStreamMode();
-                    subgroup_hdr.group_id = group_id;
-                    auto properties = StreamHeaderProperties(subgroup_hdr.type);
-                    if (properties.subgroup_id_type == SubgroupIdType::kExplicit) {
-                        subgroup_hdr.subgroup_id = subgroup_id;
-                    }
-                    subgroup_hdr.priority = priority;
-                    subgroup_hdr.track_alias = track_handler.GetTrackAlias().value();
-                    track_handler.object_msg_buffer_ << subgroup_hdr;
-
-                    auto result = quic_transport_->Enqueue(
-                      track_handler.connection_handle_,
-                      track_handler.publish_data_ctx_id_,
-                      group_id,
-                      std::make_shared<std::vector<uint8_t>>(track_handler.object_msg_buffer_.begin(),
-                                                             track_handler.object_msg_buffer_.end()),
-                      priority,
-                      ttl,
-                      0,
-                      eflags);
-
-                    track_handler.object_msg_buffer_.clear();
-                    eflags.new_stream = false;
-                    eflags.clear_tx_queue = false;
-                    eflags.use_reset = false;
-
-                    if (result != TransportError::kNone) {
-                        throw TransportException(result);
-                    }
-                }
-
-                messages::StreamSubGroupObject object;
-                object.object_id = object_id;
-                object.stream_type = track_handler.GetStreamMode();
-                object.extensions = extensions;
-                object.payload.assign(data.begin(), data.end());
-                track_handler.object_msg_buffer_ << object;
-                break;
-            }
-        }
-
-        auto result =
-          quic_transport_->Enqueue(track_handler.connection_handle_,
-                                   track_handler.publish_data_ctx_id_,
-                                   group_id,
-                                   std::make_shared<std::vector<uint8_t>>(track_handler.object_msg_buffer_.begin(),
-                                                                          track_handler.object_msg_buffer_.end()),
-                                   priority,
-                                   ttl,
-                                   0,
-                                   eflags);
 
         if (result != TransportError::kNone) {
             throw TransportException(result);
@@ -1874,4 +1751,25 @@ namespace quicr {
         }
     }
 
+    std::shared_ptr<Transport> quicr::Transport::GetSharedPtr()
+    {
+        if (!weak_from_this().lock()) {
+            throw std::runtime_error("Transport is not shared_ptr");
+        }
+
+        return shared_from_this();
+    }
+
+    TransportError Transport::Enqueue(const TransportConnId& conn_id,
+                                      const DataContextId& data_ctx_id,
+                                      std::uint64_t group_id,
+                                      std::shared_ptr<const std::vector<uint8_t>> bytes,
+                                      const uint8_t priority,
+                                      const uint32_t ttl_ms,
+                                      const uint32_t delay_ms,
+                                      const ITransport::EnqueueFlags flags)
+    {
+        return quic_transport_->Enqueue(
+          conn_id, data_ctx_id, group_id, std::move(bytes), priority, ttl_ms, delay_ms, flags);
+    }
 } // namespace moq

--- a/test/client.cpp
+++ b/test/client.cpp
@@ -9,7 +9,28 @@
 
 TEST_CASE("Multiple client creation")
 {
-    auto client = std::make_shared<quicr::Client>(quicr::ClientConfig());
-    client = nullptr;
-    client = std::make_shared<quicr::Client>(quicr::ClientConfig());
+    CHECK_NOTHROW({
+        auto client = quicr::Client::Create(quicr::ClientConfig());
+        client = nullptr;
+        client = quicr::Client::Create(quicr::ClientConfig());
+    });
+}
+
+TEST_CASE("Construction")
+{
+    CHECK_NOTHROW(quicr::Client::Create(quicr::ClientConfig()));
+}
+
+struct BadClient : public quicr::Client
+{
+    BadClient()
+      : quicr::Client(quicr::ClientConfig())
+    {
+    }
+};
+
+TEST_CASE("Construction Non-shared")
+{
+    BadClient client;
+    CHECK_THROWS(client.Connect());
 }

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -17,7 +17,7 @@ constexpr uint16_t kPort = 12345;
 const std::string kServerId = "test-server";
 constexpr std::chrono::milliseconds kDefaultTimeout(50);
 
-static std::unique_ptr<TestServer>
+static std::shared_ptr<TestServer>
 MakeTestServer()
 {
     // Run the server.
@@ -28,21 +28,21 @@ MakeTestServer()
     server_config.transport_config.debug = true;
     server_config.transport_config.tls_cert_filename = "server-cert.pem";
     server_config.transport_config.tls_key_filename = "server-key.pem";
-    auto server = std::make_unique<TestServer>(server_config);
+    auto server = std::make_shared<TestServer>(server_config);
     const auto starting = server->Start();
     CHECK_EQ(starting, Transport::Status::kReady);
     std::this_thread::sleep_for(std::chrono::milliseconds(kDefaultTimeout));
     return server;
 }
 
-std::unique_ptr<TestClient>
+std::shared_ptr<TestClient>
 MakeTestClient(const bool connect = true)
 {
     // Connect a client.
     ClientConfig client_config;
     client_config.transport_config.debug = true;
     client_config.connect_uri = "moq://" + kIp + ":" + std::to_string(kPort);
-    auto client = std::make_unique<TestClient>(client_config);
+    auto client = std::make_shared<TestClient>(client_config);
     if (connect) {
         client->Connect();
         std::this_thread::sleep_for(kDefaultTimeout);

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -138,7 +138,7 @@ TEST_CASE("Integration - Handlers with no transport")
                                   .track_mode = TrackMode::kStream,
                                   .extensions = std::nullopt };
         const auto status = handler->PublishObject(headers, std::vector<uint8_t>(1));
-        CHECK_EQ(status, PublishTrackHandler::PublishObjectStatus::kNotAnnounced);
+        CHECK_EQ(status, PublishTrackHandler::PublishObjectStatus::kInternalError);
     }
 
     // Fetch.


### PR DESCRIPTION
Remove function callback in publishers for sending data, and enforce that transport MUST be shared.