### PR TITLE
Switch to use picoquic network thread api

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -936,8 +936,8 @@ main(int argc, char* argv[])
         bool stop_threads{ false };
         auto client = MyClient::Create(config, stop_threads);
 
-        if (client->Connect() != quicr::Transport::Status::kConnecting) {
-            SPDLOG_ERROR("Failed to connect to server due to invalid params, check URI");
+        if (auto status = client->Connect(); status != quicr::Transport::Status::kConnecting) {
+            SPDLOG_ERROR("Failed to connect to server due to invalid params, check URI {}", static_cast<int>(status));
             exit(-1);
         }
 

--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -934,8 +934,8 @@ main(int argc, char* argv[])
         bool stop_threads{ false };
         auto client = MyClient::Create(config, stop_threads);
 
-        if (auto status = client->Connect(); status != quicr::Transport::Status::kConnecting) {
-            SPDLOG_ERROR("Failed to connect to server due to invalid params, check URI {}", static_cast<int>(status));
+        if (client->Connect() != quicr::Transport::Status::kConnecting) {
+            SPDLOG_ERROR("Failed to connect to server due to invalid params, check URI");
             exit(-1);
         }
 

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -88,26 +88,23 @@ namespace quicr {
      */
     struct TransportConfig
     {
-        std::string tls_cert_filename;               /// QUIC TLS certificate to use
-        std::string tls_key_filename;                /// QUIC TLS private key to use
-        uint32_t time_queue_init_queue_size{ 1000 }; /// Initial queue size to reserve upfront
-        uint32_t time_queue_max_duration{ 2000 };    /// Max duration for the time queue in milliseconds
-        uint32_t time_queue_bucket_interval{ 1 };    /// The bucket interval in milliseconds
-        uint32_t time_queue_rx_size{ 1000 };         /// Receive queue size
-        bool debug{ false };                         /// Enable debug logging/processing
-        uint64_t quic_cwin_minimum{ 131072 };        /// QUIC congestion control minimum size (default is 128k)
-        uint32_t quic_wifi_shadow_rtt_us{ 20000 };   /// QUIC wifi shadow RTT in microseconds
-
-        uint64_t pacing_decrease_threshold_bps{ 16000 }; /// QUIC pacing rate decrease threshold for notification in Bps
-        uint64_t pacing_increase_threshold_bps{ 16000 }; /// QUIC pacing rate increase threshold for notification in Bps
-
-        uint64_t idle_timeout_ms{ 30000 };     /// Idle timeout for transport connection(s) in milliseconds
-        bool use_reset_wait_strategy{ false }; /// Use Reset and wait strategy for congestion control
-        bool use_bbr{ true };                  /// Use BBR if true, NewReno if false
-        std::string quic_qlog_path;            /// If present, log QUIC LOG file to this path
-        uint8_t quic_priority_limit{ 0 };      /// Lowest priority that will not be bypassed from pacing/CC in picoquic
-        std::size_t max_connections{ 1 };
-        bool ssl_keylog{ false }; ///< Enable SSL key logging for QUIC connections
+        std::string tls_cert_filename;               ///< QUIC TLS certificate to use
+        std::string tls_key_filename;                ///< QUIC TLS private key to use
+        uint32_t time_queue_init_queue_size{ 1000 }; ///< Initial queue size to reserve upfront
+        uint32_t time_queue_max_duration{ 2000 };    ///< Max duration for the time queue in milliseconds
+        uint32_t time_queue_bucket_interval{ 1 };    ///< The bucket interval in milliseconds
+        uint32_t time_queue_rx_size{ 1000 };         ///< Receive queue size
+        bool debug{ false };                         ///< Enable debug logging/processing
+        uint64_t quic_cwin_minimum{ 131072 };        ///< QUIC congestion control minimum size (default is 128k)
+        uint32_t quic_wifi_shadow_rtt_us{ 20000 };   ///< QUIC wifi shadow RTT in microseconds
+        uint64_t idle_timeout_ms{ 30000 };           ///< Idle timeout for transport connection(s) in milliseconds
+        bool use_reset_wait_strategy{ false };       ///< Use Reset and wait strategy for congestion control
+        bool use_bbr{ true };                        ///< Use BBR if true, NewReno if false
+        std::string quic_qlog_path;                  ///< If present, log QUIC LOG file to this path
+        uint8_t quic_priority_limit{ 0 }; ///< Lowest priority that will not be bypassed from pacing/CC in picoquic
+        std::size_t max_connections{ 1 }; ///< Max number of active QUIC connections per QUIC instance
+        bool ssl_keylog{ false };         ///< Enable SSL key logging for QUIC connections
+        std::size_t socket_buffer_size{ 1'000'000 }; ///< QUIC UDP socket buffer size
     };
 
     /// Stream action that should be done by send/receive processing

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -143,6 +143,12 @@ namespace quicr {
 
             auto conn_id = quic_transport_->Start();
 
+            if (!conn_id) { // Error, connection ID should always be greater than one
+                SPDLOG_LOGGER_ERROR(logger_, "Client connection failed");
+                status_ = Status::kFailedToConnect;
+                return status_;
+            }
+
             SetConnectionHandle(conn_id);
 
             status_ = Status::kConnecting;

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1665,6 +1665,7 @@ PicoQuicTransport::Server()
       picoquic_start_network_thread(quic_ctx_, &quic_network_thread_params_, PqLoopCb, this, &quic_loop_return_value_);
 
     if (quic_ctx_ == NULL || quic_network_thread_ctx_ == NULL) {
+        SPDLOG_LOGGER_ERROR(logger, "Failed to start picoquic network thread");
         picoquic_free(quic_ctx_);
         quic_ctx_ = NULL;
         SetStatus(TransportStatus::kShutdown);
@@ -1672,7 +1673,7 @@ PicoQuicTransport::Server()
 
     // Wait for something to happen with the thread
     while (!quic_network_thread_ctx_->thread_is_ready && !quic_network_thread_ctx_->return_code) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
     if (quic_network_thread_ctx_->return_code) {

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1657,7 +1657,7 @@ PicoQuicTransport::Server()
     quic_network_thread_params_.local_port = serverInfo_.port;
     quic_network_thread_params_.local_af = PF_UNSPEC;
     quic_network_thread_params_.dest_if = 0;
-    quic_network_thread_params_.socket_buffer_size = 2000000;
+    quic_network_thread_params_.socket_buffer_size = tconfig_.socket_buffer_size;
     quic_network_thread_params_.do_not_use_gso = 0;
 
     SPDLOG_LOGGER_DEBUG(logger, "Starting picoquic network thread");
@@ -1673,7 +1673,7 @@ PicoQuicTransport::Server()
 
     // Wait for something to happen with the thread
     while (!quic_network_thread_ctx_->thread_is_ready && !quic_network_thread_ctx_->return_code) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 
     if (quic_network_thread_ctx_->return_code) {
@@ -1682,8 +1682,6 @@ PicoQuicTransport::Server()
         SetStatus(TransportStatus::kShutdown);
         return;
     }
-
-    SetStatus(TransportStatus::kReady);
 }
 
 TransportConnId

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1701,7 +1701,7 @@ PicoQuicTransport::StartClient()
     std::unique_lock lock(mtx);
 
     picoquic_runner_queue_.Push([this, &conn_id, &cv, &mtx]() {
-        auto notifyCaller = [&cv, &conn_id, &mtx](uint64_t id) {
+        auto notify_caller = [&cv, &conn_id, &mtx](uint64_t id) {
             std::lock_guard _(mtx);
             conn_id = id;
 
@@ -1718,7 +1718,7 @@ PicoQuicTransport::StartClient()
         if (ret != 0 || server_address.ss_family == 0) {
             SPDLOG_LOGGER_ERROR(
               logger, "Failed to resolve server: {0} port: {1}", serverInfo_.host_or_ip, serverInfo_.port);
-            notifyCaller(1);
+            notify_caller(1);
             return 0;
         }
 
@@ -1738,7 +1738,7 @@ PicoQuicTransport::StartClient()
 
         if (cnx == nullptr) {
             SPDLOG_LOGGER_ERROR(logger, "Could not create picoquic connection client context");
-            notifyCaller(1);
+            notify_caller(1);
 
             return PICOQUIC_ERROR_DISCONNECTED;
         }
@@ -1750,7 +1750,7 @@ PicoQuicTransport::StartClient()
 
         if (auto ret = picoquic_start_client_cnx(cnx)) {
             SPDLOG_LOGGER_ERROR(logger, "Could not activate connection ret: {}", ret);
-            notifyCaller(1);
+            notify_caller(1);
             return PICOQUIC_ERROR_DISCONNECTED;
         }
 
@@ -1764,7 +1764,7 @@ PicoQuicTransport::StartClient()
             SPDLOG_LOGGER_INFO(logger, "No priority bypass");
         }
 
-        notifyCaller(reinterpret_cast<uint64_t>(cnx));
+        notify_caller(reinterpret_cast<uint64_t>(cnx));
 
         return 0;
     });

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1660,7 +1660,7 @@ PicoQuicTransport::Server()
     quic_network_thread_params_.socket_buffer_size = 2000000;
     quic_network_thread_params_.do_not_use_gso = 0;
 
-    // int ret = picoquic_packet_loop(quic_ctx_, serverInfo_.port, PF_UNSPEC, 0, 2000000, 0, PqLoopCb, this);
+    SPDLOG_LOGGER_DEBUG(logger, "Starting picoquic network thread");
     quic_network_thread_ctx_ =
       picoquic_start_network_thread(quic_ctx_, &quic_network_thread_params_, PqLoopCb, this, &quic_loop_return_value_);
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -30,6 +30,7 @@
 #include <arpa/inet.h>
 #include <cassert>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <ctime>
@@ -338,8 +339,6 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
         return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
     }
 
-    transport->PqRunner();
-
     switch (cb_mode) {
         case picoquic_packet_loop_ready: {
             SPDLOG_LOGGER_INFO(transport->logger, "packet_loop_ready, waiting for packets");
@@ -424,6 +423,10 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
 
             break;
         }
+
+        case picoquic_packet_loop_wake_up:
+            transport->PqRunner();
+            break;
 
         default:
             // ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
@@ -518,14 +521,13 @@ PicoQuicTransport::Start()
     if (is_server_mode) {
 
         SPDLOG_LOGGER_INFO(logger, "Starting server, listening on {0}:{1}", serverInfo_.host_or_ip, serverInfo_.port);
-
-        picoQuicThread_ = std::thread(&PicoQuicTransport::Server, this);
+        Server();
 
     } else {
         SPDLOG_LOGGER_INFO(logger, "Connecting to server {0}:{1}", serverInfo_.host_or_ip, serverInfo_.port);
 
-        if ((cid = CreateClient())) {
-            picoQuicThread_ = std::thread(&PicoQuicTransport::Client, this, cid);
+        if (ClientLoop()) {
+            cid = StartClient();
         }
     }
 
@@ -611,7 +613,12 @@ PicoQuicTransport::Enqueue(const TransportConnId& conn_id,
         if (!data_ctx_it->second.mark_stream_active) {
             data_ctx_it->second.mark_stream_active = true;
 
-            picoquic_runner_queue_.Push([this, conn_id, data_ctx_id]() { MarkStreamActive(conn_id, data_ctx_id); });
+            picoquic_runner_queue_.Push([this, conn_id, data_ctx_id]() {
+                MarkStreamActive(conn_id, data_ctx_id);
+                return 0;
+            });
+
+            picoquic_wake_up_network_thread(quic_network_thread_ctx_);
         }
     } else { // datagram
         ConnData cd{ conn_id,          data_ctx_id,
@@ -622,7 +629,11 @@ PicoQuicTransport::Enqueue(const TransportConnId& conn_id,
         if (!conn_ctx_it->second.mark_dgram_ready) {
             conn_ctx_it->second.mark_dgram_ready = true;
 
-            picoquic_runner_queue_.Push([this, conn_id]() { MarkDgramReady(conn_id); });
+            picoquic_runner_queue_.Push([this, conn_id]() {
+                MarkDgramReady(conn_id);
+                return 0;
+            });
+            picoquic_wake_up_network_thread(quic_network_thread_ctx_);
         }
     }
 
@@ -823,7 +834,9 @@ PicoQuicTransport::SetStreamIdDataCtxId(const TransportConnId conn_id, DataConte
     picoquic_runner_queue_.Push([=]() {
         if (conn_it->second.pq_cnx != nullptr)
             picoquic_set_app_stream_ctx(conn_it->second.pq_cnx, stream_id, &data_ctx_it->second);
+        return 0;
     });
+    picoquic_wake_up_network_thread(quic_network_thread_ctx_);
 }
 
 /* ============================================================================
@@ -847,6 +860,9 @@ PicoQuicTransport::GetConnContext(const TransportConnId& conn_id)
 PicoQuicTransport::ConnectionContext&
 PicoQuicTransport::CreateConnContext(picoquic_cnx_t* pq_cnx)
 {
+    /*
+     * @note: This is thread safe because picoquic network thread is the only one that calls this
+     */
 
     auto [conn_it, is_new] = conn_context_.emplace(reinterpret_cast<TransportConnId>(pq_cnx), pq_cnx);
 
@@ -985,24 +1001,29 @@ PicoQuicTransport::CreateDataContextBiDirRecv(TransportConnId conn_id, uint64_t 
     return nullptr;
 }
 
-void
+int
 PicoQuicTransport::PqRunner()
 {
 
     if (picoquic_runner_queue_.Empty()) {
-        return;
+        return 0;
     }
 
     // note: check before running move of optional, which is more CPU taxing when empty
     while (auto cb = picoquic_runner_queue_.Pop()) {
         try {
-            (*cb)();
+            if (auto ret = (*cb)()) {
+                SPDLOG_LOGGER_ERROR(logger, "PQ function resulted in error: {}", ret);
+                return ret;
+            }
         } catch (const std::exception& e) {
             SPDLOG_LOGGER_ERROR(
               logger, "Caught exception running callback via notify thread (error={}), ignoring", e.what());
             // TODO(tievens): Add metrics to track if this happens
         }
     }
+
+    return 0;
 }
 
 void
@@ -1035,7 +1056,11 @@ PicoQuicTransport::DeleteDataContext(const TransportConnId& conn_id, DataContext
      * Race conditions exist with picoquic thread callbacks that will cause a problem if the context (pointer context)
      *    is deleted outside of the picoquic thread. Below schedules the delete to be done within the picoquic thread.
      */
-    picoquic_runner_queue_.Push([this, conn_id, data_ctx_id]() { DeleteDataContextInternal(conn_id, data_ctx_id); });
+    picoquic_runner_queue_.Push([this, conn_id, data_ctx_id]() {
+        DeleteDataContextInternal(conn_id, data_ctx_id);
+        return 0;
+    });
+    picoquic_wake_up_network_thread(quic_network_thread_ctx_);
 }
 
 void
@@ -1091,7 +1116,11 @@ PicoQuicTransport::SendNextDatagram(ConnectionContext* conn_ctx, uint8_t* bytes_
                 std::memcpy(buf, out_data.value.data->data(), out_data.value.data->size());
             }
         } else {
-            picoquic_runner_queue_.Push([this, conn_id = conn_ctx->conn_id]() { MarkDgramReady(conn_id); });
+            picoquic_runner_queue_.Push([this, conn_id = conn_ctx->conn_id]() {
+                MarkDgramReady(conn_id);
+                return 0;
+            });
+            picoquic_wake_up_network_thread(quic_network_thread_ctx_);
 
             /* TODO(tievens): picoquic_prepare_stream_and_datagrams() appears to ignore the
              *     below unless data was sent/provided
@@ -1210,9 +1239,13 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, uint8_t* bytes_ctx, si
         if (obj.has_value) {
             data_ctx->metrics.tx_queue_discards++;
 
-            picoquic_runner_queue_.Push([this, conn_id = data_ctx->conn_id, data_ctx_id = data_ctx->data_ctx_id]() {
-                MarkStreamActive(conn_id, data_ctx_id);
-            });
+            if (!data_ctx->tx_data->Empty()) {
+                picoquic_runner_queue_.Push([this, conn_id = data_ctx->conn_id, data_ctx_id = data_ctx->data_ctx_id]() {
+                    MarkStreamActive(conn_id, data_ctx_id);
+                    picoquic_wake_up_network_thread(quic_network_thread_ctx_);
+                    return 0;
+                });
+            }
         }
 
         data_ctx->mark_stream_active = false;
@@ -1340,15 +1373,13 @@ PicoQuicTransport::OnNewConnection(const TransportConnId conn_id)
     SPDLOG_LOGGER_INFO(
       logger, "New Connection {0} port: {1} conn_id: {2}", conn_ctx->peer_addr_text, conn_ctx->peer_port, conn_id);
 
-    //    picoquic_subscribe_pacing_rate_updates(conn_ctx->pq_cnx, tconfig.pacing_decrease_threshold_Bps,
-    //                                           tconfig.pacing_increase_threshold_Bps);
-
     TransportRemote remote{ .host_or_ip = conn_ctx->peer_addr_text,
                             .port = conn_ctx->peer_port,
                             .proto = TransportProtocol::kQuic };
 
     picoquic_enable_keep_alive(conn_ctx->pq_cnx, tconfig_.idle_timeout_ms * 500);
     picoquic_set_feedback_loss_notification(conn_ctx->pq_cnx, 1);
+    picoquic_set_callback(conn_ctx->pq_cnx, PqEventCb, this);
 
     if (tconfig_.quic_priority_limit > 0) {
         SPDLOG_LOGGER_INFO(
@@ -1629,121 +1660,172 @@ PicoQuicTransport::CheckConnsForCongestion()
 void
 PicoQuicTransport::Server()
 {
-    int ret = picoquic_packet_loop(quic_ctx_, serverInfo_.port, PF_UNSPEC, 0, 2000000, 0, PqLoopCb, this);
 
-    if (quic_ctx_ != NULL) {
+    quic_network_thread_params_.local_port = serverInfo_.port;
+    quic_network_thread_params_.local_af = PF_UNSPEC;
+    quic_network_thread_params_.dest_if = 0;
+    quic_network_thread_params_.socket_buffer_size = 2000000;
+    quic_network_thread_params_.do_not_use_gso = 0;
+
+    // int ret = picoquic_packet_loop(quic_ctx_, serverInfo_.port, PF_UNSPEC, 0, 2000000, 0, PqLoopCb, this);
+    quic_network_thread_ctx_ =
+      picoquic_start_network_thread(quic_ctx_, &quic_network_thread_params_, PqLoopCb, this, &quic_loop_return_value_);
+
+    if (quic_ctx_ == NULL || quic_network_thread_ctx_ == NULL) {
         picoquic_free(quic_ctx_);
         quic_ctx_ = NULL;
+        SetStatus(TransportStatus::kShutdown);
     }
 
-    SPDLOG_LOGGER_INFO(logger, "picoquic packet loop ended with {0}", ret);
-
-    SetStatus(TransportStatus::kShutdown);
-}
-
-TransportConnId
-PicoQuicTransport::CreateClient()
-{
-    struct sockaddr_storage server_address;
-    char const* sni = "cisco.webex.com";
-    int ret;
-
-    int is_name = 0;
-
-    ret = picoquic_get_server_address(serverInfo_.host_or_ip.c_str(), serverInfo_.port, &server_address, &is_name);
-    if (ret != 0 || server_address.ss_family == 0) {
-        SPDLOG_LOGGER_ERROR(logger, "Failed to get server: {0} port: {1}", serverInfo_.host_or_ip, serverInfo_.port);
-        SetStatus(TransportStatus::kDisconnected);
-        OnConnectionStatus(0, TransportStatus::kShutdown);
-        return 0;
-    } else if (is_name) {
-        sni = serverInfo_.host_or_ip.c_str();
+    // Wait for something to happen with the thread
+    while (!quic_network_thread_ctx_->thread_is_ready && !quic_network_thread_ctx_->return_code) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    if (tconfig_.use_bbr) {
-        picoquic_set_default_congestion_algorithm(quic_ctx_, picoquic_bbr_algorithm);
-    } else {
-        picoquic_set_default_congestion_algorithm(quic_ctx_, picoquic_newreno_algorithm);
-    }
-
-    uint64_t current_time = picoquic_current_time();
-
-    picoquic_cnx_t* cnx = picoquic_create_cnx(quic_ctx_,
-                                              picoquic_null_connection_id,
-                                              picoquic_null_connection_id,
-                                              reinterpret_cast<struct sockaddr*>(&server_address),
-                                              current_time,
-                                              0,
-                                              sni,
-                                              config_.alpn,
-                                              1);
-
-    if (cnx == NULL) {
-        SPDLOG_LOGGER_ERROR(logger, "Could not create picoquic connection client context");
-        return 0;
-    }
-
-    // Using default TP
-    picoquic_set_transport_parameters(cnx, &local_tp_options_);
-    picoquic_set_feedback_loss_notification(cnx, 1);
-
-    if (tconfig_.quic_priority_limit > 0) {
-        SPDLOG_LOGGER_INFO(
-          logger, "Setting priority bypass limit to {0}", static_cast<int>(tconfig_.quic_priority_limit));
-        picoquic_set_priority_limit_for_bypass(cnx, tconfig_.quic_priority_limit);
-    } else {
-        SPDLOG_LOGGER_INFO(logger, "No priority bypass");
-    }
-
-    //    picoquic_subscribe_pacing_rate_updates(cnx, tconfig.pacing_decrease_threshold_Bps,
-    //                                           tconfig.pacing_increase_threshold_Bps);
-
-    CreateConnContext(cnx);
-
-    return reinterpret_cast<uint64_t>(cnx);
-}
-
-void
-PicoQuicTransport::Client(const TransportConnId conn_id)
-{
-    int ret;
-
-    auto conn_ctx = GetConnContext(conn_id);
-
-    if (conn_ctx == nullptr) {
-        SPDLOG_LOGGER_ERROR(logger, "Client connection does not exist, check connection settings.");
-        SetStatus(TransportStatus::kDisconnected);
+    if (quic_network_thread_ctx_->return_code) {
+        SPDLOG_LOGGER_ERROR(
+          logger, "Could not start client quic network thread error: {}", quic_network_thread_ctx_->return_code);
+        SetStatus(TransportStatus::kShutdown);
         return;
     }
 
-    SPDLOG_LOGGER_INFO(logger, "Thread client packet loop for client conn_id: {0}", conn_id);
+    SetStatus(TransportStatus::kReady);
+}
 
-    if (conn_ctx->pq_cnx == NULL) {
-        SPDLOG_LOGGER_ERROR(logger, "Could not create picoquic connection client context");
-    } else {
-        picoquic_set_callback(conn_ctx->pq_cnx, PqEventCb, this);
+TransportConnId
+PicoQuicTransport::StartClient()
+{
+    std::condition_variable cv;
+    TransportConnId conn_id{ 0 };
+    std::mutex mtx;
+    std::unique_lock lock(mtx);
 
-        picoquic_enable_keep_alive(conn_ctx->pq_cnx, tconfig_.idle_timeout_ms * 500);
-        ret = picoquic_start_client_cnx(conn_ctx->pq_cnx);
-        if (ret < 0) {
-            SPDLOG_LOGGER_ERROR(logger, "Could not activate connection");
-            return;
+    picoquic_runner_queue_.Push([this, &conn_id, &cv, &mtx]() {
+        auto notifyCaller = [&cv, &conn_id, &mtx](uint64_t id) {
+            std::lock_guard _(mtx);
+            conn_id = id;
+
+            // Notify calling thread of connection Id
+            cv.notify_all();
+        };
+
+        sockaddr_storage server_address;
+        char const* sni = "cisco.webex.com";
+        int ret;
+        int is_name = 0;
+
+        ret = picoquic_get_server_address(serverInfo_.host_or_ip.c_str(), serverInfo_.port, &server_address, &is_name);
+        if (ret != 0 || server_address.ss_family == 0) {
+            SPDLOG_LOGGER_ERROR(
+              logger, "Failed to resolve server: {0} port: {1}", serverInfo_.host_or_ip, serverInfo_.port);
+            notifyCaller(1);
+            return 0;
         }
+
+        if (is_name) {
+            sni = serverInfo_.host_or_ip.c_str();
+        }
+
+        picoquic_cnx_t* cnx = picoquic_create_cnx(quic_ctx_,
+                                                  picoquic_null_connection_id,
+                                                  picoquic_null_connection_id,
+                                                  reinterpret_cast<struct sockaddr*>(&server_address),
+                                                  picoquic_current_time(),
+                                                  0,
+                                                  sni,
+                                                  config_.alpn,
+                                                  1);
+
+        if (cnx == nullptr) {
+            SPDLOG_LOGGER_ERROR(logger, "Could not create picoquic connection client context");
+            notifyCaller(1);
+
+            return PICOQUIC_ERROR_DISCONNECTED;
+        }
+
+        picoquic_set_transport_parameters(cnx, &local_tp_options_);
+        picoquic_set_feedback_loss_notification(cnx, 1);
+        picoquic_enable_keep_alive(cnx, tconfig_.idle_timeout_ms * 500);
+        picoquic_set_callback(cnx, PqEventCb, this);
+
+        if (auto ret = picoquic_start_client_cnx(cnx)) {
+            SPDLOG_LOGGER_ERROR(logger, "Could not activate connection ret: {}", ret);
+            notifyCaller(1);
+            return PICOQUIC_ERROR_DISCONNECTED;
+        }
+
+        CreateConnContext(cnx);
+
+        if (tconfig_.quic_priority_limit > 0) {
+            SPDLOG_LOGGER_INFO(
+              logger, "Setting priority bypass limit to {0}", static_cast<int>(tconfig_.quic_priority_limit));
+            picoquic_set_priority_limit_for_bypass(cnx, tconfig_.quic_priority_limit);
+        } else {
+            SPDLOG_LOGGER_INFO(logger, "No priority bypass");
+        }
+
+        notifyCaller(reinterpret_cast<uint64_t>(cnx));
+
+        return 0;
+    });
+
+    picoquic_wake_up_network_thread(quic_network_thread_ctx_);
+
+    SPDLOG_LOGGER_DEBUG(logger, "Waiting for client connection context");
+
+    cv.wait_for(lock, std::chrono::milliseconds(3000), [&]() { return conn_id > 0; });
+
+    SPDLOG_LOGGER_DEBUG(logger, "Got client connection context conn_id: {}", conn_id);
+    if (conn_id <= 1) {
+        SPDLOG_LOGGER_DEBUG(logger, "Client connection to {}:{} failed", serverInfo_.host_or_ip, serverInfo_.port);
+        SetStatus(TransportStatus::kDisconnected);
+        return 0;
+    }
+
+    picoquic_wake_up_network_thread(quic_network_thread_ctx_);
+
+    return conn_id;
+}
+
+bool
+PicoQuicTransport::ClientLoop()
+{
+    SPDLOG_LOGGER_INFO(logger, "Thread client packet loop starting");
+
+    quic_network_thread_params_.local_port = 0;
+    quic_network_thread_params_.local_af = PF_UNSPEC;
+    quic_network_thread_params_.dest_if = 0;
+    quic_network_thread_params_.socket_buffer_size = 2'000'000;
+    quic_network_thread_params_.do_not_use_gso = 0;
+
 #ifdef ESP_PLATFORM
-        ret = picoquic_packet_loop(quic_ctx_, 0, PF_UNSPEC, 0, 0x2048, 0, PqLoopCb, this);
-#else
-        ret = picoquic_packet_loop(quic_ctx_, 0, PF_UNSPEC, 0, 2000000, 0, PqLoopCb, this);
+    quic_network_thread_params_.socket_buffer_size = 0x2048;
 #endif
 
-        SPDLOG_LOGGER_INFO(logger, "picoquic ended with {0}", ret);
-    }
+    quic_network_thread_ctx_ =
+      picoquic_start_network_thread(quic_ctx_, &quic_network_thread_params_, PqLoopCb, this, &quic_loop_return_value_);
 
-    if (quic_ctx_ != NULL) {
+    if (quic_ctx_ == nullptr || quic_network_thread_ctx_ == nullptr) {
+        SPDLOG_LOGGER_ERROR(logger, "Failed to create picoquic network thread");
         picoquic_free(quic_ctx_);
-        quic_ctx_ = NULL;
+        quic_ctx_ = nullptr;
+        return false;
     }
 
-    SetStatus(TransportStatus::kDisconnected);
+    // Wait for something to happen with the thread
+    while (!quic_network_thread_ctx_->thread_is_ready && !quic_network_thread_ctx_->return_code) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    if (quic_network_thread_ctx_->return_code) {
+        SPDLOG_LOGGER_ERROR(
+          logger, "Could not start client quic network thread error: {}", quic_network_thread_ctx_->return_code);
+        return false;
+    }
+
+    SPDLOG_LOGGER_DEBUG(logger, "Thread client packet loop started");
+
+    return true;
 }
 
 void
@@ -1754,9 +1836,9 @@ PicoQuicTransport::Shutdown()
 
     stop_ = true;
 
-    if (picoQuicThread_.joinable()) {
+    if (quic_network_thread_ctx_ != NULL) {
         SPDLOG_LOGGER_INFO(logger, "Closing transport pico thread");
-        picoQuicThread_.join();
+        picoquic_delete_network_thread(quic_network_thread_ctx_);
     }
 
     picoquic_runner_queue_.StopWaiting();
@@ -1854,7 +1936,9 @@ PicoQuicTransport::CreateStream(ConnectionContext& conn_ctx, DataContext* data_c
 
     picoquic_runner_queue_.Push([this, conn_id = conn_ctx.conn_id, data_ctx_id = data_ctx->data_ctx_id]() {
         MarkStreamActive(conn_id, data_ctx_id);
+        return 0;
     });
+    picoquic_wake_up_network_thread(quic_network_thread_ctx_);
 }
 
 void

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -325,7 +325,7 @@ namespace quicr {
         void Server();
         bool ClientLoop();
         void CbNotifier();
-
+        void RunPqFunction(std::function<int()>&& function);
         void CheckCallbackDelta(DataContext* data_ctx, bool tx = true);
 
         /**

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -33,7 +33,7 @@
 
 namespace quicr {
 
-    constexpr int kPqLoopMaxDelayUs = 500;            /// The max microseconds that pq_loop will be ran again
+    constexpr int kPqLoopMaxDelayUs = 5000;           /// The max microseconds that pq_loop will be ran again
     constexpr int kPqRestWaitMinPriority = 4;         /// Minimum priority value to consider for RESET and WAIT
     constexpr int kPqCcLowCwin = 4000;                /// Bytes less than this value are considered a low/congested CWIN
     constexpr int kCongestionCheckInterval = 100'000; /// Congestion check interval in microseconds
@@ -299,13 +299,16 @@ namespace quicr {
         bool StreamActionCheck(DataContext* data_ctx, StreamAction stream_action);
 
         /**
-         * @brief Function run the queue functions within the picoquic thread via the pq_loop_cb
+         * @brief Function to run the queue functions within the picoquic thread via the pq_loop_cb
          *
          * @details Function runs the picoquic specific functions in the same thread that runs the
          *      the event loop. This allows picoquic to be thread safe.  All picoquic functions that
-         *      other threads want to call should queue those in `picoquic_runner_queue`.
+         *      other threads want to call should queue those so they can be ran via
+         *      the loop callback picoquic_packet_loop_wake_up
+         *
+         * @returns PIOCOQUIC error code, or ZERO if no error
          */
-        void PqRunner();
+        int PqRunner();
 
         /*
          * Internal Public Variables
@@ -316,11 +319,11 @@ namespace quicr {
         bool debug{ false };
 
       private:
-        TransportConnId CreateClient();
+        TransportConnId StartClient();
         void Shutdown();
 
         void Server();
-        void Client(TransportConnId conn_id);
+        bool ClientLoop();
         void CbNotifier();
 
         void CheckCallbackDelta(DataContext* data_ctx, bool tx = true);
@@ -363,16 +366,18 @@ namespace quicr {
          */
         picoquic_quic_config_t config_;
         picoquic_quic_t* quic_ctx_;
+        picoquic_network_thread_ctx_t* quic_network_thread_ctx_;
+        picoquic_packet_loop_param_t quic_network_thread_params_;
+        int quic_loop_return_value_{ 0 };
         picoquic_tp_t local_tp_options_;
         SafeQueue<std::function<void()>> cbNotifyQueue_;
 
-        SafeQueue<std::function<void()>>
-          picoquic_runner_queue_; /// Threads queue functions that picoquic will call via the pq_loop_cb call
+        /// Threads queue functions that picoquic will call via the pq_loop callback
+        SafeQueue<std::function<int()>> picoquic_runner_queue_;
 
         std::atomic<bool> stop_;
         std::mutex state_mutex_; /// Used for stream/context/state updates
         std::atomic<TransportStatus> transportStatus_;
-        std::thread picoQuicThread_;
         std::thread cbNotifyThread_;
 
         TransportRemote serverInfo_;


### PR DESCRIPTION
This moves from libquicr created picoquic thread to picoquic creating the thread instead.  The advantage with this is that picoquic enables faster loop notifications than having to run the loop in a fast 500us loop.  This performs better and improves latency.

The changes also support adding multiple clients using the same quic instance. This will help dramatically with peering so that each outbound peer connection is not creating a new quic context. Another PR will expand on the client changes using network thread to expose a connect and disconnect API with the client.   

Resolves #697
