### PR TITLE
Dynamic groups for publisher initiated

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -474,6 +474,8 @@ namespace quicr {
                 auto new_group_request_id =
                   msg.parameters.GetOptional<std::uint64_t>(messages::ParameterType::kNewGroupRequest);
 
+                auto dynamic_groups = msg.track_extensions.GetOptional<bool>(messages::ExtensionType::kDynamicGroups);
+
                 messages::PublishAttributes attrs;
                 attrs.track_full_name = tfn;
                 attrs.track_alias = msg.track_alias;
@@ -483,6 +485,7 @@ namespace quicr {
                 attrs.is_publisher_initiated = true;
                 attrs.new_group_request_id = new_group_request_id;
                 attrs.delivery_timeout = std::chrono::milliseconds(delivery_timeout);
+                attrs.dynamic_groups = dynamic_groups.value_or(false);
 
                 std::weak_ptr<SubscribeNamespaceHandler> sub_ns_handler;
 

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1306,6 +1306,63 @@ TEST_CASE("Integration - Dynamic groups support roundtrip")
         }
     };
 
+    auto test_dynamic_groups_publisher_initiated = [&](const std::string& protocol_scheme) {
+        auto publisher = MakeTestClient(true, std::nullopt, protocol_scheme);
+        auto subscriber = MakeTestClient(true, std::nullopt, protocol_scheme);
+
+        TrackNamespace prefix_namespace({ "dyngrp" });
+
+        FullTrackName ftn;
+        ftn.name_space = prefix_namespace;
+        ftn.name = { 1, 2, 3 };
+
+        // Subscriber sets up SubscribeNamespace first, then publisher publishes.
+        std::promise<FullTrackName> publish_promise;
+        auto publish_future = publish_promise.get_future();
+        subscriber->SetPublishReceivedPromise(std::move(publish_promise));
+
+        CHECK_NOTHROW(subscriber->SubscribeNamespace(SubscribeNamespaceHandler::Create(prefix_namespace)));
+
+        // Give the namespace subscription time to settle.
+        std::this_thread::sleep_for(kDefaultTimeout);
+
+        // Publish the track, watching for a new group request.
+        std::atomic new_group_was_requested{ false };
+        const auto pub_handler = std::make_shared<CallbackPublishTrackHandler>(
+          ftn, 1, 5000, [&new_group_was_requested](const PublishTrackHandler::Status status) {
+              if (status == PublishTrackHandler::Status::kNewGroupRequested) {
+                  new_group_was_requested = true;
+              }
+          });
+        publisher->PublishTrack(pub_handler);
+        const bool pub_ready = WaitFor([&pub_handler]() { return pub_handler->CanPublish(); });
+        REQUIRE(pub_ready);
+
+        // Subscriber should receive the PUBLISH for this track via namespace match.
+        auto publish_status = publish_future.wait_for(std::chrono::milliseconds(3000));
+        REQUIRE(publish_status == std::future_status::ready);
+        const auto& received_name = publish_future.get();
+        CHECK_EQ(received_name.name_space, ftn.name_space);
+        CHECK_EQ(received_name.name, ftn.name);
+
+        // Get the subscribe handler created by PublishReceived.
+        auto sub_handler = subscriber->GetLastPublishReceivedSubHandler();
+        REQUIRE(sub_handler);
+
+        // Wait for the subscribe to be set up.
+        const bool sub_ready =
+          WaitFor([&sub_handler]() { return sub_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; });
+        REQUIRE(sub_ready);
+
+        // Should reflect dynamic group support from the publisher.
+        CHECK(sub_handler->IsNewGroupRequestSupported());
+
+        // Request a new group; it should make it back to the publisher.
+        sub_handler->RequestNewGroup();
+        const bool received = WaitFor([&new_group_was_requested]() { return new_group_was_requested.load(); });
+        CHECK(received);
+    };
+
     SUBCASE("Raw QUIC")
     {
         test_dynamic_groups("moq", true);
@@ -1314,5 +1371,15 @@ TEST_CASE("Integration - Dynamic groups support roundtrip")
     SUBCASE("WebTransport")
     {
         test_dynamic_groups("https", true);
+    }
+
+    SUBCASE("Raw QUIC - Publisher initiated")
+    {
+        test_dynamic_groups_publisher_initiated("moq");
+    }
+
+    SUBCASE("WebTransport - Publisher initiated")
+    {
+        test_dynamic_groups_publisher_initiated("https");
     }
 }

--- a/test/integration_test/test_client.cpp
+++ b/test/integration_test/test_client.cpp
@@ -31,11 +31,13 @@ TestClient::PublishReceived(quicr::ConnectionHandle connection_handle,
                             const quicr::messages::PublishAttributes& publish_attributes,
                             [[maybe_unused]] std::weak_ptr<SubscribeNamespaceHandler> ns_handler)
 {
+    auto sub_handler = SubscribeTrackHandler::Create(publish_attributes.track_full_name, publish_attributes.priority);
+    last_publish_received_sub_handler_ = sub_handler;
+
     if (publish_received_) {
         publish_received_->set_value(publish_attributes.track_full_name);
     }
 
-    auto sub_handler = SubscribeTrackHandler::Create(publish_attributes.track_full_name, publish_attributes.priority);
     ResolvePublish(connection_handle,
                    request_id,
                    publish_attributes,

--- a/test/integration_test/test_client.h
+++ b/test/integration_test/test_client.h
@@ -27,6 +27,11 @@ namespace quicr_test {
             publish_received_ = std::move(promise);
         }
 
+        std::shared_ptr<quicr::SubscribeTrackHandler> GetLastPublishReceivedSubHandler() const
+        {
+            return last_publish_received_sub_handler_;
+        }
+
         void PublishReceived(quicr::ConnectionHandle connection_handle,
                              uint64_t request_id,
                              const quicr::messages::PublishAttributes& publish_attributes,
@@ -45,5 +50,6 @@ namespace quicr_test {
         std::optional<std::promise<quicr::TrackNamespace>> publish_namespace_received_;
         std::optional<std::promise<quicr::FullTrackName>> publish_received_;
         std::optional<std::promise<quicr::messages::RequestID>> publish_namespace_status_changed_;
+        std::shared_ptr<quicr::SubscribeTrackHandler> last_publish_received_sub_handler_;
     };
 }


### PR DESCRIPTION
Fix client side dynamic groups subscribe handler always being 0 on publish initiated flow. 