### PR TITLE
Fix non-zero initialisation

### DIFF
--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1653,12 +1653,15 @@ PicoQuicTransport::CheckConnsForCongestion()
 void
 PicoQuicTransport::Server()
 {
-
     quic_network_thread_params_.local_port = serverInfo_.port;
     quic_network_thread_params_.local_af = PF_UNSPEC;
     quic_network_thread_params_.dest_if = 0;
     quic_network_thread_params_.socket_buffer_size = tconfig_.socket_buffer_size;
     quic_network_thread_params_.do_not_use_gso = 0;
+    quic_network_thread_params_.extra_socket_required = 0;
+    quic_network_thread_params_.prefer_extra_socket = 0;
+    quic_network_thread_params_.simulate_eio = 0;
+    quic_network_thread_params_.send_length_max = 0;
 
     SPDLOG_LOGGER_DEBUG(logger, "Starting picoquic network thread");
     quic_network_thread_ctx_ =
@@ -1784,11 +1787,14 @@ PicoQuicTransport::ClientLoop()
     quic_network_thread_params_.local_af = PF_UNSPEC;
     quic_network_thread_params_.dest_if = 0;
     quic_network_thread_params_.socket_buffer_size = tconfig_.socket_buffer_size;
-    quic_network_thread_params_.do_not_use_gso = 0;
-
 #ifdef ESP_PLATFORM
     quic_network_thread_params_.socket_buffer_size = 0x2048;
 #endif
+    quic_network_thread_params_.do_not_use_gso = 0;
+    quic_network_thread_params_.extra_socket_required = 0;
+    quic_network_thread_params_.prefer_extra_socket = 0;
+    quic_network_thread_params_.simulate_eio = 0;
+    quic_network_thread_params_.send_length_max = 0;
 
     quic_network_thread_ctx_ =
       picoquic_start_network_thread(quic_ctx_, &quic_network_thread_params_, PqLoopCb, this, &quic_loop_return_value_);

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -367,7 +367,7 @@ namespace quicr {
         picoquic_quic_config_t config_;
         picoquic_quic_t* quic_ctx_;
         picoquic_network_thread_ctx_t* quic_network_thread_ctx_;
-        picoquic_packet_loop_param_t quic_network_thread_params_;
+        picoquic_packet_loop_param_t quic_network_thread_params_{};
         int quic_loop_return_value_{ 0 };
         picoquic_tp_t local_tp_options_;
         SafeQueue<std::function<void()>> cbNotifyQueue_;


### PR DESCRIPTION
Garbage values in non-initialised fields of this structure were causing bad accesses when used in Release builds - specifically the extra socket parameter. Added explicit init to resolve, figured no harm in doing it twice and being very explicit. 