### PR TITLE
Add basic client FETCH protocol support

### DIFF
--- a/include/quicr/detail/ctrl_message_types.h
+++ b/include/quicr/detail/ctrl_message_types.h
@@ -283,6 +283,12 @@ namespace quicr::messages {
         kNotSupported = 0x3,
         kTrackDoesNotExist = 0x4,
         kInvalidRange = 0x5,
+        kNoObjects = 0x6,
+        kInvalidJoiningRequestId = 0x7,
+        kUnknownStatusInRange = 0x8,
+        kMalformedTrack = 0x9,
+        kMalformedAuthToken = 0x10,
+        kExpiredAuthToken = 0x12
     };
 
     Bytes& operator<<(Bytes& buffer, FetchErrorCode value);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -794,7 +794,6 @@ namespace quicr {
                         const auto opt_largest_location = subscribe_state->second.largest_location;
                         if (!opt_largest_location.has_value()) {
                             // We have no data to complete the fetch with.
-                            // TODO: Possibly missing "No Objects" code per the draft.
                             SendFetchError(
                               conn_ctx, msg.request_id, messages::FetchErrorCode::kInvalidRange, "Nothing to give");
 
@@ -857,6 +856,7 @@ namespace quicr {
                 SendFetchOk(conn_ctx, msg.request_id, msg.group_order, end_of_track, largest_location);
 
                 if (!OnFetchOk(conn_ctx.connection_handle, msg.request_id, tfn, attrs)) {
+                    // TODO: Need more info from OnFetchOk to give a better error code.
                     SendFetchError(conn_ctx,
                                    msg.request_id,
                                    messages::FetchErrorCode::kInvalidRange,


### PR DESCRIPTION
Stub in some basic protocol support for relative FETCH to the client. This is effectively the same as what we have in server, so I do think this can be refactored up to transport and shared between the two, but this gets us to protocol interop I think. 