### PR TITLE
Support new fetch object serialization variants

### DIFF
--- a/include/quicr/detail/joining_fetch_handler.h
+++ b/include/quicr/detail/joining_fetch_handler.h
@@ -28,6 +28,7 @@ namespace quicr {
 
       private:
         std::shared_ptr<SubscribeTrackHandler> joining_subscribe_;
+        messages::FetchObjectSerializationState state_;
     };
 
 } // namespace moq

--- a/include/quicr/fetch_track_handler.h
+++ b/include/quicr/fetch_track_handler.h
@@ -70,9 +70,14 @@ namespace quicr {
                             uint64_t stream_id,
                             std::shared_ptr<const std::vector<uint8_t>> data) override;
 
+        static ObjectHeaders From(const messages::FetchObject& message,
+                                  const messages::FetchObjectSerializationState& state);
+
       private:
         messages::Location start_location_;
         messages::FetchEndLocation end_location_;
+
+        messages::FetchObjectSerializationState state_;
 
         friend class Transport;
         friend class Client;

--- a/include/quicr/publish_fetch_handler.h
+++ b/include/quicr/publish_fetch_handler.h
@@ -38,6 +38,7 @@ namespace quicr {
         messages::GroupOrder group_order_;
         bool sent_first_header_{ false };
         uint64_t stream_id_{ 0 }; /// Stream ID for fetch, set on sent_first_header
+        messages::FetchObjectSerializationState serialization_state_;
     };
 
 } // namespace moq

