### PR TITLE
Datagram header bitfields

### DIFF
--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -262,12 +262,14 @@ namespace quicr {
          *
          * @param group_id              Group ID of the status
          * @param object_id             Object ID of the status
+         * @param priority              Priority of the status
          * @param status                Status
          * @param extensions            Mutable extensions, if any
          * @param immutable_extensions  Immutable extensions, if any
          */
         virtual void ObjectStatusReceived([[maybe_unused]] uint64_t group_id,
                                           [[maybe_unused]] uint64_t object_id,
+                                          [[maybe_unused]] std::uint8_t priority,
                                           [[maybe_unused]] ObjectStatus status,
                                           [[maybe_unused]] std::optional<Extensions> extensions,
                                           [[maybe_unused]] std::optional<Extensions> immutable_extensions)

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1974,8 +1974,10 @@ namespace quicr {
                 auto msg_type = data->front();
 
                 // Message type needs to be either datagram header types or status types.
-                const auto data_type = static_cast<DatagramMessageType>(msg_type);
-                if (!TypeIsDatagram(data_type)) {
+                try {
+                    const auto _ = DatagramHeaderProperties(msg_type);
+                } catch (const ProtocolViolationException&) {
+                    // TODO: Should this exception bubble up instead?
                     SPDLOG_LOGGER_DEBUG(
                       logger_, "Received datagram that is not a supported datagram type, dropping: {0}", msg_type);
                     auto& conn_ctx = connections_[conn_id];

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1974,10 +1974,7 @@ namespace quicr {
                 auto msg_type = data->front();
 
                 // Message type needs to be either datagram header types or status types.
-                try {
-                    const auto _ = DatagramHeaderProperties(msg_type);
-                } catch (const ProtocolViolationException&) {
-                    // TODO: Should this exception bubble up instead?
+                if (!DatagramHeaderProperties::IsValid(msg_type)) {
                     SPDLOG_LOGGER_DEBUG(
                       logger_, "Received datagram that is not a supported datagram type, dropping: {0}", msg_type);
                     auto& conn_ctx = connections_[conn_id];


### PR DESCRIPTION
Refactor datagram header types for draft-16, using the now explicit bitfields. ref #770. See also note about publisher priority which isn't implemented yet: #777 