### PR TITLE
Support multiple occurrences of a given extension type

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -157,18 +157,22 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
         if (hdr.extensions) {
             ext << "mutable hdrs: ";
 
-            for (const auto& [type, value] : hdr.extensions.value()) {
-                ext << std::hex << std::setfill('0') << std::setw(2) << type;
-                ext << " = " << std::dec << std::setw(0) << uint64_t(quicr::UintVar(value)) << " ";
+            for (const auto& [type, values] : hdr.extensions.value()) {
+                for (const auto& value : values) {
+                    ext << std::hex << std::setfill('0') << std::setw(2) << type;
+                    ext << " = " << std::dec << std::setw(0) << uint64_t(quicr::UintVar(value)) << " ";
+                }
             }
         }
 
         if (hdr.immutable_extensions) {
             ext << "immutable hdrs: ";
 
-            for (const auto& [type, value] : hdr.immutable_extensions.value()) {
-                ext << std::hex << std::setfill('0') << std::setw(2) << type;
-                ext << " = " << std::dec << std::setw(0) << uint64_t(quicr::UintVar(value)) << " ";
+            for (const auto& [type, values] : hdr.immutable_extensions.value()) {
+                for (const auto& value : values) {
+                    ext << std::hex << std::setfill('0') << std::setw(2) << type;
+                    ext << " = " << std::dec << std::setw(0) << uint64_t(quicr::UintVar(value)) << " ";
+                }
             }
         }
 

--- a/include/quicr/detail/messages.h
+++ b/include/quicr/detail/messages.h
@@ -17,7 +17,7 @@
 namespace quicr::messages {
     using SubGroupId = quicr::messages::GroupId;
     using ObjectPriority = uint8_t;
-    using Extensions = std::multimap<uint64_t, Bytes>;
+    using Extensions = std::map<uint64_t, std::vector<Bytes>>;
 
     Bytes& operator<<(Bytes& buffer, const std::optional<Extensions>& extensions);
     Bytes& operator<<(Bytes& buffer, const Extensions& extensions);

--- a/include/quicr/object.h
+++ b/include/quicr/object.h
@@ -9,7 +9,7 @@
 #include <quicr/detail/base_track_handler.h>
 
 namespace quicr {
-    using Extensions = std::multimap<uint64_t, std::vector<uint8_t>>;
+    using Extensions = std::map<uint64_t, std::vector<std::vector<uint8_t>>>;
 
     /**
      * @brief Status of object as reported by the publisher

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -182,8 +182,8 @@ namespace quicr {
                 object_extensions = Extensions{};
             }
 
-            object_extensions->insert(
-              { static_cast<uint64_t>(messages::ExtensionHeaderType::kPriorGroupIdGap), value_bytes });
+            (*object_extensions)[static_cast<uint64_t>(messages::ExtensionHeaderType::kPriorGroupIdGap)].push_back(
+              value_bytes);
         }
 
         if (object_id_delta > 0) {
@@ -194,8 +194,8 @@ namespace quicr {
                 object_extensions = Extensions{};
             }
 
-            object_extensions->insert(
-              { static_cast<uint64_t>(messages::ExtensionHeaderType::kPriorObjectIdGap), value_bytes });
+            (*object_extensions)[static_cast<uint64_t>(messages::ExtensionHeaderType::kPriorObjectIdGap)].push_back(
+              value_bytes);
         }
 
         latest_group_id_ = object_headers.group_id;


### PR DESCRIPTION
MoQ allows repeated entries of a header extension with different values. Today our implementation uses `std::map`, which doesn't support this, but swapping to `std::multimap` should work out of the box. 

There are some extensions that explicitly do not allow this. Dealing with those is outside the scope of *this* PR. 