### PR TITLE
Fix shutdown deadlock in PicoQuicTransport and qclient signal handling

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -1187,7 +1187,7 @@ main(int argc, char* argv[])
             exit(-1);
         }
 
-        while (not stop_threads && not moq_example::terminate) {
+        while (not stop_threads && not moq_example::terminate.load()) {
             if (client->GetStatus() == MyClient::Status::kReady) {
                 SPDLOG_INFO("Connected to server");
                 break;

--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -1258,7 +1258,7 @@ main(int argc, char* argv[])
         }
 
         // Wait until told to terminate
-        moq_example::cv.wait(lock, [&]() { return moq_example::terminate; });
+        moq_example::cv.wait(lock, [&]() { return moq_example::terminate.load(); });
 
         stop_threads = true;
         SPDLOG_INFO("Stopping threads...");

--- a/cmd/examples/server.cpp
+++ b/cmd/examples/server.cpp
@@ -1065,7 +1065,7 @@ main(int argc, char* argv[])
         }
 
         // Wait until told to terminate
-        moq_example::cv.wait(lock, [&]() { return moq_example::terminate; });
+        moq_example::cv.wait(lock, [&]() { return moq_example::terminate.load(); });
 
         // Unlock the mutex
         lock.unlock();

--- a/cmd/examples/signal_handler.h
+++ b/cmd/examples/signal_handler.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <csignal>
 #include <iostream>
@@ -10,7 +11,7 @@
 
 namespace moq_example {
     std::mutex main_mutex;                     // Main's mutex
-    bool terminate{ false };                   // Termination flag
+    std::atomic<bool> terminate{ false };      // Termination flag
     std::condition_variable cv;                // Main thread waits on this
     const char* termination_reason{ nullptr }; // Termination reason
 };

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -2628,6 +2628,9 @@ PicoQuicTransport::Shutdown()
 
     if (quic_network_thread_ctx_ != NULL) {
         SPDLOG_LOGGER_INFO(logger, "Closing transport picoquic thread");
+
+        // Signal thread to exit BEFORE waiting
+        quic_network_thread_ctx_->thread_should_close = 1;
         picoquic_wake_up_network_thread(quic_network_thread_ctx_);
 
         while (quic_network_thread_ctx_->thread_is_ready) {


### PR DESCRIPTION
Currently, PicoQuicTransport::Shutdown() contains a deadlock that prevents graceful process termination. The code waits for the picoquic network thread to exit (`thread_is_ready == 0`) before calling `picoquic_delete_network_thread()`, but the thread only exits when `thread_should_close` is set — which only happens inside `picoquic_delete_network_thread()`. Additionally, the qclient example holds a mutex during its connection loop that blocks the signal handler from executing, preventing Ctrl-C from working.                                                                                                                     

This PR fixes both issues: it sets thread_should_close = 1 before the busy-wait loop in Shutdown(), and moves the mutex acquisition in qclient to after the connection loop while also checking the terminate flag during connection attempts. Together, these changes allow qclient (and any application using libquicr) to shut down cleanly when interrupted with Ctrl-C.