### PR TITLE
Fix gap extension double encode

### DIFF
--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -169,23 +169,27 @@ namespace quicr {
         auto object_extensions = object_headers.extensions;
 
         if (group_id_delta > 1) {
-            auto value = UintVar(group_id_delta - 1);
+            const std::uint64_t value = group_id_delta - 1;
+            std::vector<std::uint8_t> value_bytes(sizeof(value));
+            memcpy(value_bytes.data(), &value, sizeof(value));
             if (not object_extensions.has_value()) {
                 object_extensions = Extensions{};
             }
 
             object_extensions->try_emplace(static_cast<uint64_t>(messages::ExtensionHeaderType::kPriorGroupIdGap),
-                                           std::vector(value.begin(), value.end()));
+                                           value_bytes);
         }
 
         if (object_id_delta > 1) {
-            auto value = UintVar(object_id_delta - 1);
+            const std::uint64_t value = object_id_delta - 1;
+            std::vector<std::uint8_t> value_bytes(sizeof(value));
+            memcpy(value_bytes.data(), &value, sizeof(value));
             if (not object_extensions.has_value()) {
                 object_extensions = Extensions{};
             }
 
             object_extensions->try_emplace(static_cast<uint64_t>(messages::ExtensionHeaderType::kPriorObjectIdGap),
-                                           std::vector(value.begin(), value.end()));
+                                           value_bytes);
         }
 
         latest_group_id_ = object_headers.group_id;

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -24,6 +24,12 @@ TestServer::PublishReceived([[maybe_unused]] quicr::ConnectionHandle connection_
                             [[maybe_unused]] const quicr::FullTrackName& track_full_name,
                             [[maybe_unused]] const quicr::messages::PublishAttributes& publish_attributes)
 {
+    ResolvePublish(connection_handle,
+                   request_id,
+                   publish_attributes.forward,
+                   publish_attributes.priority,
+                   publish_attributes.group_order,
+                   {});
 }
 
 void


### PR DESCRIPTION
- Gap extensions were being double VarInt encoded. Extensions expects non-varint `std::uint64_t`s that it will compress on serialisation when the key is even. I would very much like to refactor to extensions to more strongly type this even/odd capability because this is an easy mistake to make. 
- Added a test that crashed on the bad behaviour, as well as real data roundtrip test, but this requires a test framework that can actually roundtrip data which we don't have yet, but I'd already written it so figured I'd leave it here. 