### PR TITLE
Rename announe to pub/sub namespace

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -387,20 +387,20 @@ class MyClient : public quicr::Client
         }
     }
 
-    void AnnounceReceived(const quicr::TrackNamespace& track_namespace,
-                          const quicr::PublishAnnounceAttributes&) override
+    void PublishNamespaceReceived(const quicr::TrackNamespace& track_namespace,
+                                  const quicr::PublishNamespaceAttributes&) override
     {
         auto th = quicr::TrackHash({ track_namespace, {} });
         SPDLOG_INFO("Received announce for namespace_hash: {}", th.track_namespace_hash);
     }
 
-    void UnannounceReceived(const quicr::TrackNamespace& track_namespace) override
+    void PublishNamespaceDoneReceived(const quicr::TrackNamespace& track_namespace) override
     {
         auto th = quicr::TrackHash({ track_namespace, {} });
         SPDLOG_INFO("Received unannounce for namespace_hash: {}", th.track_namespace_hash);
     }
 
-    void SubscribeAnnouncesStatusChanged(const quicr::TrackNamespace& track_namespace,
+    void SubscribeNamespaceStatusChanged(const quicr::TrackNamespace& track_namespace,
                                          std::optional<quicr::messages::SubscribeNamespaceErrorCode> error_code,
                                          std::optional<quicr::messages::ReasonPhrase> reason) override
     {

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -115,8 +115,8 @@ namespace qserver_vars {
              std::map<quicr::messages::RequestID, std::shared_ptr<quicr::SubscribeTrackHandler>>>
       pub_subscribes_by_req_id;
 
-    /// Subscriber connection handles by subscribe prefix namespace for subscribe announces
-    std::map<quicr::TrackNamespace, std::set<quicr::ConnectionHandle>> subscribes_announces;
+    /// Subscriber connection handles by subscribe prefix namespace for subscribe namespaces
+    std::map<quicr::TrackNamespace, std::set<quicr::ConnectionHandle>> subscribe_namespaces;
 
     /**
      * Cache of MoQ objects by track alias
@@ -445,7 +445,7 @@ class MyServer : public quicr::Server
         std::vector<quicr::ConnectionHandle> sub_annos_connections;
 
         // TODO: Fix O(prefix namespaces) matching
-        for (const auto& [ns, conns] : qserver_vars::subscribes_announces) {
+        for (const auto& [ns, conns] : qserver_vars::subscribe_namespaces) {
             if (!ns.HasSamePrefix(track_namespace)) {
                 continue;
             }
@@ -485,11 +485,11 @@ class MyServer : public quicr::Server
         return sub_annos_connections;
     }
 
-    void UnsubscribeAnnouncesReceived(quicr::ConnectionHandle connection_handle,
+    void UnsubscribeNamespaceReceived(quicr::ConnectionHandle connection_handle,
                                       const quicr::TrackNamespace& prefix_namespace) override
     {
-        auto it = qserver_vars::subscribes_announces.find(prefix_namespace);
-        if (it == qserver_vars::subscribes_announces.end()) {
+        auto it = qserver_vars::subscribe_namespaces.find(prefix_namespace);
+        if (it == qserver_vars::subscribe_namespaces.end()) {
             return;
         }
 
@@ -500,13 +500,13 @@ class MyServer : public quicr::Server
     }
 
     std::pair<std::optional<quicr::messages::SubscribeNamespaceErrorCode>, std::vector<quicr::TrackNamespace>>
-    SubscribeAnnouncesReceived(quicr::ConnectionHandle connection_handle,
+    SubscribeNamespaceReceived(quicr::ConnectionHandle connection_handle,
                                const quicr::TrackNamespace& prefix_namespace,
-                               const quicr::PublishAnnounceAttributes&) override
+                               const quicr::PublishNamespaceAttributes&) override
     {
         auto th = quicr::TrackHash({ prefix_namespace, {} });
 
-        auto [it, is_new] = qserver_vars::subscribes_announces.try_emplace(prefix_namespace);
+        auto [it, is_new] = qserver_vars::subscribe_namespaces.try_emplace(prefix_namespace);
         it->second.insert(connection_handle);
 
         if (is_new) {
@@ -570,13 +570,13 @@ class MyServer : public quicr::Server
         }
     }
 
-    void AnnounceReceived(quicr::ConnectionHandle connection_handle,
-                          const quicr::TrackNamespace& track_namespace,
-                          const quicr::PublishAnnounceAttributes& attrs) override
+    void PublishNamespaceReceived(quicr::ConnectionHandle connection_handle,
+                                  const quicr::TrackNamespace& track_namespace,
+                                  const quicr::PublishNamespaceAttributes& attrs) override
     {
         auto th = quicr::TrackHash({ track_namespace, {} });
 
-        SPDLOG_INFO("Received announce from connection handle: {0} for namespace_hash: {1}",
+        SPDLOG_INFO("Received publish namespace from connection handle: {0} for namespace_hash: {1}",
                     connection_handle,
                     th.track_namespace_hash);
 
@@ -584,21 +584,22 @@ class MyServer : public quicr::Server
         auto [anno_conn_it, is_new] = qserver_vars::announce_active[track_namespace].try_emplace(connection_handle);
 
         if (!is_new) {
-            SPDLOG_INFO("Received announce from connection handle: {} for namespace hash: {} is duplicate, ignoring",
-                        connection_handle,
-                        th.track_namespace_hash);
+            SPDLOG_INFO(
+              "Received publish namespace from connection handle: {} for namespace hash: {} is duplicate, ignoring",
+              connection_handle,
+              th.track_namespace_hash);
             return;
         }
 
-        AnnounceResponse announce_response;
-        announce_response.reason_code = quicr::Server::AnnounceResponse::ReasonCode::kOk;
+        PublishNamespaceResponse publish_namespace_response;
+        publish_namespace_response.reason_code = quicr::Server::PublishNamespaceResponse::ReasonCode::kOk;
 
         auto& anno_tracks = qserver_vars::announce_active[track_namespace][connection_handle];
 
         std::vector<quicr::ConnectionHandle> sub_annos_connections;
 
         // TODO: Fix O(prefix namespaces) matching
-        for (const auto& [ns, conns] : qserver_vars::subscribes_announces) {
+        for (const auto& [ns, conns] : qserver_vars::subscribe_namespaces) {
             if (!ns.HasSamePrefix(track_namespace)) {
                 continue;
             }
@@ -613,7 +614,8 @@ class MyServer : public quicr::Server
             }
         }
 
-        ResolveAnnounce(connection_handle, attrs.request_id, track_namespace, sub_annos_connections, announce_response);
+        ResolvePublishNamespace(
+          connection_handle, attrs.request_id, track_namespace, sub_annos_connections, publish_namespace_response);
 
         // Check if there are any subscribes. If so, send subscribe to announce for all tracks matching namespace
         for (const auto& [ns, sub_tracks] : qserver_vars::subscribe_active) {
@@ -656,7 +658,7 @@ class MyServer : public quicr::Server
 
             // Remove all subscribe announces for this connection handle
             std::vector<quicr::TrackNamespace> remove_ns;
-            for (auto& [ns, conns] : qserver_vars::subscribes_announces) {
+            for (auto& [ns, conns] : qserver_vars::subscribe_namespaces) {
                 auto it = conns.find(connection_handle);
                 if (it != conns.end()) {
                     conns.erase(it);
@@ -667,7 +669,7 @@ class MyServer : public quicr::Server
             }
 
             for (auto ns : remove_ns) {
-                qserver_vars::subscribes_announces.erase(ns);
+                qserver_vars::subscribe_namespaces.erase(ns);
             }
         }
 

--- a/include/quicr/client.h
+++ b/include/quicr/client.h
@@ -79,42 +79,43 @@ namespace quicr {
         virtual void ServerSetupReceived(const ServerSetupAttributes& server_setup_attributes);
 
         /**
-         * @brief Notification on publish announcement status change
+         * @brief Notification on publish namespace status change
          *
-         * @details Callback notification for a change in publish announcement status
+         * @details Callback notification for a change in publish namespace status
          *
-         * @param track_namespace             Track namespace to announce
-         * @param status                      Publish announce status
+         * @param track_namespace             Track namespace to publish
+         * @param status                      Publish namespace status
          */
-        virtual void AnnounceStatusChanged(const TrackNamespace& track_namespace, const PublishAnnounceStatus status);
+        virtual void PublishNamespaceStatusChanged(const TrackNamespace& track_namespace,
+                                                   const PublishNamespaceStatus status);
 
         /**
          * @brief Callback notification for announce received by subscribe announces
          *
          * @param track_namespace       Track namespace
-         * @param announce_attributes   Publish announce attributes received
+         * @param publish_namespace_attributes   Publish announce attributes received
          */
-        virtual void AnnounceReceived(const TrackNamespace& track_namespace,
-                                      const PublishAnnounceAttributes& announce_attributes);
+        virtual void PublishNamespaceReceived(const TrackNamespace& track_namespace,
+                                              const PublishNamespaceAttributes& publish_namespace_attributes);
 
         /**
-         * @brief Callback notification for unannounce received by subscribe announces
+         * @brief Callback notification for publish namespace done received
          *
          * @param track_namespace       Track namespace
          */
-        virtual void UnannounceReceived(const TrackNamespace& track_namespace);
+        virtual void PublishNamespaceDoneReceived(const TrackNamespace& track_namespace);
 
         /**
-         * @brief Callback notification for subscribe announces OK or Error
+         * @brief Callback notification for subscribe namespace OK or Error
          *
-         * @details error_code and reason will be nullopt is the announces status is OK and accepted.
+         * @details error_code and reason will be nullopt if the status is OK and accepted.
          *      If error, the error_code and reason will be set to indicate the error.
          *
          * @param track_namespace       Track namespace
          * @param error_code            Set if there is an error; error code
          * @param reason                Set if there is an error; reason phrase
          */
-        virtual void SubscribeAnnouncesStatusChanged(const TrackNamespace& track_namespace,
+        virtual void SubscribeNamespaceStatusChanged(const TrackNamespace& track_namespace,
                                                      std::optional<messages::SubscribeNamespaceErrorCode> error_code,
                                                      std::optional<messages::ReasonPhrase> reason);
 
@@ -204,7 +205,7 @@ namespace quicr {
          *
          * @return PublishAnnounceStatus of the namespace
          */
-        PublishAnnounceStatus GetAnnounceStatus(const TrackNamespace& track_namespace);
+        PublishNamespaceStatus GetPublishNamespaceStatus(const TrackNamespace& track_namespace);
 
         /**
          * @brief Subscribe to a track
@@ -268,7 +269,7 @@ namespace quicr {
          * @param track_namespace    Track handler to use for track related functions
          *                           and callbacks
          */
-        void PublishAnnounce(const TrackNamespace& track_namespace);
+        void PublishNamespace(const TrackNamespace& track_namespace);
 
         /**
          * @brief Unannounce a publish namespace
@@ -278,7 +279,7 @@ namespace quicr {
          *
          * @param track_namespace         Track namespace to unannounce
          */
-        void PublishUnannounce(const TrackNamespace& track_namespace);
+        void PublishNamespaceDone(const TrackNamespace& track_namespace);
 
         /**
          * @brief Subscribe Announces to prefix namespace
@@ -293,7 +294,7 @@ namespace quicr {
                 return;
             }
 
-            SendSubscribeAnnounces(*connection_handle_, prefix_namespace);
+            SendSubscribeNamespace(*connection_handle_, prefix_namespace);
         }
 
         /**
@@ -307,7 +308,7 @@ namespace quicr {
                 return;
             }
 
-            SendUnsubscribeAnnounces(*connection_handle_, prefix_namespace);
+            SendUnsubscribeNamespace(*connection_handle_, prefix_namespace);
         }
 
         /**

--- a/include/quicr/common.h
+++ b/include/quicr/common.h
@@ -21,11 +21,11 @@ namespace quicr {
     using BytesSpan = std::span<const Byte>;
     using ConnectionHandle = uint64_t;
     /**
-     * @brief Publish announce attributes
+     * @brief Publish namespace attributes
      *
-     * @details Various attributes relative to the publish announce
+     * @details Various attributes relative to the publish namespace
      */
-    struct PublishAnnounceAttributes
+    struct PublishNamespaceAttributes
     {
         uint64_t request_id{ 0 };
     };
@@ -50,14 +50,14 @@ namespace quicr {
     /**
      * @brief  Publish Announce Status
      */
-    enum class PublishAnnounceStatus : uint8_t
+    enum class PublishNamespaceStatus : uint8_t
     {
         kOK = 0,
         kNotConnected,
-        kNotAnnounced,
-        kPendingAnnounceResponse,
-        kAnnounceNotAuthorized,
-        kSendingUnannounce, ///< In this state, callbacks will not be called
+        kNotPublished,
+        kPendingResponse,
+        kPublishNotAuthorized,
+        kSendingDone, ///< In this state, callbacks will not be called
     };
 }
 // namespace quicr

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -395,8 +395,8 @@ namespace quicr {
             /// Fetch Publishers by subscribe ID.
             std::map<messages::RequestID, std::shared_ptr<PublishTrackHandler>> pub_fetch_tracks_by_sub_id;
 
-            /// Subscribe Announces namespace prefix by request Id
-            std::map<messages::RequestID, TrackNamespace> sub_announces_by_request_id;
+            /// Subscribe Namespace prefix by request Id
+            std::map<messages::RequestID, TrackNamespace> sub_namespace_prefix_by_request_id;
 
             ConnectionMetrics metrics{}; ///< Connection metrics
 
@@ -423,11 +423,11 @@ namespace quicr {
         void SendCtrlMsg(const ConnectionContext& conn_ctx, BytesSpan data);
         void SendClientSetup();
         void SendServerSetup(ConnectionContext& conn_ctx);
-        void SendAnnounce(ConnectionContext& conn_ctx,
-                          messages::RequestID request_id,
-                          const TrackNamespace& track_namespace);
-        void SendAnnounceOk(ConnectionContext& conn_ctx, messages::RequestID request_id);
-        void SendUnannounce(ConnectionContext& conn_ctx, const TrackNamespace& track_namespace);
+        void SendPublishNamespace(ConnectionContext& conn_ctx,
+                                  messages::RequestID request_id,
+                                  const TrackNamespace& track_namespace);
+        void SendPublishNamespaceOk(ConnectionContext& conn_ctx, messages::RequestID request_id);
+        void SendPublishNamespaceDone(ConnectionContext& conn_ctx, const TrackNamespace& track_namespace);
         void SendSubscribe(ConnectionContext& conn_ctx,
                            messages::RequestID request_id,
                            const FullTrackName& tfn,
@@ -489,10 +489,10 @@ namespace quicr {
                               messages::SubscribeErrorCode error,
                               const std::string& reason);
 
-        void SendSubscribeAnnounces(ConnectionHandle conn_handle, const TrackNamespace& prefix_namespace);
-        void SendUnsubscribeAnnounces(ConnectionHandle conn_handle, const TrackNamespace& prefix_namespace);
-        void SendSubscribeAnnouncesOk(ConnectionContext& conn_ctx, messages::RequestID request_id);
-        void SendSubscribeAnnouncesError(ConnectionContext& conn_ctx,
+        void SendSubscribeNamespace(ConnectionHandle conn_handle, const TrackNamespace& prefix_namespace);
+        void SendUnsubscribeNamespace(ConnectionHandle conn_handle, const TrackNamespace& prefix_namespace);
+        void SendSubscribeNamespaceOk(ConnectionContext& conn_ctx, messages::RequestID request_id);
+        void SendSubscribeNamespaceError(ConnectionContext& conn_ctx,
                                          messages::RequestID request_id,
                                          messages::SubscribeNamespaceErrorCode err_code,
                                          const messages::ReasonPhrase& reason);

--- a/include/quicr/server.h
+++ b/include/quicr/server.h
@@ -31,7 +31,7 @@ namespace quicr {
         /**
          * @brief Response to received MOQT Announce message
          */
-        struct AnnounceResponse
+        struct PublishNamespaceResponse
         {
             /**
              * @details **kOK** indicates that the announce is accepted and OK should be sent. Any other
@@ -219,9 +219,9 @@ namespace quicr {
          * @param track_namespace               Track namespace
          * @param publish_announce_attributes   Publish announce attributes received
          */
-        virtual void AnnounceReceived(ConnectionHandle connection_handle,
-                                      const TrackNamespace& track_namespace,
-                                      const PublishAnnounceAttributes& publish_announce_attributes);
+        virtual void PublishNamespaceReceived(ConnectionHandle connection_handle,
+                                              const TrackNamespace& track_namespace,
+                                              const PublishNamespaceAttributes& publish_announce_attributes);
 
         /**
          * @brief Accept or reject an announce that was received
@@ -236,11 +236,11 @@ namespace quicr {
          * @param subscribers              Vector/list of subscriber connection handles that should be sent the announce
          * @param announce_response        response to for the announcement
          */
-        void ResolveAnnounce(ConnectionHandle connection_handle,
-                             uint64_t request_id,
-                             const TrackNamespace& track_namespace,
-                             const std::vector<ConnectionHandle>& subscribers,
-                             const AnnounceResponse& announce_response);
+        void ResolvePublishNamespace(ConnectionHandle connection_handle,
+                                     uint64_t request_id,
+                                     const TrackNamespace& track_namespace,
+                                     const std::vector<ConnectionHandle>& subscribers,
+                                     const PublishNamespaceResponse& announce_response);
 
         /**
          * @brief Callback notification for unannounce received
@@ -266,7 +266,7 @@ namespace quicr {
          * @param prefix_namespace           Prefix namespace
          *
          */
-        virtual void UnsubscribeAnnouncesReceived(ConnectionHandle connection_handle,
+        virtual void UnsubscribeNamespaceReceived(ConnectionHandle connection_handle,
                                                   const TrackNamespace& prefix_namespace) = 0;
 
         /**
@@ -284,10 +284,10 @@ namespace quicr {
         using SubscribeAnnouncesResponse =
           std::pair<std::optional<messages::SubscribeNamespaceErrorCode>, std::vector<TrackNamespace>>;
 
-        virtual SubscribeAnnouncesResponse SubscribeAnnouncesReceived(
+        virtual SubscribeAnnouncesResponse SubscribeNamespaceReceived(
           ConnectionHandle connection_handle,
           const TrackNamespace& prefix_namespace,
-          const PublishAnnounceAttributes& announce_attributes);
+          const PublishNamespaceAttributes& announce_attributes);
 
         /**
          * @brief Callback notification for new subscribe received

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -21,11 +21,11 @@ namespace quicr {
 
     void Client::ServerSetupReceived(const ServerSetupAttributes&) {}
 
-    void Client::AnnounceStatusChanged(const TrackNamespace&, const PublishAnnounceStatus) {}
-    void Client::AnnounceReceived(const TrackNamespace&, const PublishAnnounceAttributes&) {}
-    void Client::UnannounceReceived(const TrackNamespace&) {}
+    void Client::PublishNamespaceStatusChanged(const TrackNamespace&, const PublishNamespaceStatus) {}
+    void Client::PublishNamespaceReceived(const TrackNamespace&, const PublishNamespaceAttributes&) {}
+    void Client::PublishNamespaceDoneReceived(const TrackNamespace&) {}
 
-    void Client::SubscribeAnnouncesStatusChanged(const TrackNamespace&,
+    void Client::SubscribeNamespaceStatusChanged(const TrackNamespace&,
                                                  std::optional<messages::SubscribeNamespaceErrorCode>,
                                                  std::optional<messages::ReasonPhrase>)
     {
@@ -159,14 +159,14 @@ namespace quicr {
 
     void Client::MetricsSampled(const ConnectionMetrics&) {}
 
-    PublishAnnounceStatus Client::GetAnnounceStatus(const TrackNamespace&)
+    PublishNamespaceStatus Client::GetPublishNamespaceStatus(const TrackNamespace&)
     {
-        return PublishAnnounceStatus();
+        return PublishNamespaceStatus();
     }
 
-    void Client::PublishAnnounce(const TrackNamespace&) {}
+    void Client::PublishNamespace(const TrackNamespace&) {}
 
-    void Client::PublishUnannounce(const TrackNamespace&) {}
+    void Client::PublishNamespaceDone(const TrackNamespace&) {}
 
     bool Client::ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan msg_bytes)
     try {
@@ -367,7 +367,7 @@ namespace quicr {
 
                 auto tfn = FullTrackName{ msg.track_namespace, {} };
 
-                AnnounceReceived(tfn.name_space, {});
+                PublishNamespaceReceived(tfn.name_space, {});
                 return true;
             }
 
@@ -376,7 +376,7 @@ namespace quicr {
                 msg_bytes >> msg;
 
                 auto tfn = FullTrackName{ msg.track_namespace, {} };
-                UnannounceReceived(tfn.name_space);
+                PublishNamespaceDoneReceived(tfn.name_space);
 
                 return true;
             }
@@ -386,7 +386,7 @@ namespace quicr {
                 msg_bytes >> msg;
 
                 SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Received announce ok, conn_id: {} request_id: {}",
+                                    "Received publish namespace ok, conn_id: {} request_id: {}",
                                     conn_ctx.connection_handle,
                                     msg.request_id);
 
@@ -411,7 +411,7 @@ namespace quicr {
                 reason.assign(msg.error_reason.begin(), msg.error_reason.end());
 
                 SPDLOG_LOGGER_INFO(logger_,
-                                   "Received announce error for request_id: {} error code: {} reason: {}",
+                                   "Received publish namespace error for request_id: {} error code: {} reason: {}",
                                    msg.request_id,
                                    static_cast<std::uint64_t>(msg.error_code),
                                    reason);
@@ -422,9 +422,9 @@ namespace quicr {
                 messages::SubscribeNamespaceOk msg;
                 msg_bytes >> msg;
 
-                const auto it = conn_ctx.sub_announces_by_request_id.find(msg.request_id);
-                if (it != conn_ctx.sub_announces_by_request_id.end()) {
-                    SubscribeAnnouncesStatusChanged(it->second, std::nullopt, std::nullopt);
+                const auto it = conn_ctx.sub_namespace_prefix_by_request_id.find(msg.request_id);
+                if (it != conn_ctx.sub_namespace_prefix_by_request_id.end()) {
+                    SubscribeNamespaceStatusChanged(it->second, std::nullopt, std::nullopt);
                 }
 
                 return true;
@@ -433,12 +433,12 @@ namespace quicr {
                 messages::SubscribeNamespaceError msg;
                 msg_bytes >> msg;
 
-                const auto it = conn_ctx.sub_announces_by_request_id.find(msg.request_id);
-                if (it != conn_ctx.sub_announces_by_request_id.end()) {
-                    SubscribeAnnouncesStatusChanged(it->second, std::nullopt, std::nullopt);
+                const auto it = conn_ctx.sub_namespace_prefix_by_request_id.find(msg.request_id);
+                if (it != conn_ctx.sub_namespace_prefix_by_request_id.end()) {
+                    SubscribeNamespaceStatusChanged(it->second, std::nullopt, std::nullopt);
 
                     auto error_code = static_cast<messages::SubscribeNamespaceErrorCode>(msg.error_code);
-                    SubscribeAnnouncesStatusChanged(
+                    SubscribeNamespaceStatusChanged(
                       it->second, error_code, std::make_optional<messages::ReasonPhrase>(msg.error_reason));
                 }
 
@@ -500,7 +500,7 @@ namespace quicr {
                 auto tfn = sub_it->second->GetFullTrackName();
 
                 SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Received subscribe done conn_id: {0} request_id: {1} track namespace hash: {2} "
+                                    "Received publish done conn_id: {0} request_id: {1} track namespace hash: {2} "
                                     "name hash: {3} track alias: {4}",
                                     conn_ctx.connection_handle,
                                     msg.request_id,
@@ -533,8 +533,8 @@ namespace quicr {
                 auto th = TrackHash(tfn);
 
                 SPDLOG_LOGGER_INFO(
-                  logger_, "Received announce cancel for namespace_hash: {0}", th.track_namespace_hash);
-                AnnounceStatusChanged(tfn.name_space, PublishAnnounceStatus::kNotAnnounced);
+                  logger_, "Received publish namespace cancel for namespace_hash: {0}", th.track_namespace_hash);
+                PublishNamespaceStatusChanged(tfn.name_space, PublishNamespaceStatus::kNotPublished);
                 return true;
             }
 

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -34,7 +34,7 @@ namespace quicr_test {
         {
             return {};
         };
-        void UnsubscribeAnnouncesReceived([[maybe_unused]] quicr::ConnectionHandle connection_handle,
+        void UnsubscribeNamespaceReceived([[maybe_unused]] quicr::ConnectionHandle connection_handle,
                                           [[maybe_unused]] const quicr::TrackNamespace& prefix_namespace) override {};
         void UnsubscribeReceived([[maybe_unused]] quicr::ConnectionHandle connection_handle,
                                  [[maybe_unused]] uint64_t request_id) override {};


### PR DESCRIPTION
This is pure renaming to reflect change from announce to pub/sub_namespace. Not exhaustive replacement of all references to announce, but most of the API calls. I just didn't want all this renaming noise in amongst subsequent changes that actually do something. 