### PR TITLE
Add timeouts to GitHub actions

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,6 +14,7 @@ jobs:
   format-check:
     name: Format Check
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: jidicula/clang-format-action@v4.13.0
@@ -31,6 +32,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     continue-on-error: true
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,6 +10,7 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
I've noticed that the macOS benchmark run seems to sometimes get stuck on completion - forever. Not sure what the root cause is, and need to have a look, but a 10 minute timeout seems reasonable to add right now so we're not burning actions minutes on nothing. 