### PR TITLE
Fix priority to use round-robin in PQ

### DIFF
--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1192,11 +1192,10 @@ PicoQuicTransport::CreateDataContext(const TransportConnId conn_id,
     std::unique_lock lock(state_mutex_);
 
     if (priority > 127) {
-        auto new_priority = priority >> 1;
-        SPDLOG_LOGGER_DEBUG(
-          logger, "Priority is greater than allowed by picoquic, adjusting from {} to {}", priority, new_priority);
-        priority = new_priority;
+        priority += 32;
     }
+
+    priority <<= 1;
 
     const auto conn_it = conn_context_.find(conn_id);
     if (conn_it == conn_context_.end()) {

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1191,11 +1191,13 @@ PicoQuicTransport::CreateDataContext(const TransportConnId conn_id,
 {
     std::unique_lock lock(state_mutex_);
 
-    if (priority > 127) {
-        priority += 32;
+    auto pri_initial = priority;
+    priority <<= 1;
+
+    if (pri_initial > 127) {
+        priority += 64;
     }
 
-    priority <<= 1;
 
     const auto conn_it = conn_context_.find(conn_id);
     if (conn_it == conn_context_.end()) {

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1198,7 +1198,6 @@ PicoQuicTransport::CreateDataContext(const TransportConnId conn_id,
         priority += 64;
     }
 
-
     const auto conn_it = conn_context_.find(conn_id);
     if (conn_it == conn_context_.end()) {
         SPDLOG_LOGGER_ERROR(logger, "Invalid conn_id: {0}, cannot create data context", conn_id);


### PR DESCRIPTION
Fix the priority to always be round-robin.  This fixes an issue with odd priorities getting stuck in FIFO dequeue. 