### PR TITLE
Make client consistent with server handling

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -584,7 +584,7 @@ class MyClient : public quicr::Client
             for (const auto& entry : cache_entries) {
                 for (const auto& object : *entry) {
                     if (end->object && object.headers.group_id == end->group &&
-                        object.headers.object_id > end->object) {
+                        object.headers.object_id >= end->object) {
                         return;
                     }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -875,9 +875,7 @@ namespace quicr {
                             .group_order = msg.group_order,
                             .start_location = msg.group_0->standalone.start,
                             .end_location = { .group = msg.group_0->standalone.end.group,
-                                              .object = msg.group_0->standalone.end.object > 0
-                                                          ? msg.group_0->standalone.end.object - 1
-                                                          : 0 },
+                                              .object = msg.group_0->standalone.end.object },
                         };
 
                         StandaloneFetchReceived(conn_ctx.connection_handle, msg.request_id, tfn, attrs);


### PR DESCRIPTION
Makes the client inbound FETCH handling consistent with the existing server side FETCH handling. 

(This duplication can be removed, but for now just making them behave the same way). 