### PR TITLE
Stub support for bidir stream for control message and implement subscribe namespace to use its own

### DIFF
--- a/include/quicr/client.h
+++ b/include/quicr/client.h
@@ -401,7 +401,10 @@ namespace quicr {
         std::optional<ConnectionHandle> GetConnectionHandle() const { return connection_handle_; }
 
       private:
-        bool ProcessCtrlMessage(ConnectionContext& conn_ctx, uint64_t data_ctx_id, BytesSpan stream_buffer) override;
+        bool ProcessCtrlMessage(ConnectionContext& conn_ctx,
+                                uint64_t data_ctx_id,
+                                messages::ControlMessageType msg_type,
+                                BytesSpan stream_buffer) override;
 
         void SetConnectionHandle(ConnectionHandle connection_handle) override
         {

--- a/include/quicr/client.h
+++ b/include/quicr/client.h
@@ -401,7 +401,7 @@ namespace quicr {
         std::optional<ConnectionHandle> GetConnectionHandle() const { return connection_handle_; }
 
       private:
-        bool ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan stream_buffer) override;
+        bool ProcessCtrlMessage(ConnectionContext& conn_ctx, uint64_t data_ctx_id, BytesSpan stream_buffer) override;
 
         void SetConnectionHandle(ConnectionHandle connection_handle) override
         {

--- a/include/quicr/detail/quic_transport.h
+++ b/include/quicr/detail/quic_transport.h
@@ -441,10 +441,10 @@ namespace quicr {
          * @details Add data to the transport queue. Data enqueued will be transmitted
          * when available.
          *
-         * @param[in] context_id	Identifying the connection
-         * @param[in] data_ctx_id	stream Id to send data on
-         * @param[in] stream_id     Stream ID to send message on
-         * @param[in] bytes		    Data to send/write
+         * @param[in] context_id    Identifying the connection
+         * @param[in] data_ctx_id   stream Id to send data on
+         * @param[in] stream_id     Stream ID to send message on, Only used for unidir data contexts
+         * @param[in] bytes	    Data to send/write
          * @param[in] priority      Priority of the object, range should be 0 - 255
          * @param[in] ttl_ms        The age the object should exist in queue in milliseconds
          * @param[in] delay_ms      Delay the pop by millisecond value

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -386,7 +386,7 @@ namespace quicr {
             std::optional<messages::ControlMessageType>
               ctrl_msg_type_received; ///< Indicates the current message type being read
 
-            std::vector<uint8_t> ctrl_msg_buffer; ///< Control message buffer
+            std::map<uint64_t, std::vector<uint8_t>> ctrl_msg_buffer; ///< Control message buffer
 
             /** Next Connection request Id. This value is shifted left when setting Request Id.
              * The least significant bit is used to indicate client (0) vs server (1).
@@ -461,7 +461,7 @@ namespace quicr {
             ConnectionMetrics metrics{};   ///< Connection metrics
             bool is_webtransport{ false }; ///< True if this connection uses WebTransport over HTTP/3
 
-            ConnectionContext() { ctrl_msg_buffer.reserve(kControlMessageBufferSize); }
+            ConnectionContext() {}
 
             /*
              * Get the next request Id to use
@@ -481,7 +481,7 @@ namespace quicr {
 
         void Init();
 
-        void SendCtrlMsg(const ConnectionContext& conn_ctx, BytesSpan data);
+        void SendCtrlMsg(const ConnectionContext& conn_ctx, DataContextId data_ctx_id, BytesSpan data);
         void SendClientSetup();
         void SendServerSetup(ConnectionContext& conn_ctx);
         void SendPublishNamespace(ConnectionContext& conn_ctx,
@@ -652,7 +652,7 @@ namespace quicr {
         // Private member functions that will be implemented by both Server and Client
         // ------------------------------------------------------------------------------------------------
 
-        virtual bool ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan msg_bytes) = 0;
+        virtual bool ProcessCtrlMessage(ConnectionContext& conn_ctx, uint64_t data_ctx_id, BytesSpan msg_bytes) = 0;
 
         std::uint64_t CreateStream(ConnectionHandle conn, std::uint64_t data_ctx_id, uint8_t priority);
 

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -559,8 +559,11 @@ namespace quicr {
         void SendSubscribeNamespace(ConnectionHandle conn_handle, std::shared_ptr<SubscribeNamespaceHandler> handler);
         void SendUnsubscribeNamespace(ConnectionHandle conn_handle,
                                       const std::shared_ptr<SubscribeNamespaceHandler>& handler);
-        void SendSubscribeNamespaceOk(ConnectionContext& conn_ctx, messages::RequestID request_id);
+        void SendSubscribeNamespaceOk(ConnectionContext& conn_ctx,
+                                      DataContextId data_ctx_id,
+                                      messages::RequestID request_id);
         void SendSubscribeNamespaceError(ConnectionContext& conn_ctx,
+                                         DataContextId data_ctx_id,
                                          messages::RequestID request_id,
                                          messages::SubscribeNamespaceErrorCode err_code,
                                          const std::string& reason);

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -383,10 +383,15 @@ namespace quicr {
             bool setup_complete{ false }; ///< True if both client and server setup messages have completed
             bool closed{ false };
             uint64_t client_version{ 0 };
-            std::optional<messages::ControlMessageType>
-              ctrl_msg_type_received; ///< Indicates the current message type being read
 
-            std::map<uint64_t, std::vector<uint8_t>> ctrl_msg_buffer; ///< Control message buffer
+            struct CtrlMsgBuffer
+            {
+                /// Indicates the current message type being read
+                std::optional<messages::ControlMessageType> msg_type;
+
+                std::vector<uint8_t> data; ///< Data buffer to parse control message
+            };
+            std::map<uint64_t, CtrlMsgBuffer> ctrl_msg_buffer; ///< Control message buffer
 
             /** Next Connection request Id. This value is shifted left when setting Request Id.
              * The least significant bit is used to indicate client (0) vs server (1).
@@ -655,7 +660,10 @@ namespace quicr {
         // Private member functions that will be implemented by both Server and Client
         // ------------------------------------------------------------------------------------------------
 
-        virtual bool ProcessCtrlMessage(ConnectionContext& conn_ctx, uint64_t data_ctx_id, BytesSpan msg_bytes) = 0;
+        virtual bool ProcessCtrlMessage(ConnectionContext& conn_ctx,
+                                        uint64_t data_ctx_id,
+                                        messages::ControlMessageType msg_type,
+                                        BytesSpan msg_bytes) = 0;
 
         std::uint64_t CreateStream(ConnectionHandle conn, std::uint64_t data_ctx_id, uint8_t priority);
 

--- a/include/quicr/server.h
+++ b/include/quicr/server.h
@@ -394,7 +394,10 @@ namespace quicr {
         // --END OF CALLBACKS ----------------------------------------------------------------------------------
 
       private:
-        bool ProcessCtrlMessage(ConnectionContext& conn_ctx, uint64_t data_ctx_id, BytesSpan msg_bytes) override;
+        bool ProcessCtrlMessage(ConnectionContext& conn_ctx,
+                                uint64_t data_ctx_id,
+                                messages::ControlMessageType msg_type,
+                                BytesSpan msg_bytes) override;
 
         bool stop_{ false };
     };

--- a/include/quicr/server.h
+++ b/include/quicr/server.h
@@ -388,7 +388,7 @@ namespace quicr {
         // --END OF CALLBACKS ----------------------------------------------------------------------------------
 
       private:
-        bool ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan msg_bytes) override;
+        bool ProcessCtrlMessage(ConnectionContext& conn_ctx, uint64_t data_ctx_id, BytesSpan msg_bytes) override;
 
         bool stop_{ false };
     };

--- a/include/quicr/server.h
+++ b/include/quicr/server.h
@@ -148,11 +148,13 @@ namespace quicr {
          * @brief Accept or reject subscribe namespace that was received
          *
          * @param connection_handle source connection ID
+         * @param data_ctx_id       Data context ID for the bidir connection to use
          * @param request_id        Request ID
          * @param prefix            Track namespace prefix
          * @param response          Response for remainder of subscribe namespace flow
          */
         virtual void ResolveSubscribeNamespace(ConnectionHandle connection_handle,
+                                               DataContextId data_ctx_id,
                                                uint64_t request_id,
                                                const messages::TrackNamespacePrefix& prefix,
                                                const SubscribeNamespaceResponse& response);
@@ -291,10 +293,12 @@ namespace quicr {
          * @brief Callback notification for Unsubscribe announces received
          *
          * @param connection_handle         Source connection ID
-         * @param prefix_namespace           Prefix namespace
+         * @param data_ctx_id               Data context ID that the message received on
+         * @param prefix_namespace          Prefix namespace
          *
          */
         virtual void UnsubscribeNamespaceReceived(ConnectionHandle connection_handle,
+                                                  DataContextId data_ctx_id,
                                                   const TrackNamespace& prefix_namespace) = 0;
 
         /**
@@ -303,10 +307,12 @@ namespace quicr {
          * @note The implementor **MUST** call ResolveSubscribeNamespace().
          *
          * @param connection_handle             Source connection ID
+         * @param data_ctx_id                   Data context ID that the message was received on
          * @param prefix_namespace              Track namespace
          * @param attributes                    Attributes received
          */
         virtual void SubscribeNamespaceReceived(ConnectionHandle connection_handle,
+                                                DataContextId data_ctx_id,
                                                 const TrackNamespace& prefix_namespace,
                                                 const SubscribeNamespaceAttributes& attributes) = 0;
 

--- a/include/quicr/subscribe_namespace_handler.h
+++ b/include/quicr/subscribe_namespace_handler.h
@@ -107,6 +107,7 @@ namespace quicr {
         std::optional<Error> error_{};
 
         quicr::ConnectionHandle connection_handle_;
+        DataContextId data_ctx_id_{ 0 };
 
         friend class Transport;
         friend class Client;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -156,9 +156,12 @@ namespace quicr {
 
     void Client::PublishNamespaceDone(const TrackNamespace&) {}
 
-    bool Client::ProcessCtrlMessage(ConnectionContext& conn_ctx, uint64_t data_ctx_id, BytesSpan msg_bytes)
+    bool Client::ProcessCtrlMessage(ConnectionContext& conn_ctx,
+                                    [[maybe_unused]] uint64_t data_ctx_id,
+                                    messages::ControlMessageType msg_type,
+                                    BytesSpan msg_bytes)
     try {
-        switch (*conn_ctx.ctrl_msg_type_received) {
+        switch (msg_type) {
             case messages::ControlMessageType::kSubscribe: {
                 messages::Subscribe msg(
                   [](messages::Subscribe& msg) {
@@ -919,9 +922,8 @@ namespace quicr {
                 return true;
             }
             default: {
-                SPDLOG_LOGGER_ERROR(logger_,
-                                    "Unsupported MOQT message type: {0}, bad stream",
-                                    static_cast<uint64_t>(*conn_ctx.ctrl_msg_type_received));
+                SPDLOG_LOGGER_ERROR(
+                  logger_, "Unsupported MOQT message type: {0}, bad stream", static_cast<uint64_t>(msg_type));
                 return false;
             }
         }
@@ -931,7 +933,7 @@ namespace quicr {
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_,
                             "Caught exception trying to process control message. (type={}, error={})",
-                            static_cast<int>(*conn_ctx.ctrl_msg_type_received),
+                            static_cast<int>(msg_type),
                             e.what());
         return false;
     }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -156,7 +156,7 @@ namespace quicr {
 
     void Client::PublishNamespaceDone(const TrackNamespace&) {}
 
-    bool Client::ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan msg_bytes)
+    bool Client::ProcessCtrlMessage(ConnectionContext& conn_ctx, uint64_t data_ctx_id, BytesSpan msg_bytes)
     try {
         switch (*conn_ctx.ctrl_msg_type_received) {
             case messages::ControlMessageType::kSubscribe: {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -377,7 +377,7 @@ namespace quicr {
         conn_it->second.pub_fetch_tracks_by_request_id[request_id] = track_handler;
     }
 
-    bool Server::ProcessCtrlMessage(ConnectionContext& conn_ctx, BytesSpan msg_bytes)
+    bool Server::ProcessCtrlMessage(ConnectionContext& conn_ctx, uint64_t data_ctx_id, BytesSpan msg_bytes)
     try {
         switch (*conn_ctx.ctrl_msg_type_received) {
             case messages::ControlMessageType::kSubscribe: {

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1868,6 +1868,8 @@ namespace quicr {
                         if (conn_ctx.ctrl_stream_id.has_value() && conn_ctx.ctrl_stream_id == stream_id) {
                             CloseConnection(
                               connection_handle, TerminationReason::kProtocolViolation, "Primary control stream FIN");
+                        } else {
+                            conn_ctx.ctrl_msg_buffer.erase(stream_id);
                         }
 
                         break;
@@ -1875,6 +1877,8 @@ namespace quicr {
                         if (conn_ctx.ctrl_stream_id.has_value() && conn_ctx.ctrl_stream_id == stream_id) {
                             CloseConnection(
                               connection_handle, TerminationReason::kProtocolViolation, "Primary control stream RESET");
+                        } else {
+                            conn_ctx.ctrl_msg_buffer.erase(stream_id);
                         }
                         break;
                 }

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -309,9 +309,9 @@ namespace quicr {
         }
     }
 
-    void Transport::SendCtrlMsg(const ConnectionContext& conn_ctx, BytesSpan data)
+    void Transport::SendCtrlMsg(const ConnectionContext& conn_ctx, DataContextId data_ctx_id, BytesSpan data)
     {
-        if (!conn_ctx.ctrl_data_ctx_id.has_value() || !conn_ctx.ctrl_stream_id.has_value()) {
+        if (!conn_ctx.ctrl_data_ctx_id.has_value()) {
             CloseConnection(conn_ctx.connection_handle,
                             messages::TerminationReason::kProtocolViolation,
                             "Control bidir data context not created");
@@ -319,8 +319,8 @@ namespace quicr {
         }
 
         auto result = quic_transport_->Enqueue(conn_ctx.connection_handle,
-                                               *conn_ctx.ctrl_data_ctx_id,
-                                               *conn_ctx.ctrl_stream_id,
+                                               data_ctx_id,
+                                               0 /* not use for bidir streams */,
                                                std::make_shared<const std::vector<uint8_t>>(data.begin(), data.end()),
                                                0,
                                                2000,
@@ -352,7 +352,7 @@ namespace quicr {
 
         auto& conn_ctx = connections_.begin()->second;
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending ClientSetup (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -374,7 +374,7 @@ namespace quicr {
 
         SPDLOG_LOGGER_DEBUG(logger_, "Sending SERVER_SETUP to conn_id: {0}", conn_ctx.connection_handle);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending ServerSetup (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -396,7 +396,7 @@ namespace quicr {
                             request_id,
                             th.track_namespace_hash);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending PublishNamespace (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -414,7 +414,7 @@ namespace quicr {
                             conn_ctx.connection_handle,
                             request_id);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending PUBLISH_NAMESPACE_OK (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -429,7 +429,7 @@ namespace quicr {
 
         SPDLOG_LOGGER_DEBUG(logger_, "Sending PUBLISH_NAMESPACE_DONE to conn_id: {}", conn_ctx.connection_handle);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending PUBLISH_NAMESPACE_DONE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -456,7 +456,7 @@ namespace quicr {
         SPDLOG_LOGGER_DEBUG(
           logger_, "Sending TRACK_STATUS to conn_id: {0} request_id: {1}", conn_ctx.connection_handle, request_id);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Trac (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -514,7 +514,7 @@ namespace quicr {
           th.track_namespace_hash,
           th.track_name_hash);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Subscribe (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -554,7 +554,7 @@ namespace quicr {
                             request_id,
                             track_alias);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Publish (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -584,7 +584,7 @@ namespace quicr {
         SPDLOG_LOGGER_DEBUG(
           logger_, "Sending PUBLISH_OK to conn_id: {0} request_id: {1} ", conn_ctx.connection_handle, request_id);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
 
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Publish Ok (error={})", e.what());
@@ -608,7 +608,7 @@ namespace quicr {
                             static_cast<int>(error),
                             reason);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Publish Error (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -646,7 +646,7 @@ namespace quicr {
                             th.track_name_hash,
                             forward);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending SubscribeUpdate (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -673,7 +673,7 @@ namespace quicr {
         SPDLOG_LOGGER_DEBUG(
           logger_, "Sending TRACK_STATUS_OK to conn_id: {0} request_id: {1}", conn_ctx.connection_handle, request_id);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending TrackStatusOk (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -705,7 +705,7 @@ namespace quicr {
         SPDLOG_LOGGER_DEBUG(
           logger_, "Sending SUBSCRIBE OK to conn_id: {0} request_id: {1}", conn_ctx.connection_handle, request_id);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending SubscribeOk (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -727,7 +727,7 @@ namespace quicr {
                             request_id,
                             static_cast<uint64_t>(status));
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending PUBLISH_DONE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -743,7 +743,7 @@ namespace quicr {
         SPDLOG_LOGGER_DEBUG(
           logger_, "Sending UNSUBSCRIBE to conn_id: {0} request_id: {1}", conn_ctx.connection_handle, request_id);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Unsubscribe (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -787,7 +787,7 @@ namespace quicr {
                             rid,
                             th.track_namespace_hash);
 
-        SendCtrlMsg(conn_it->second, buffer);
+        SendCtrlMsg(conn_it->second, conn_it->second.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending SUBSCRIBE_NAMESPACE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -805,7 +805,7 @@ namespace quicr {
                             conn_ctx.connection_handle,
                             request_id);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending SUBSCRIBE_NAMESPACE_OK (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -827,7 +827,7 @@ namespace quicr {
                             conn_ctx.connection_handle,
                             request_id);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending SUBSCRIBE_NAMESPACE_ERROR (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -868,7 +868,7 @@ namespace quicr {
                             conn_handle,
                             th.track_namespace_hash);
 
-        SendCtrlMsg(conn_it->second, buffer);
+        SendCtrlMsg(conn_it->second, conn_it->second.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending UNSUBSCRIBE_NAMESPACE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -891,7 +891,7 @@ namespace quicr {
                             static_cast<int>(error),
                             reason);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending TRACK_STATUS_ERROR (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -914,7 +914,7 @@ namespace quicr {
                             static_cast<int>(error),
                             reason);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending SUBSCRIBE_ERROR (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -941,7 +941,7 @@ namespace quicr {
         Bytes buffer;
         buffer << fetch;
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Fetch (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -969,7 +969,7 @@ namespace quicr {
         Bytes buffer;
         buffer << fetch;
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending JoiningFetch (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -982,7 +982,7 @@ namespace quicr {
         Bytes buffer;
         buffer << fetch_cancel;
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending FetchCancel (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -999,7 +999,7 @@ namespace quicr {
         Bytes buffer;
         buffer << fetch_ok;
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending FetchOk (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -1022,7 +1022,7 @@ namespace quicr {
                             static_cast<int>(error),
                             reason);
 
-        SendCtrlMsg(conn_ctx, buffer);
+        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending FetchError (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -1559,8 +1559,7 @@ namespace quicr {
                                        "Connection established, creating bi-dir stream and sending CLIENT_SETUP");
 
                     conn_ctx.ctrl_data_ctx_id = quic_transport_->CreateDataContext(conn_id, true, 0, true);
-                    conn_ctx.ctrl_stream_id =
-                      quic_transport_->CreateStream(conn_id, conn_ctx.ctrl_data_ctx_id.value(), 0);
+                    quic_transport_->CreateStream(conn_id, conn_ctx.ctrl_data_ctx_id.value(), 0);
 
                     SendClientSetup();
 
@@ -1671,15 +1670,17 @@ namespace quicr {
 
             // CONTROL STREAM
             if (is_bidir) {
-                // auto blob = to_hex(data);
-                conn_ctx.ctrl_msg_buffer.insert(conn_ctx.ctrl_msg_buffer.end(), data.begin(), data.end());
+                auto& ctrl_msg_buffer = conn_ctx.ctrl_msg_buffer[stream_id];
+                ctrl_msg_buffer.insert(ctrl_msg_buffer.end(), data.begin(), data.end());
+
                 rx_ctx->data_queue.PopFront();
                 SPDLOG_LOGGER_DEBUG(logger_,
                                     "Transport:ControlMessageReceived conn_id: {} stream_id: {} data size: {}",
                                     conn_id,
                                     stream_id,
-                                    conn_ctx.ctrl_msg_buffer.size());
+                                    ctrl_msg_buffer.size());
 
+                // Set the default/primary control stream and data context id
                 if (not conn_ctx.ctrl_data_ctx_id) {
                     if (not data_ctx_id) {
                         CloseConnection(conn_id,
@@ -1687,24 +1688,27 @@ namespace quicr {
                                         "Received bidir is missing data context");
                         return;
                     }
+
                     conn_ctx.ctrl_data_ctx_id = data_ctx_id;
-                    conn_ctx.ctrl_stream_id = stream_id;
+
+                    if (!conn_ctx.ctrl_stream_id.has_value()) { // First bidir is the primary control stream
+                        conn_ctx.ctrl_stream_id = stream_id;
+                    }
                 }
 
-                while (conn_ctx.ctrl_msg_buffer.size() > 0) {
+                while (ctrl_msg_buffer.size() > 0) {
                     if (not conn_ctx.ctrl_msg_type_received.has_value()) {
                         // Decode message type
-                        auto uv_sz = UintVar::Size(conn_ctx.ctrl_msg_buffer.front());
-                        if (conn_ctx.ctrl_msg_buffer.size() < uv_sz) {
+                        auto uv_sz = UintVar::Size(ctrl_msg_buffer.front());
+                        if (ctrl_msg_buffer.size() < uv_sz) {
                             i = kReadLoopMaxPerStream - 4;
                             break; // Not enough bytes to process control message. Try again once more.
                         }
 
-                        auto msg_type = uint64_t(quicr::UintVar(
-                          { conn_ctx.ctrl_msg_buffer.begin(), conn_ctx.ctrl_msg_buffer.begin() + uv_sz }));
+                        auto msg_type =
+                          uint64_t(quicr::UintVar({ ctrl_msg_buffer.begin(), ctrl_msg_buffer.begin() + uv_sz }));
 
-                        conn_ctx.ctrl_msg_buffer.erase(conn_ctx.ctrl_msg_buffer.begin(),
-                                                       conn_ctx.ctrl_msg_buffer.begin() + uv_sz);
+                        ctrl_msg_buffer.erase(ctrl_msg_buffer.begin(), ctrl_msg_buffer.begin() + uv_sz);
 
                         conn_ctx.ctrl_msg_type_received = static_cast<ControlMessageType>(msg_type);
                     }
@@ -1712,34 +1716,32 @@ namespace quicr {
                     uint16_t payload_len = 0;
 
                     // Decode control payload length in bytes
-                    if (conn_ctx.ctrl_msg_buffer.size() < sizeof(payload_len)) {
+                    if (ctrl_msg_buffer.size() < sizeof(payload_len)) {
                         i = kReadLoopMaxPerStream - 4;
                         break; // Not enough bytes to process control message. Try again once more.
                     }
 
-                    std::memcpy(&payload_len, conn_ctx.ctrl_msg_buffer.data(), sizeof(payload_len));
+                    std::memcpy(&payload_len, ctrl_msg_buffer.data(), sizeof(payload_len));
                     payload_len = SwapBytes(payload_len);
 
-                    if (conn_ctx.ctrl_msg_buffer.size() < payload_len + sizeof(payload_len)) {
+                    if (ctrl_msg_buffer.size() < payload_len + sizeof(payload_len)) {
                         i = kReadLoopMaxPerStream - 4;
                         break; // Not enough bytes to process control message. Try again once more.
                     }
 
-                    if (ProcessCtrlMessage(
-                          conn_ctx,
-                          { conn_ctx.ctrl_msg_buffer.begin() + sizeof(payload_len), conn_ctx.ctrl_msg_buffer.end() })) {
+                    if (ProcessCtrlMessage(conn_ctx,
+                                           data_ctx_id.value(),
+                                           { ctrl_msg_buffer.begin() + sizeof(payload_len), ctrl_msg_buffer.end() })) {
 
                         // Reset the control message buffer and message type to start a new message.
                         conn_ctx.ctrl_msg_type_received = std::nullopt;
-                        conn_ctx.ctrl_msg_buffer.erase(conn_ctx.ctrl_msg_buffer.begin(),
-                                                       conn_ctx.ctrl_msg_buffer.begin() + sizeof(payload_len) +
-                                                         payload_len);
+                        ctrl_msg_buffer.erase(ctrl_msg_buffer.begin(),
+                                              ctrl_msg_buffer.begin() + sizeof(payload_len) + payload_len);
                     } else {
                         conn_ctx.metrics.invalid_ctrl_stream_msg++;
                         conn_ctx.ctrl_msg_type_received = std::nullopt;
-                        conn_ctx.ctrl_msg_buffer.erase(conn_ctx.ctrl_msg_buffer.begin(),
-                                                       conn_ctx.ctrl_msg_buffer.begin() + sizeof(payload_len) +
-                                                         payload_len);
+                        ctrl_msg_buffer.erase(ctrl_msg_buffer.begin(),
+                                              ctrl_msg_buffer.begin() + sizeof(payload_len) + payload_len);
                     }
                 }
                 continue;
@@ -1851,6 +1853,29 @@ namespace quicr {
         }
 
         try {
+
+            if ((stream_id & 2) == 0) { // bidir
+                auto& conn_ctx = connections_[connection_handle];
+
+                switch (flag) {
+                    case StreamClosedFlag::kFin:
+                        if (conn_ctx.ctrl_stream_id.has_value() && conn_ctx.ctrl_stream_id == stream_id) {
+                            CloseConnection(
+                              connection_handle, TerminationReason::kProtocolViolation, "Primary control stream FIN");
+                        }
+
+                        break;
+                    case StreamClosedFlag::kReset:
+                        if (conn_ctx.ctrl_stream_id.has_value() && conn_ctx.ctrl_stream_id == stream_id) {
+                            CloseConnection(
+                              connection_handle, TerminationReason::kProtocolViolation, "Primary control stream RESET");
+                        }
+                        break;
+                }
+
+                return;
+            }
+
             const auto handler_weak = std::any_cast<std::weak_ptr<SubscribeTrackHandler>>(rx_ctx->caller_any);
             if (const auto handler = handler_weak.lock(); handler) {
                 try {

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -161,7 +161,6 @@ namespace quicr {
             TransportConnId conn_id{ 0 };     /// This connection ID
             picoquic_cnx_t* pq_cnx = nullptr; /// Picoquic connection/path context
             uint64_t last_stream_id{ 0 };     /// last stream Id
-            std::optional<uint64_t> control_stream_id{ std::nullopt };
 
             bool mark_dgram_ready{ false };                       /// Instructs datagram to be marked ready/active
             TransportMode transport_mode{ TransportMode::kQuic }; /// Transport mode for this connection

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -128,6 +128,7 @@ TestServer::SubscribeReceived(ConnectionHandle connection_handle,
 
 void
 TestServer::SubscribeNamespaceReceived(const ConnectionHandle connection_handle,
+                                       const DataContextId data_ctx_id,
                                        const TrackNamespace& prefix_namespace,
                                        const SubscribeNamespaceAttributes& attributes)
 {
@@ -150,7 +151,7 @@ TestServer::SubscribeNamespaceReceived(const ConnectionHandle connection_handle,
     }
 
     // Blindly accept it.
-    ResolveSubscribeNamespace(connection_handle, attributes.request_id, prefix_namespace, response);
+    ResolveSubscribeNamespace(connection_handle, data_ctx_id, attributes.request_id, prefix_namespace, response);
 }
 
 void

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -174,6 +174,7 @@ namespace quicr_test {
         }
 
         void UnsubscribeNamespaceReceived([[maybe_unused]] quicr::ConnectionHandle connection_handle,
+                                          [[maybe_unused]] quicr::DataContextId data_ctx_id,
                                           [[maybe_unused]] const quicr::TrackNamespace& prefix_namespace) override {};
         void UnsubscribeReceived([[maybe_unused]] quicr::ConnectionHandle connection_handle,
                                  [[maybe_unused]] uint64_t request_id) override
@@ -201,6 +202,7 @@ namespace quicr_test {
         void PublishDoneReceived(quicr::ConnectionHandle connection_handle, uint64_t request_id) override;
 
         void SubscribeNamespaceReceived(quicr::ConnectionHandle connection_handle,
+                                        quicr::DataContextId data_ctx_id,
                                         const quicr::TrackNamespace& prefix_namespace,
                                         const quicr::SubscribeNamespaceAttributes& attributes) override;
 


### PR DESCRIPTION
Stub support for control messages to use their own control stream. Per draft-16, `SUBSCRIBE_NAMESPACE`, OK, and ERROR use a new bidir stream for the transaction. 

Resolves #773 