### PR TITLE
Fixup FETCH data plane logic

### DIFF
--- a/include/quicr/detail/messages.h
+++ b/include/quicr/detail/messages.h
@@ -475,7 +475,7 @@ namespace quicr::messages {
     struct FetchHeader
     {
         FetchHeaderType type{ FetchHeaderType::kFetchHeader };
-        uint64_t subscribe_id;
+        uint64_t request_id;
 
         template<class StreamBufferType>
         friend bool operator>>(StreamBufferType& buffer, FetchHeader& msg);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -117,7 +117,7 @@ namespace quicr {
             eflags.use_reset = true;
 
             messages::FetchHeader fetch_header{};
-            fetch_header.subscribe_id = request_id;
+            fetch_header.request_id = request_id;
             track_handler.object_msg_buffer_ << fetch_header;
 
             quic_transport_->Enqueue(track_handler.connection_handle_,

--- a/src/joining_fetch_handler.cpp
+++ b/src/joining_fetch_handler.cpp
@@ -13,7 +13,6 @@ namespace quicr {
 
             stream_buffer_.InitAny<messages::FetchHeader>();
             stream_buffer_.Push(*data);
-            stream_buffer_.Pop(); // Remove type header
 
             // Expect that on initial start of stream, there is enough data to process the stream headers
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -166,7 +166,7 @@ namespace quicr::messages {
                 [[fallthrough]];
             }
             case 1: {
-                if (!ParseUintVField(buffer, msg.subscribe_id)) {
+                if (!ParseUintVField(buffer, msg.request_id)) {
                     return false;
                 }
                 msg.current_pos += 1;
@@ -186,7 +186,7 @@ namespace quicr::messages {
     Bytes& operator<<(Bytes& buffer, const FetchHeader& msg)
     {
         buffer << UintVar(static_cast<uint64_t>(msg.type));
-        buffer << UintVar(msg.subscribe_id);
+        buffer << UintVar(msg.request_id);
         return buffer;
     }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -305,7 +305,7 @@ namespace quicr {
             eflags.use_reset = true;
 
             messages::FetchHeader fetch_header{};
-            fetch_header.subscribe_id = request_id;
+            fetch_header.request_id = request_id;
             track_handler.object_msg_buffer_ << fetch_header;
 
             quic_transport_->Enqueue(track_handler.connection_handle_,

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -331,7 +331,7 @@ FetchStreamEncodeDecode(bool extensions, bool empty_payload)
 
     Bytes buffer;
     auto fetch_header = messages::FetchHeader{};
-    fetch_header.subscribe_id = 0x1234;
+    fetch_header.request_id = 0x1234;
 
     buffer << fetch_header;
 
@@ -339,7 +339,7 @@ FetchStreamEncodeDecode(bool extensions, bool empty_payload)
     CHECK(Verify(buffer, fetch_header_out));
     CHECK_EQ(fetch_header.type, fetch_header_out.type);
     CHECK_EQ(fetch_header.type, FetchHeaderType::kFetchHeader);
-    CHECK_EQ(fetch_header.subscribe_id, fetch_header_out.subscribe_id);
+    CHECK_EQ(fetch_header.request_id, fetch_header_out.request_id);
 
     // stream all the objects
     buffer.clear();


### PR DESCRIPTION
With some recent changes it looks like the FETCH data plan was using the stream subgroup header format. This fixes that up. Our fetch integration test doesn't actually roundtrip data, so didn't catch this. 