### PR TITLE
Update 699 new fetch update 1

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -51,7 +51,7 @@ namespace qclient_vars {
     bool add_gaps = false;
     bool req_track_status = false;
     std::chrono::milliseconds playback_speed_ms(20);
-    std::chrono::milliseconds cache_duration_ms(20);
+    std::chrono::milliseconds cache_duration_ms(5000);
     std::unordered_map<quicr::messages::TrackAlias, quicr::Cache<quicr::messages::GroupId, std::set<CacheObject>>>
       cache;
     std::shared_ptr<quicr::ThreadedTickService> tick_service = std::make_shared<quicr::ThreadedTickService>();
@@ -364,7 +364,7 @@ class MyFetchTrackHandler : public quicr::FetchTrackHandler
                        uint64_t end_object)
     {
         return std::shared_ptr<MyFetchTrackHandler>(
-          new MyFetchTrackHandler(full_track_name, start_group, end_group, start_object, end_object));
+          new MyFetchTrackHandler(full_track_name, start_group, start_object, end_group, end_object));
     }
 
     void ObjectReceived(const quicr::ObjectHeaders& headers, quicr::BytesSpan data) override
@@ -386,6 +386,14 @@ class MyFetchTrackHandler : public quicr::FetchTrackHandler
             case Status::kError: {
                 SPDLOG_INFO("Fetch failed");
                 break;
+            }
+            case Status::kDoneByFin: {
+                SPDLOG_INFO("Fetch completed");
+                break;
+            }
+
+            case Status::kDoneByReset: {
+                SPDLOG_INFO("Fetch failed");
             }
             default:
                 break;
@@ -823,7 +831,11 @@ DoFetch(const quicr::FullTrackName& full_track_name,
     auto track_handler = MyFetchTrackHandler::Create(
       full_track_name, group_range.start, object_range.start, group_range.end, object_range.end);
 
-    SPDLOG_INFO("Started fetch");
+    SPDLOG_INFO("Started fetch start: {}.{} end: {}.{}",
+                group_range.start,
+                object_range.start,
+                group_range.end,
+                object_range.end);
 
     bool fetch_track{ false };
 
@@ -837,7 +849,7 @@ DoFetch(const quicr::FullTrackName& full_track_name,
         if (track_handler->GetStatus() == quicr::FetchTrackHandler::Status::kPendingResponse) {
             // do nothing...
         } else if (!fetch_track || (track_handler->GetStatus() != quicr::FetchTrackHandler::Status::kOk)) {
-            SPDLOG_INFO("GetStatus() != quicr::FetchTrackHandler::Status::kOk {}", (int)track_handler->GetStatus());
+            SPDLOG_DEBUG("GetStatus() != quicr::FetchTrackHandler::Status::kOk {}", (int)track_handler->GetStatus());
             moq_example::terminate = true;
             moq_example::cv.notify_all();
             break;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -139,6 +139,7 @@ namespace quicr {
           logger_, "Client publish fetch track conn_id: {} subscribe id: {} unbind", connection_handle, request_id);
 
         conn_it->second.pub_fetch_tracks_by_sub_id.erase(request_id);
+        quic_transport_->DeleteDataContext(connection_handle, track_handler->publish_data_ctx_id_);
     }
 
     PublishTrackHandler::PublishObjectStatus Client::SendFetchObject(PublishFetchHandler& track_handler,

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -219,6 +219,8 @@ namespace quicr {
         }
 
         conn_it->second.pub_tracks_by_data_ctx_id.erase(track_handler->publish_data_ctx_id_);
+
+        quic_transport_->DeleteDataContext(connection_handle, track_handler->publish_data_ctx_id_);
     }
 
     void Server::BindPublisherTrack(ConnectionHandle conn_id,
@@ -281,6 +283,7 @@ namespace quicr {
           logger_, "Server publish fetch track conn_id: {} subscribe id: {} unbind", connection_handle, request_id);
 
         conn_it->second.pub_fetch_tracks_by_sub_id.erase(request_id);
+        quic_transport_->DeleteDataContext(connection_handle, track_handler->publish_data_ctx_id_);
     }
 
     void Server::BindFetchTrack(TransportConnId conn_id, std::shared_ptr<PublishFetchHandler> track_handler)

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1462,7 +1462,7 @@ try {
 void
 PicoQuicTransport::OnStreamClosed(TransportConnId conn_id, uint64_t stream_id, bool is_fin, bool is_reset)
 {
-    SPDLOG_INFO("Stream {} closed for connection {}", stream_id, conn_id);
+    SPDLOG_DEBUG("Stream {} closed for connection {}", stream_id, conn_id);
     cbNotifyQueue_.Push([=, this]() { delegate_.OnStreamClosed(conn_id, stream_id, is_fin, is_reset); });
 }
 


### PR DESCRIPTION
Updates PR #703

* Make transport close stream and data context on unpublish, unbindpublish and unbindfetch
* Update default cache duration
* Correct end-group setting in qclient
* Handle new status kDoneByFin and kDoneByReset
* Change various log messages to debug and trace
* Use RxStream track handler instead of for loop in OnStreamClosed