--- a/src/fetch_track_handler.cpp
+++ b/src/fetch_track_handler.cpp
@@ -14,6 +14,7 @@ namespace quicr {
 
         if (is_start) {
             stream.buffer.Clear();
+            state_ = {};
 
             stream.buffer.InitAny<messages::FetchHeader>();
             stream.buffer.Push(*data);

--- a/src/fetch_track_handler.cpp
+++ b/src/fetch_track_handler.cpp
@@ -92,8 +92,9 @@ namespace quicr {
             }
             headers.object_id = *state.prior_object_id + 1;
         }
+        assert(message.properties.has_value());
         const auto& properties = *message.properties;
-        if (!properties.datagram) {
+        if (!properties.datagram && !properties.end_of_range.has_value()) {
             if (!properties.subgroup_id_mode.has_value()) {
                 throw std::invalid_argument("Missing subgroup_id_mode");
             }
@@ -115,8 +116,7 @@ namespace quicr {
                     headers.subgroup_id = 0;
                     break;
                 case messages::FetchSerializationProperties::FetchSubgroupIdType::kSubgroupExplicit:
-                    // TODO: Think about what to do if subgroup_id is not set.
-                    // At this point in the code is this a bug or a protocol violation?
+                    assert(message.subgroup_id.has_value());
                     headers.subgroup_id = *message.subgroup_id;
                     break;
                 default:

--- a/src/fetch_track_handler.cpp
+++ b/src/fetch_track_handler.cpp
@@ -56,11 +56,11 @@ namespace quicr {
             SPDLOG_TRACE("Received fetch_object subscribe_id: {} priority: {} "
                          "group_id: {} subgroup_id: {} object_id: {} data size: {}",
                          *GetSubscribeId(),
-                         headers.publisher_priority,
+                         headers.priority.has_value() ? static_cast<int>(*headers.priority) : -1,
                          headers.group_id,
                          headers.subgroup_id,
                          headers.object_id,
-                         headers.payload.size());
+                         headers.payload_length);
             try {
                 ObjectReceived(headers, obj.payload);
             } catch (const std::exception& e) {
@@ -94,6 +94,9 @@ namespace quicr {
         }
         const auto& properties = *message.properties;
         if (!properties.datagram) {
+            if (!properties.subgroup_id_mode.has_value()) {
+                throw std::invalid_argument("Missing subgroup_id_mode");
+            }
             switch (*properties.subgroup_id_mode) {
                 case messages::FetchSerializationProperties::FetchSubgroupIdType::kSubgroupPrior:
                     if (!state.prior_subgroup_id.has_value()) {
@@ -132,6 +135,7 @@ namespace quicr {
         }
 
         headers.payload_length = message.payload.size();
+        headers.status = message.payload.empty() ? message.object_status : ObjectStatus::kAvailable;
         headers.ttl = std::nullopt; // TODO: TTL?
         headers.track_mode = properties.datagram ? TrackMode::kDatagram : TrackMode::kStream;
         headers.extensions = message.extensions;

--- a/src/joining_fetch_handler.cpp
+++ b/src/joining_fetch_handler.cpp
@@ -14,6 +14,7 @@ namespace quicr {
 
         if (is_start) {
             stream.buffer.Clear();
+            state_ = {};
 
             stream.buffer.InitAny<messages::FetchHeader>();
             stream.buffer.Push(*data);

--- a/src/joining_fetch_handler.cpp
+++ b/src/joining_fetch_handler.cpp
@@ -47,11 +47,11 @@ namespace quicr {
             SPDLOG_TRACE("Received fetch_object subscribe_id: {} priority: {} "
                          "group_id: {} subgroup_id: {} object_id: {} data size: {}",
                          *GetSubscribeId(),
-                         headers.publisher_priority,
+                         headers.priority.has_value() ? static_cast<int>(*headers.priority) : -1,
                          headers.group_id,
                          headers.subgroup_id,
                          headers.object_id,
-                         headers.payload.size());
+                         headers.payload_length);
             try {
                 joining_subscribe_->ObjectReceived(headers, obj.payload);
             } catch (const std::exception& e) {

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -491,20 +491,27 @@ namespace quicr::messages {
             case 2: {
                 const auto& properties = *msg.properties;
                 if (!properties.datagram) {
-                    switch (*properties.subgroup_id_mode) {
-                        case FetchSerializationProperties::FetchSubgroupIdType::kSubgroupZero:
-                            msg.subgroup_id = 0;
-                            break;
-                        case FetchSerializationProperties::FetchSubgroupIdType::kSubgroupExplicit:
-                            std::uint64_t subgroup_id;
-                            if (!ParseUintVField(buffer, subgroup_id)) {
-                                return false;
-                            }
-                            msg.subgroup_id = subgroup_id;
-                            break;
-                        default:
-                            msg.subgroup_id = std::nullopt;
-                            break;
+                    if (properties.end_of_range.has_value()) {
+                        msg.subgroup_id = std::nullopt;
+                    } else {
+                        if (!properties.subgroup_id_mode.has_value()) {
+                            throw new ProtocolViolationException("Unexpectedly missing subgroup mode");
+                        }
+                        switch (*properties.subgroup_id_mode) {
+                            case FetchSerializationProperties::FetchSubgroupIdType::kSubgroupZero:
+                                msg.subgroup_id = 0;
+                                break;
+                            case FetchSerializationProperties::FetchSubgroupIdType::kSubgroupExplicit:
+                                std::uint64_t subgroup_id;
+                                if (!ParseUintVField(buffer, subgroup_id)) {
+                                    return false;
+                                }
+                                msg.subgroup_id = subgroup_id;
+                                break;
+                            default:
+                                msg.subgroup_id = std::nullopt;
+                                break;
+                        }
                     }
                 } else {
                     msg.subgroup_id = std::nullopt;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -474,6 +474,7 @@ namespace quicr::messages {
                 }
                 msg.properties.emplace(FetchSerializationProperties(serialized_flags));
                 msg.current_pos += 1;
+                [[fallthrough]];
             }
             case 1: {
                 if (msg.properties->group_id_present) {
@@ -495,7 +496,7 @@ namespace quicr::messages {
                         msg.subgroup_id = std::nullopt;
                     } else {
                         if (!properties.subgroup_id_mode.has_value()) {
-                            throw new ProtocolViolationException("Unexpectedly missing subgroup mode");
+                            throw ProtocolViolationException("Unexpectedly missing subgroup mode");
                         }
                         switch (*properties.subgroup_id_mode) {
                             case FetchSerializationProperties::FetchSubgroupIdType::kSubgroupZero:

--- a/src/publish_fetch_handler.cpp
+++ b/src/publish_fetch_handler.cpp
@@ -17,6 +17,9 @@ namespace quicr {
 
         bool is_stream_header_needed{ !sent_first_header_ };
         sent_first_header_ = true;
+        if (is_stream_header_needed) {
+            serialization_state_ = {};
+        }
 
         const auto request_id = GetRequestId();
         if (!request_id.has_value()) {

--- a/src/publish_fetch_handler.cpp
+++ b/src/publish_fetch_handler.cpp
@@ -66,7 +66,9 @@ namespace quicr {
             }
         }
 
+        // Serialize.
         messages::FetchObject object{};
+        object.properties.emplace(serialization_state_.MakeProperties(object_headers, priority));
         object.group_id = group_id;
         object.subgroup_id = object_headers.subgroup_id;
         object.object_id = object_id;
@@ -89,6 +91,9 @@ namespace quicr {
         if (result != TransportError::kNone) {
             throw TransportException(result);
         }
+
+        // Save state for serialization optimizations.
+        serialization_state_.Update(object_headers);
 
         return PublishTrackHandler::PublishObjectStatus::kOk;
     }

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -760,7 +760,7 @@ TEST_CASE("Integration - Annouce Flow")
         CHECK_EQ(ns_handler->GetStatus(), PublishNamespaceHandler::Status::kOk);
 
         const std::string name = "test";
-        const FullTrackName ftn(prefix, std::vector<uint8_t>{ name.begin(), name.end() });
+        const FullTrackName ftn{ prefix, std::vector<uint8_t>{ name.begin(), name.end() } };
 
         std::weak_ptr<PublishTrackHandler> w_pub_handler;
         REQUIRE_NOTHROW(w_pub_handler = ns_handler->PublishTrack(ftn, TrackMode::kStream, 1, 5000));

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -904,6 +904,77 @@ TEST_CASE("Integration - Fetch object roundtrip")
     }
 }
 
+TEST_CASE("Integration - Fetch serialization state resets between streams")
+{
+    using namespace quicr::messages;
+
+    auto serialize_objects = [](Bytes& buffer,
+                                FetchObjectSerializationState& state,
+                                GroupId group,
+                                SubGroupId subgroup,
+                                ObjectId object_start,
+                                ObjectPriority priority,
+                                std::size_t count) {
+        for (std::size_t i = 0; i < count; i++) {
+            ObjectHeaders oh{};
+            oh.group_id = group;
+            oh.subgroup_id = subgroup;
+            oh.object_id = object_start + i;
+            oh.priority = priority;
+            oh.track_mode = TrackMode::kStream;
+
+            FetchObject obj{};
+            obj.group_id = oh.group_id;
+            obj.subgroup_id = oh.subgroup_id;
+            obj.object_id = oh.object_id;
+            obj.publisher_priority = priority;
+            obj.payload = { static_cast<uint8_t>(i) };
+
+            obj.properties.emplace(state.MakeProperties(oh, priority));
+            state.Update(oh);
+            buffer << obj;
+        }
+    };
+
+    FullTrackName ftn;
+    ftn.name_space = TrackNamespace(std::vector<std::string>{ "test", "fetch-reset" });
+    ftn.name = { 1, 2, 3 };
+
+    constexpr std::size_t kObjectsPerStream = 5;
+
+    // Stream 1.
+    Bytes stream1_buf;
+    FetchHeader hdr1;
+    hdr1.request_id = 1;
+    stream1_buf << hdr1;
+    FetchObjectSerializationState sender_state;
+    serialize_objects(stream1_buf, sender_state, 100, 10, 0, 5, kObjectsPerStream);
+
+    // Stream 2 with stale data should fail gracefully
+    Bytes stream2_buf;
+    FetchHeader hdr2;
+    hdr2.request_id = 1;
+    stream2_buf << hdr2;
+    serialize_objects(stream2_buf, sender_state, 100, 10, 5, 5, kObjectsPerStream);
+
+    auto handler = TestFetchTrackHandler::Create(
+      ftn, 0, GroupOrder::kOriginalPublisherOrder, { 0, 0 }, { 0, std::nullopt });
+    handler->SetRequestId(1);
+
+    // Stream 1 fine.
+    auto s1 = std::make_shared<std::vector<uint8_t>>(stream1_buf.begin(), stream1_buf.end());
+    handler->StreamDataRecv(true, 1, s1);
+    auto empty = std::make_shared<std::vector<uint8_t>>();
+    for (std::size_t i = 1; i < kObjectsPerStream; i++) {
+        handler->StreamDataRecv(false, 1, empty);
+    }
+    REQUIRE_EQ(handler->GetReceivedCount(), kObjectsPerStream);
+
+    // Stream 2 is bad and should throw.
+    auto s2 = std::make_shared<std::vector<uint8_t>>(stream2_buf.begin(), stream2_buf.end());
+    CHECK_THROWS_AS(handler->StreamDataRecv(true, 2, s2), ProtocolViolationException);
+}
+
 TEST_CASE("Integration - Subgroup and Stream Testing")
 {
     // Server needs to support 2 connections (subscriber + publisher)

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -940,7 +940,7 @@ TEST_CASE("Integration - Fetch serialization state resets between streams")
     ftn.name_space = TrackNamespace(std::vector<std::string>{ "test", "fetch-reset" });
     ftn.name = { 1, 2, 3 };
 
-    constexpr std::size_t kObjectsPerStream = 5;
+    constexpr std::size_t objects_per_stream = 5;
 
     // Stream 1.
     Bytes stream1_buf;
@@ -948,27 +948,27 @@ TEST_CASE("Integration - Fetch serialization state resets between streams")
     hdr1.request_id = 1;
     stream1_buf << hdr1;
     FetchObjectSerializationState sender_state;
-    serialize_objects(stream1_buf, sender_state, 100, 10, 0, 5, kObjectsPerStream);
+    serialize_objects(stream1_buf, sender_state, 100, 10, 0, 5, objects_per_stream);
 
     // Stream 2 with stale data should fail gracefully
     Bytes stream2_buf;
     FetchHeader hdr2;
     hdr2.request_id = 1;
     stream2_buf << hdr2;
-    serialize_objects(stream2_buf, sender_state, 100, 10, 5, 5, kObjectsPerStream);
+    serialize_objects(stream2_buf, sender_state, 100, 10, 5, 5, objects_per_stream);
 
-    auto handler = TestFetchTrackHandler::Create(
-      ftn, 0, GroupOrder::kOriginalPublisherOrder, { 0, 0 }, { 0, std::nullopt });
+    auto handler =
+      TestFetchTrackHandler::Create(ftn, 0, GroupOrder::kOriginalPublisherOrder, { 0, 0 }, { 0, std::nullopt });
     handler->SetRequestId(1);
 
     // Stream 1 fine.
     auto s1 = std::make_shared<std::vector<uint8_t>>(stream1_buf.begin(), stream1_buf.end());
     handler->StreamDataRecv(true, 1, s1);
     auto empty = std::make_shared<std::vector<uint8_t>>();
-    for (std::size_t i = 1; i < kObjectsPerStream; i++) {
+    for (std::size_t i = 1; i < objects_per_stream; i++) {
         handler->StreamDataRecv(false, 1, empty);
     }
-    REQUIRE_EQ(handler->GetReceivedCount(), kObjectsPerStream);
+    REQUIRE_EQ(handler->GetReceivedCount(), objects_per_stream);
 
     // Stream 2 is bad and should throw.
     auto s2 = std::make_shared<std::vector<uint8_t>>(stream2_buf.begin(), stream2_buf.end());

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "quicr/detail/messages.h"
+#include "quicr/fetch_track_handler.h"
 
 #include <any>
 #include <doctest/doctest.h>
@@ -549,31 +550,51 @@ FetchStreamEncodeDecode(ExtensionTest extensions, bool empty_payload)
     // stream all the objects
     buffer.clear();
     auto objects = std::vector<messages::FetchObject>{};
+    auto expected_headers = std::vector<ObjectHeaders>{};
+    FetchObjectSerializationState send_state;
+    FetchObjectSerializationState recv_state;
     // send 10 objects
     for (size_t i = 0; i < 10; i++) {
+        ObjectHeaders expected{};
+        expected.group_id = 0x1234;
+        expected.subgroup_id = 0x5678;
+        expected.object_id = 0x9012 + i;
+        expected.priority = 127;
+        expected.track_mode = TrackMode::kStream;
+
         auto obj = messages::FetchObject{};
-        obj.group_id = 0x1234;
-        obj.subgroup_id = 0x5678;
-        obj.object_id = 0x9012;
-        obj.publisher_priority = 127;
+        obj.group_id = expected.group_id;
+        obj.subgroup_id = expected.subgroup_id;
+        obj.object_id = expected.object_id;
+        obj.publisher_priority = expected.priority;
 
         if (empty_payload) {
             obj.object_status = ObjectStatus::kDoesNotExist;
         } else {
             obj.payload = { 0x1, 0x2, 0x3, 0x4, 0x5 };
         }
+        expected.payload_length = obj.payload.size();
 
         if (extensions == ExtensionTest::kBoth || extensions == ExtensionTest::kMutable) {
             obj.extensions = kOptionalExtensions;
+            expected.extensions = kOptionalExtensions;
         } else {
             obj.extensions = std::nullopt;
+            expected.extensions = std::nullopt;
         }
         if (extensions == ExtensionTest::kBoth || extensions == ExtensionTest::kImmutable) {
             obj.immutable_extensions = kOptionalExtensions;
+            expected.immutable_extensions = kOptionalExtensions;
         } else {
             obj.immutable_extensions = std::nullopt;
+            expected.immutable_extensions = std::nullopt;
         }
+
+        obj.properties.emplace(send_state.MakeProperties(expected, *expected.priority));
+        send_state.Update(expected);
+
         objects.push_back(obj);
+        expected_headers.push_back(expected);
         buffer << obj;
     }
 
@@ -586,10 +607,19 @@ FetchStreamEncodeDecode(ExtensionTest extensions, bool empty_payload)
         if (!done) {
             continue;
         }
-        CHECK_EQ(obj_out.group_id, objects[object_count].group_id);
-        CHECK_EQ(obj_out.subgroup_id, objects[object_count].subgroup_id);
-        CHECK_EQ(obj_out.object_id, objects[object_count].object_id);
-        CHECK_EQ(obj_out.publisher_priority, objects[object_count].publisher_priority);
+
+        const auto decoded_headers = FetchTrackHandler::From(obj_out, recv_state);
+        recv_state.Update(decoded_headers);
+        CHECK_EQ(decoded_headers.group_id, expected_headers[object_count].group_id);
+        CHECK_EQ(decoded_headers.subgroup_id, expected_headers[object_count].subgroup_id);
+        CHECK_EQ(decoded_headers.object_id, expected_headers[object_count].object_id);
+        CHECK_EQ(decoded_headers.payload_length, expected_headers[object_count].payload_length);
+        if (obj_out.publisher_priority.has_value()) {
+            CHECK_EQ(*obj_out.publisher_priority, *expected_headers[object_count].priority);
+        } else {
+            REQUIRE(recv_state.prior_priority.has_value());
+            CHECK_EQ(*recv_state.prior_priority, *expected_headers[object_count].priority);
+        }
         if (empty_payload) {
             CHECK_EQ(obj_out.object_status, objects[object_count].object_status);
         } else {
@@ -602,7 +632,7 @@ FetchStreamEncodeDecode(ExtensionTest extensions, bool empty_payload)
         CHECK_EQ(obj_out.immutable_extensions, objects[object_count].immutable_extensions);
         // got one object
         object_count++;
-        obj_out = {};
+        std::construct_at(&obj_out);
         in_buffer.Pop(in_buffer.Size());
     }
 
@@ -689,6 +719,15 @@ TEST_CASE("Immutable Extensions Nesting")
     msg.immutable_extensions = nested_immutable;
     msg.payload_len = 0;
     msg.object_status = ObjectStatus::kAvailable;
+    ObjectHeaders headers{};
+    headers.group_id = *msg.group_id;
+    headers.subgroup_id = *msg.subgroup_id;
+    headers.object_id = *msg.object_id;
+    headers.priority = *msg.publisher_priority;
+    headers.track_mode = TrackMode::kStream;
+    headers.immutable_extensions = msg.immutable_extensions;
+    FetchObjectSerializationState serialization_state{};
+    msg.properties.emplace(serialization_state.MakeProperties(headers, *headers.priority));
 
     // Serialization should throw ProtocolViolationException
     Bytes buffer;


### PR DESCRIPTION
New fetch object serialization. It's getting late so I've thrown this up - I think it's almost there but haven't deeply reviewed what I've done. There are some assertions in here I need to check are actual assertions and not protocol violations. I have tried to keep things type safe / explicit where I can. Now that basically everything is optional, it's harder to easily reason about the valid states. 