### PR TITLE
Dynamic Groups x New Group Request

### DIFF
--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -88,18 +88,21 @@ namespace quicr {
          * @param default_ttl           Default TTL for objects if not specified in ObjectHeaderss
          * @param stream_mode           Stream to use when track mode is kStream.
          * @param largest_location      Largest location to start the handler
+         * @param dynamic_groups        Whether this track supports dynamic groups
          */
         PublishTrackHandler(const FullTrackName& full_track_name,
                             TrackMode track_mode,
                             uint8_t default_priority,
                             uint32_t default_ttl,
                             std::optional<messages::StreamHeaderProperties> stream_mode = std::nullopt,
-                            messages::Location largest_location = { 0, 0 })
+                            messages::Location largest_location = { 0, 0 },
+                            const bool dynamic_groups = true)
           : BaseTrackHandler(full_track_name)
           , default_track_mode_(track_mode)
           , default_priority_(default_priority)
           , default_ttl_(default_ttl)
           , largest_location_(largest_location)
+          , support_new_group_request_(dynamic_groups)
         {
             switch (track_mode) {
                 case TrackMode::kDatagram:
@@ -126,15 +129,22 @@ namespace quicr {
          * @param default_priority      Default priority for objects if not specified in ObjectHeaderss
          * @param default_ttl           Default TTL for objects if not specified in ObjectHeaderss
          * @param largest_location      Largest location to start handler at
+         * @param dynamic_groups        Whether this track supports dynamic groups
          */
         static std::shared_ptr<PublishTrackHandler> Create(const FullTrackName& full_track_name,
                                                            TrackMode track_mode,
                                                            uint8_t default_priority,
                                                            uint32_t default_ttl,
-                                                           messages::Location largest_location)
+                                                           messages::Location largest_location,
+                                                           const bool dynamic_groups = true)
         {
-            return std::shared_ptr<PublishTrackHandler>(new PublishTrackHandler(
-              full_track_name, track_mode, default_priority, default_ttl, std::nullopt, largest_location));
+            return std::shared_ptr<PublishTrackHandler>(new PublishTrackHandler(full_track_name,
+                                                                                track_mode,
+                                                                                default_priority,
+                                                                                default_ttl,
+                                                                                std::nullopt,
+                                                                                largest_location,
+                                                                                dynamic_groups));
         }
 
         // TODO: Is this all the info needed for an alias calculation?
@@ -409,7 +419,7 @@ namespace quicr {
 
         Bytes object_msg_buffer_; // TODO(tievens): Review shrink/resize
 
-        bool support_new_group_request_{ true };
+        const bool support_new_group_request_;
         std::optional<uint64_t> pending_new_group_request_id_;
 
         friend class Transport;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -391,6 +391,19 @@ namespace quicr {
                         sub_handler->SetLatestLocation(largest_location.value());
                     }
 
+                    // Dynamic group support?
+                    bool dynamic_groups = false;
+                    try {
+                        const auto value =
+                          msg.track_extensions.Get<std::uint64_t>(messages::ExtensionType::kDynamicGroups);
+                        if (value > 1) {
+                            throw messages::ProtocolViolationException("Dynamic Groups value must be 0 or 1");
+                        }
+                        dynamic_groups = value;
+                    } catch (const std::out_of_range&) {
+                    }
+
+                    sub_handler->SupportNewGroupRequest(dynamic_groups);
                     sub_handler->SetReceivedTrackAlias(msg.track_alias);
                     sub_handler->SetStatus(SubscribeTrackHandler::Status::kOk);
                 }
@@ -482,6 +495,16 @@ namespace quicr {
                 attrs.is_publisher_initiated = true;
                 attrs.new_group_request_id = new_group_request_id;
                 attrs.delivery_timeout = std::chrono::milliseconds(delivery_timeout);
+
+                // Dynamic group support?
+                try {
+                    const auto value = msg.track_extensions.Get<std::uint64_t>(messages::ExtensionType::kDynamicGroups);
+                    if (value > 1) {
+                        throw messages::ProtocolViolationException("Dynamic Groups value must be 0 or 1");
+                    }
+                    attrs.dynamic_groups = value;
+                } catch (const std::out_of_range&) {
+                }
 
                 std::weak_ptr<SubscribeNamespaceHandler> sub_ns_handler;
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -334,8 +334,21 @@ namespace quicr {
                 messages::RequestUpdate msg;
                 msg_bytes >> msg;
 
-                auto track_it = conn_ctx.request_handlers.find(msg.existing_request_id);
-                if (track_it == conn_ctx.request_handlers.end()) {
+                // Find the handler to route to.
+                std::shared_ptr<BaseTrackHandler> track_handler;
+                const auto track_it = conn_ctx.request_handlers.find(msg.existing_request_id);
+                if (track_it != conn_ctx.request_handlers.end()) {
+                    // Our local handler lookup.
+                    track_handler = track_it->second.handler;
+                } else {
+                    // Resolve remote request to local handler.
+                    const auto req_it = conn_ctx.recv_req_id.find(msg.existing_request_id);
+                    if (req_it != conn_ctx.recv_req_id.end()) {
+                        track_handler = GetPubTrackHandler(conn_ctx, req_it->second.track_hash);
+                    }
+                }
+
+                if (!track_handler) {
                     SPDLOG_LOGGER_WARN(logger_,
                                        "Received REQUEST_UPDATE to unknown track conn_id: {} request_id: {}, "
                                        "existing_request_id: {} ignored",
@@ -344,8 +357,6 @@ namespace quicr {
                                        msg.existing_request_id);
                     return true;
                 }
-
-                auto& track_handler = track_it->second.handler;
 
                 track_handler->RequestUpdate(msg.request_id, msg.parameters);
 

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -407,6 +407,13 @@ namespace quicr {
 
     void PublishTrackHandler::RequestUpdate([[maybe_unused]] uint64_t request_id, const messages::Parameters& params)
     {
+        if (const auto new_group_request_id =
+              params.GetOptional<std::uint64_t>(messages::ParameterType::kNewGroupRequest);
+            new_group_request_id) {
+            pending_new_group_request_id_ = *new_group_request_id;
+            SetStatus(Status::kNewGroupRequested);
+        }
+
         if (auto forward = params.GetOptional<bool>(messages::ParameterType::kForward); forward) {
             SetStatus(*forward ? Status::kOk : Status::kPaused);
         }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -774,7 +774,11 @@ namespace quicr {
 
                 conn_ctx.recv_req_id[msg.request_id] = { .track_full_name = tfn, .track_hash = th };
 
-                bool dynamic_groups = false; // TODO: Figure this out
+                bool dynamic_groups = false;
+                try {
+                    dynamic_groups = msg.track_extensions.Get<std::uint64_t>(messages::ExtensionType::kDynamicGroups);
+                } catch (const std::out_of_range&) {
+                }
                 auto delivery_timeout = msg.parameters.Get<std::uint64_t>(messages::ParameterType::kDeliveryTimeout);
                 auto expires = msg.parameters.Get<std::uint64_t>(messages::ParameterType::kExpires);
                 auto group_order = msg.parameters.Get<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
@@ -851,13 +855,15 @@ namespace quicr {
                 messages::RequestUpdate msg;
                 msg_bytes >> msg;
 
-                auto sub_ctx_it = conn_ctx.recv_req_id.find(msg.request_id);
+                auto sub_ctx_it = conn_ctx.recv_req_id.find(msg.existing_request_id);
                 if (sub_ctx_it == conn_ctx.recv_req_id.end()) {
                     // update for invalid subscription
                     SPDLOG_LOGGER_WARN(logger_,
-                                       "Received subscribe_update for unknown subscription conn_id: {} request_id: {}",
+                                       "Received subscribe_update for unknown subscription conn_id: {} request_id: {} "
+                                       "existing_request_id: {}",
                                        conn_ctx.connection_handle,
-                                       msg.request_id);
+                                       msg.request_id,
+                                       msg.existing_request_id);
 
                     SendRequestError(
                       conn_ctx, msg.request_id, messages::ErrorCode::kDoesNotExist, 0ms, "Subscription not found");

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -65,6 +65,32 @@ WaitFor(Predicate predicate,
     return predicate(); // Final check
 }
 
+class CallbackPublishTrackHandler final : public PublishTrackHandler
+{
+  public:
+    using StatusCallback = std::function<void(Status)>;
+
+    CallbackPublishTrackHandler(const FullTrackName& ftn,
+                                const uint8_t priority,
+                                const uint32_t ttl,
+                                const StatusCallback on_status,
+                                const bool support_dynamic_groups = true)
+      : PublishTrackHandler(ftn, TrackMode::kStream, priority, ttl, std::nullopt, { 0, 0 }, support_dynamic_groups)
+      , on_status_(std::move(on_status))
+    {
+    }
+
+    void StatusChanged(const Status status) override
+    {
+        if (on_status_) {
+            on_status_(status);
+        }
+    }
+
+  private:
+    const StatusCallback on_status_;
+};
+
 static std::shared_ptr<TestServer>
 MakeTestServer(const std::optional<std::string>& qlog_path = std::nullopt,
                std::optional<std::size_t> max_connections = std::nullopt)
@@ -1248,9 +1274,19 @@ TEST_CASE("Integration - Dynamic groups support roundtrip")
         ftn.name_space = TrackNamespace({ "namespace" });
         ftn.name = { 1, 2, 3 };
 
-        // Publish a track.
-        const auto pub_handler =
-          PublishTrackHandler::Create(ftn, TrackMode::kStream, 1, 5000, { 0, 0 }, dynamic_groups);
+        // Publish the track, watching for a new group request.
+        std::atomic new_group_was_requested{ false };
+        const auto pub_handler = std::make_shared<CallbackPublishTrackHandler>(
+          ftn,
+          1,
+          5000,
+          [&new_group_was_requested](const PublishTrackHandler::Status status) {
+              // Ensure we get the status callback.
+              if (status == PublishTrackHandler::Status::kNewGroupRequested) {
+                  new_group_was_requested = true;
+              }
+          },
+          dynamic_groups);
         publisher->PublishTrack(pub_handler);
         const bool pub_ready = WaitFor([&pub_handler]() { return pub_handler->CanPublish(); });
         REQUIRE(pub_ready);
@@ -1266,6 +1302,13 @@ TEST_CASE("Integration - Dynamic groups support roundtrip")
 
         // The subscriber's handler should reflect the publisher's declared dynamic group support.
         CHECK_EQ(sub_handler->IsNewGroupRequestSupported(), dynamic_groups);
+
+        // If there is support, check a request will make it back to the publisher.
+        if (dynamic_groups) {
+            sub_handler->RequestNewGroup();
+            const bool received = WaitFor([&new_group_was_requested]() { return new_group_was_requested.load(); });
+            CHECK(received);
+        }
     };
 
     SUBCASE("Raw QUIC")

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1235,3 +1235,46 @@ TEST_CASE("Integration - New subgroup preserves object IDs")
         test_subgroup_roll("https");
     }
 }
+
+TEST_CASE("Integration - Dynamic groups support roundtrip")
+{
+    auto server = MakeTestServer(std::nullopt, 4);
+
+    auto test_dynamic_groups = [&](const std::string& protocol_scheme, bool dynamic_groups) {
+        auto publisher = MakeTestClient(true, std::nullopt, protocol_scheme);
+        auto subscriber = MakeTestClient(true, std::nullopt, protocol_scheme);
+
+        FullTrackName ftn;
+        ftn.name_space = TrackNamespace({ "namespace" });
+        ftn.name = { 1, 2, 3 };
+
+        // Publish a track.
+        const auto pub_handler =
+          PublishTrackHandler::Create(ftn, TrackMode::kStream, 1, 5000, { 0, 0 }, dynamic_groups);
+        publisher->PublishTrack(pub_handler);
+        const bool pub_ready = WaitFor([&pub_handler]() { return pub_handler->CanPublish(); });
+        REQUIRE(pub_ready);
+
+        // Subscribe to the track and wait for setup.
+        constexpr auto filter_type = messages::FilterType::kLargestObject;
+        const auto sub_handler =
+          SubscribeTrackHandler::Create(ftn, 0, messages::GroupOrder::kOriginalPublisherOrder, filter_type);
+        CHECK_NOTHROW(subscriber->SubscribeTrack(sub_handler));
+        const bool sub_ready =
+          WaitFor([&sub_handler]() { return sub_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; });
+        REQUIRE(sub_ready);
+
+        // The subscriber's handler should reflect the publisher's declared dynamic group support.
+        CHECK_EQ(sub_handler->IsNewGroupRequestSupported(), dynamic_groups);
+    };
+
+    SUBCASE("Raw QUIC")
+    {
+        test_dynamic_groups("moq", true);
+    }
+
+    SUBCASE("WebTransport")
+    {
+        test_dynamic_groups("https", true);
+    }
+}

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -247,3 +247,21 @@ TestServer::StandaloneFetchReceived(const ConnectionHandle connection_handle,
         pub_fetch_handler->PublishObject(fetch_response_data_[i].headers, fetch_response_data_[i].payload);
     }
 }
+
+void
+TestServer::NewGroupRequested(const quicr::FullTrackName& track_full_name, quicr::messages::GroupId group_id)
+{
+    std::lock_guard lock(state_mutex_);
+    const auto th = quicr::TrackHash(track_full_name);
+
+    auto it = pub_subscribes_.find(th.track_fullname_hash);
+    if (it == pub_subscribes_.end()) {
+        return;
+    }
+
+    for (auto& [conn_id, sub_handler] : it->second) {
+        if (sub_handler) {
+            sub_handler->RequestNewGroup(group_id);
+        }
+    }
+}

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -219,6 +219,8 @@ namespace quicr_test {
                                       const quicr::TrackNamespace& track_namespace,
                                       const quicr::PublishNamespaceAttributes& publish_announce_attributes) override;
 
+        void NewGroupRequested(const quicr::FullTrackName& track_full_name, quicr::messages::GroupId group_id) override;
+
       public:
         std::optional<std::promise<SubscribeDetails>> publish_accepted_promise_;
 


### PR DESCRIPTION
EDIT: Actually there was more going on here on the REQUEST_UPDATE side. 

Somewhere along the line we lost the ability to send new group requests because we started gating on the support but it was never set from the transport. 

Couple things to point out here: 

- Exception as control flow is dodgy, we should optional support in track extensions lookups (#802)
- The server hardcodes true (and all other track properties). We need to properly pass around parameters and extensions. But I just wanted to unblock myself for the moment. 