### PR TITLE
Rework group order for interop

### DIFF
--- a/c-bridge/src/quicr_bridge.cpp
+++ b/c-bridge/src/quicr_bridge.cpp
@@ -351,11 +351,12 @@ struct qbridge_publish_track_handler
 class BridgeSubscribeTrackHandler : public quicr::SubscribeTrackHandler
 {
   public:
-    static std::shared_ptr<BridgeSubscribeTrackHandler> Create(const quicr::FullTrackName& full_track_name,
-                                                               const std::uint8_t priority,
-                                                               const quicr::messages::GroupOrder group_order,
-                                                               qbridge_object_received_callback_t callback,
-                                                               void* user_data)
+    static std::shared_ptr<BridgeSubscribeTrackHandler> Create(
+      const quicr::FullTrackName& full_track_name,
+      const std::uint8_t priority,
+      const std::optional<quicr::messages::GroupOrder>& group_order,
+      qbridge_object_received_callback_t callback,
+      void* user_data)
     {
         return std::shared_ptr<BridgeSubscribeTrackHandler>(
           new BridgeSubscribeTrackHandler(full_track_name, priority, group_order, std::nullopt, callback, user_data));
@@ -364,7 +365,7 @@ class BridgeSubscribeTrackHandler : public quicr::SubscribeTrackHandler
     static std::shared_ptr<BridgeSubscribeTrackHandler> Create(
       const quicr::FullTrackName& full_track_name,
       const std::uint8_t priority,
-      const quicr::messages::GroupOrder group_order,
+      const std::optional<quicr::messages::GroupOrder>& group_order,
       const std::optional<quicr::SubscribeTrackHandler::JoiningFetch>& joining_fetch,
       qbridge_object_received_callback_t callback,
       void* user_data)
@@ -379,7 +380,7 @@ class BridgeSubscribeTrackHandler : public quicr::SubscribeTrackHandler
   protected:
     BridgeSubscribeTrackHandler(const quicr::FullTrackName& full_track_name,
                                 const std::uint8_t priority,
-                                const quicr::messages::GroupOrder group_order,
+                                const std::optional<quicr::messages::GroupOrder>& group_order,
                                 const std::optional<quicr::SubscribeTrackHandler::JoiningFetch>& joining_fetch,
                                 qbridge_object_received_callback_t callback,
                                 void* data)
@@ -549,13 +550,14 @@ struct qbridge_subscribe_namespace_track_handler
 class BridgeFetchTrackHandler : public quicr::FetchTrackHandler
 {
   public:
-    static std::shared_ptr<BridgeFetchTrackHandler> Create(const quicr::FullTrackName& full_track_name,
-                                                           const std::uint8_t priority,
-                                                           const quicr::messages::GroupOrder group_order,
-                                                           const quicr::messages::Location& start_location,
-                                                           const quicr::messages::FetchEndLocation& end_location,
-                                                           qbridge_object_received_callback_t callback,
-                                                           void* user_data)
+    static std::shared_ptr<BridgeFetchTrackHandler> Create(
+      const quicr::FullTrackName& full_track_name,
+      const std::uint8_t priority,
+      const std::optional<quicr::messages::GroupOrder>& group_order,
+      const quicr::messages::Location& start_location,
+      const quicr::messages::FetchEndLocation& end_location,
+      qbridge_object_received_callback_t callback,
+      void* user_data)
     {
         return std::shared_ptr<BridgeFetchTrackHandler>(new BridgeFetchTrackHandler(
           full_track_name, priority, group_order, start_location, end_location, callback, user_data));
@@ -567,7 +569,7 @@ class BridgeFetchTrackHandler : public quicr::FetchTrackHandler
   protected:
     BridgeFetchTrackHandler(const quicr::FullTrackName& full_track_name,
                             const std::uint8_t priority,
-                            const quicr::messages::GroupOrder group_order,
+                            const std::optional<quicr::messages::GroupOrder>& group_order,
                             const quicr::messages::Location& start_location,
                             const quicr::messages::FetchEndLocation& end_location,
                             qbridge_object_received_callback_t callback,

--- a/c-bridge/src/quicr_bridge.cpp
+++ b/c-bridge/src/quicr_bridge.cpp
@@ -23,12 +23,27 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <unordered_map>
 #include <vector>
 
 namespace {
+
+    std::optional<quicr::messages::GroupOrder> cpp_group_order_from_c(const uint64_t group_order)
+    {
+        switch (group_order) {
+            case 0:
+                return std::nullopt;
+            case static_cast<uint64_t>(quicr::messages::GroupOrder::kAscending):
+                return quicr::messages::GroupOrder::kAscending;
+            case static_cast<uint64_t>(quicr::messages::GroupOrder::kDescending):
+                return quicr::messages::GroupOrder::kDescending;
+            default:
+                throw std::invalid_argument("Invalid group order");
+        }
+    }
 
     /**
      * @brief Convert C namespace structure to C++ TrackNamespace
@@ -452,12 +467,11 @@ struct qbridge_subscribe_track_handler
             }
 
             // Create without joining fetch for normal subscribe (latest object)
-            cpp_handler =
-              BridgeSubscribeTrackHandler::Create(full_track_name,
-                                                  static_cast<std::uint8_t>(config->priority),
-                                                  static_cast<quicr::messages::GroupOrder>(config->group_order),
-                                                  callback,
-                                                  data);
+            cpp_handler = BridgeSubscribeTrackHandler::Create(full_track_name,
+                                                              static_cast<std::uint8_t>(config->priority),
+                                                              cpp_group_order_from_c(config->group_order),
+                                                              callback,
+                                                              data);
         }
     }
 };
@@ -631,7 +645,7 @@ struct qbridge_fetch_track_handler
 
             cpp_handler = BridgeFetchTrackHandler::Create(full_track_name,
                                                           static_cast<std::uint8_t>(config->priority),
-                                                          static_cast<quicr::messages::GroupOrder>(config->group_order),
+                                                          cpp_group_order_from_c(config->group_order),
                                                           start_location,
                                                           end_location,
                                                           callback,

--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -521,7 +521,7 @@ class MyClient : public quicr::Client
                        uint64_t request_id,
                        const quicr::FullTrackName& track_full_name,
                        std::uint8_t priority,
-                       quicr::messages::GroupOrder group_order,
+                       std::optional<quicr::messages::GroupOrder> group_order,
                        quicr::messages::Location start,
                        quicr::messages::FetchEndLocation end)
     {
@@ -575,8 +575,8 @@ class MyClient : public quicr::Client
         }
 
         // TODO: Adjust the TTL
-        auto pub_fetch_h =
-          quicr::PublishFetchHandler::Create(track_full_name, priority, request_id, group_order, 50000);
+        auto pub_fetch_h = quicr::PublishFetchHandler::Create(
+          track_full_name, priority, request_id, group_order.value_or(quicr::messages::GroupOrder::kAscending), 50000);
         BindFetchTrack(connection_handle, pub_fetch_h);
 
         std::thread retrieve_cache_thread([=, cache_entries = std::move(cache_entries), this] {

--- a/include/quicr/client.h
+++ b/include/quicr/client.h
@@ -202,7 +202,7 @@ namespace quicr {
         virtual void ResolveFetch(ConnectionHandle connection_handle,
                                   uint64_t request_id,
                                   std::uint8_t priority,
-                                  messages::GroupOrder group_order,
+                                  std::optional<messages::GroupOrder> group_order,
                                   const FetchResponse& response);
 
         void RequestUpdateReceived(ConnectionHandle connection_handle,

--- a/include/quicr/detail/attributes.h
+++ b/include/quicr/detail/attributes.h
@@ -18,11 +18,12 @@ namespace quicr::messages {
      */
     struct SubscribeAttributes
     {
-        std::uint8_t priority;                        ///< Subscriber priority
-        GroupOrder group_order;                       ///< Subscriber group order
-        std::chrono::milliseconds delivery_timeout;   ///< Subscriber delivery timeout
-        std::chrono::milliseconds expires;            ///< Subscriber expiry in ms
-        Filter filter;                                /// Subscriber filter
+        std::uint8_t priority;                                              ///< Subscriber priority
+        std::optional<GroupOrder> group_order;                              ///< Subscriber group order
+        GroupOrder publisher_default_group_order{ GroupOrder::kAscending }; ///< Publisher track default group order
+        std::chrono::milliseconds delivery_timeout;                         ///< Subscriber delivery timeout
+        std::chrono::milliseconds expires;                                  ///< Subscriber expiry in ms
+        Filter filter;                                                      /// Subscriber filter
         std::uint8_t forward;                         ///< True to Resume/forward data, False to pause/stop data
         std::optional<uint64_t> new_group_request_id; ///< Indicates new group id is requested
         bool is_publisher_initiated;                  ///< True will not send SUBSCRIBE_OK.
@@ -46,19 +47,21 @@ namespace quicr::messages {
 
     struct StandaloneFetchAttributes
     {
-        std::uint8_t priority;         ///< Fetch priority
-        GroupOrder group_order;        ///< Fetch group order
-        Location start_location;       ///< Fetch starting location in range
-        FetchEndLocation end_location; ///< Fetch final location.
+        std::uint8_t priority;                                              ///< Fetch priority
+        std::optional<GroupOrder> group_order;                              ///< Fetch group order
+        GroupOrder publisher_default_group_order{ GroupOrder::kAscending }; ///< Publisher track default group order
+        Location start_location;                                            ///< Fetch starting location in range
+        FetchEndLocation end_location;                                      ///< Fetch final location.
     };
 
     struct JoiningFetchAttributes
     {
-        std::uint8_t priority;        ///< Fetch priority
-        GroupOrder group_order;       ///< Fetch group order
-        RequestID joining_request_id; ///< Fetch joining request_id
-        bool relative{ false };       ///< True indicates relative to largest, False indicates absolute
-        std::uint64_t joining_start;  ///< Fetch joining start
+        std::uint8_t priority;                                              ///< Fetch priority
+        std::optional<GroupOrder> group_order;                              ///< Fetch group order
+        GroupOrder publisher_default_group_order{ GroupOrder::kAscending }; ///< Publisher track default group order
+        RequestID joining_request_id;                                       ///< Fetch joining request_id
+        bool relative{ false };      ///< True indicates relative to largest, False indicates absolute
+        std::uint64_t joining_start; ///< Fetch joining start
     };
 
     struct SubscribeNamespaceAttributes

--- a/include/quicr/detail/base_track_handler.h
+++ b/include/quicr/detail/base_track_handler.h
@@ -64,6 +64,7 @@ namespace quicr {
         std::optional<std::string> error_reason = std::nullopt;
 
         std::optional<messages::Location> largest_location = std::nullopt;
+        messages::GroupOrder publisher_default_group_order = messages::GroupOrder::kAscending;
     };
 
     /**
@@ -89,6 +90,7 @@ namespace quicr {
         std::optional<std::string> error_reason = std::nullopt;
 
         std::optional<messages::Location> largest_location = std::nullopt;
+        messages::GroupOrder publisher_default_group_order = messages::GroupOrder::kAscending;
     };
 
     struct SubscribeNamespaceResponse
@@ -135,6 +137,7 @@ namespace quicr {
         std::optional<std::string> error_reason = std::nullopt;
 
         std::optional<messages::Location> largest_location = std::nullopt;
+        messages::GroupOrder publisher_default_group_order = messages::GroupOrder::kAscending;
     };
 
     /**

--- a/include/quicr/detail/ctrl_message_types.h
+++ b/include/quicr/detail/ctrl_message_types.h
@@ -277,9 +277,8 @@ namespace quicr::messages {
 
     enum struct GroupOrder : uint8_t
     {
-        kOriginalPublisherOrder = 0x0,
-        kAscending,
-        kDescending
+        kAscending = 0x1,
+        kDescending = 0x2
     };
 
     Bytes& operator<<(Bytes& buffer, GroupOrder value);

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -599,7 +599,7 @@ namespace quicr {
                            const FullTrackName& tfn,
                            TrackHash th,
                            std::uint8_t priority,
-                           messages::GroupOrder group_order,
+                           std::optional<messages::GroupOrder> group_order,
                            const messages::Filter& filter,
                            std::optional<std::chrono::milliseconds> delivery_timeout);
 
@@ -607,7 +607,8 @@ namespace quicr {
                              messages::RequestID request_id,
                              uint64_t track_alias,
                              uint64_t expires,
-                             const std::optional<messages::Location>& largest_location);
+                             const std::optional<messages::Location>& largest_location,
+                             messages::GroupOrder publisher_default_group_order);
         void SendUnsubscribe(ConnectionContext& conn_ctx, messages::RequestID request_id);
 
         /*===================================================================*/
@@ -632,7 +633,7 @@ namespace quicr {
                            messages::RequestID request_id,
                            bool forward,
                            std::uint8_t priority,
-                           messages::GroupOrder group_order,
+                           std::optional<messages::GroupOrder> group_order,
                            const messages::Filter& filter);
 
         /*===================================================================*/
@@ -649,14 +650,14 @@ namespace quicr {
                        messages::RequestID request_id,
                        const FullTrackName& tfn,
                        std::uint8_t priority,
-                       messages::GroupOrder group_order,
+                       std::optional<messages::GroupOrder> group_order,
                        const messages::Location& start_location,
                        const messages::FetchEndLocation& end_location);
 
         void SendJoiningFetch(ConnectionContext& conn_ctx,
                               messages::RequestID request_id,
                               std::uint8_t priority,
-                              messages::GroupOrder group_order,
+                              std::optional<messages::GroupOrder> group_order,
                               messages::RequestID joining_request_id,
                               messages::GroupId joining_start,
                               bool absolute);
@@ -665,7 +666,7 @@ namespace quicr {
 
         void SendFetchOk(ConnectionContext& conn_ctx,
                          messages::RequestID request_id,
-                         messages::GroupOrder group_order,
+                         messages::GroupOrder publisher_default_group_order,
                          bool end_of_track,
                          messages::Location end_location);
 

--- a/include/quicr/fetch_track_handler.h
+++ b/include/quicr/fetch_track_handler.h
@@ -22,7 +22,7 @@ namespace quicr {
          */
         FetchTrackHandler(const FullTrackName& full_track_name,
                           const std::uint8_t priority,
-                          const messages::GroupOrder group_order,
+                          const std::optional<messages::GroupOrder> group_order,
                           const messages::Location& start_location,
                           const messages::FetchEndLocation& end_location)
           : SubscribeTrackHandler(full_track_name,
@@ -52,7 +52,7 @@ namespace quicr {
          */
         static std::shared_ptr<FetchTrackHandler> Create(const FullTrackName& full_track_name,
                                                          const std::uint8_t priority,
-                                                         const messages::GroupOrder group_order,
+                                                         const std::optional<messages::GroupOrder> group_order,
                                                          const messages::Location& start_location,
                                                          const messages::FetchEndLocation& end_location)
         {

--- a/include/quicr/server.h
+++ b/include/quicr/server.h
@@ -174,7 +174,7 @@ namespace quicr {
         virtual void ResolveFetch(ConnectionHandle connection_handle,
                                   uint64_t request_id,
                                   std::uint8_t priority,
-                                  messages::GroupOrder group_order,
+                                  std::optional<messages::GroupOrder> group_order,
                                   const FetchResponse& response);
 
         // --BEGIN CALLBACKS ----------------------------------------------------------------------------------

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -57,7 +57,7 @@ namespace quicr {
         struct JoiningFetch
         {
             const std::uint8_t priority;
-            const messages::GroupOrder group_order;
+            const std::optional<messages::GroupOrder> group_order;
             const messages::Parameters parameters;
             const messages::GroupId joining_start;
             const bool absolute;
@@ -73,7 +73,7 @@ namespace quicr {
          */
         SubscribeTrackHandler(const FullTrackName& full_track_name,
                               std::uint8_t priority,
-                              messages::GroupOrder group_order,
+                              std::optional<messages::GroupOrder> group_order,
                               const messages::Filter& filter = std::monostate{},
                               const std::optional<JoiningFetch>& joining_fetch = std::nullopt,
                               bool publisher_initiated = false)
@@ -101,7 +101,7 @@ namespace quicr {
         static std::shared_ptr<SubscribeTrackHandler> Create(
           const FullTrackName& full_track_name,
           std::uint8_t priority,
-          messages::GroupOrder group_order = messages::GroupOrder::kAscending,
+          std::optional<messages::GroupOrder> group_order = messages::GroupOrder::kAscending,
           const messages::Filter& filter = std::monostate{},
           bool publisher_initiated = false)
         {
@@ -136,7 +136,17 @@ namespace quicr {
          * @return GroupOrder value
          */
 
-        constexpr messages::GroupOrder GetGroupOrder() const noexcept { return group_order_; }
+        constexpr std::optional<messages::GroupOrder> GetGroupOrder() const noexcept { return group_order_; }
+
+        constexpr messages::GroupOrder GetPublisherDefaultGroupOrder() const noexcept
+        {
+            return publisher_default_group_order_;
+        }
+
+        void SetPublisherDefaultGroupOrder(messages::GroupOrder group_order) noexcept
+        {
+            publisher_default_group_order_ = group_order;
+        }
 
         /**
          * @brief Get subscription filter type
@@ -410,7 +420,8 @@ namespace quicr {
       private:
         Status status_{ Status::kNotSubscribed };
         std::uint8_t priority_;
-        messages::GroupOrder group_order_;
+        std::optional<messages::GroupOrder> group_order_;
+        messages::GroupOrder publisher_default_group_order_{ messages::GroupOrder::kAscending };
         messages::Filter filter_;
         std::optional<messages::Location> latest_location_;
         std::optional<JoiningFetch> joining_fetch_;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -59,8 +59,12 @@ namespace quicr {
 
         switch (subscribe_response.reason_code) {
             case RequestResponse::ReasonCode::kOk: {
-                SendSubscribeOk(
-                  conn_it->second, request_id, track_alias, kSubscribeExpires, subscribe_response.largest_location);
+                SendSubscribeOk(conn_it->second,
+                                request_id,
+                                track_alias,
+                                kSubscribeExpires,
+                                subscribe_response.largest_location,
+                                subscribe_response.publisher_default_group_order);
                 break;
             }
 
@@ -90,7 +94,7 @@ namespace quicr {
     void Client::ResolveFetch(ConnectionHandle connection_handle,
                               uint64_t request_id,
                               std::uint8_t priority,
-                              messages::GroupOrder group_order,
+                              std::optional<messages::GroupOrder> group_order,
                               const FetchResponse& response)
     {
         auto conn_it = connections_.find(connection_handle);
@@ -100,7 +104,11 @@ namespace quicr {
 
         switch (response.reason_code) {
             case FetchResponse::ReasonCode::kOk: {
-                SendFetchOk(conn_it->second, request_id, group_order, priority, response.largest_location.value());
+                SendFetchOk(conn_it->second,
+                            request_id,
+                            response.publisher_default_group_order,
+                            priority,
+                            response.largest_location.value());
                 break;
             }
             default:
@@ -374,6 +382,10 @@ namespace quicr {
 
                 if (auto sub_handler = sub_it->second.Get<SubscribeTrackHandler>()) {
                     std::optional<messages::Location> largest_location;
+                    const auto publisher_default_group_order =
+                      msg.track_extensions
+                        .GetOptional<messages::GroupOrder>(messages::ExtensionType::kDefaultPublisherGroupOrder)
+                        .value_or(messages::GroupOrder::kAscending);
                     if (msg.parameters.Contains(messages::ParameterType::kLargestObject)) {
                         largest_location =
                           msg.parameters.Get<messages::Location>(messages::ParameterType::kLargestObject);
@@ -392,6 +404,7 @@ namespace quicr {
                     }
 
                     sub_handler->SetReceivedTrackAlias(msg.track_alias);
+                    sub_handler->SetPublisherDefaultGroupOrder(publisher_default_group_order);
                     sub_handler->SetStatus(SubscribeTrackHandler::Status::kOk);
                     sub_handler->SupportNewGroupRequest(true); // TODO: Change this to track extension post draft-16
                 }
@@ -469,18 +482,22 @@ namespace quicr {
 
                 auto delivery_timeout = msg.parameters.Get<std::uint64_t>(messages::ParameterType::kDeliveryTimeout);
                 auto expires = msg.parameters.Get<std::uint64_t>(messages::ParameterType::kExpires);
-                auto group_order = msg.parameters.Get<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
                 auto forward = msg.parameters.Get<bool>(messages::ParameterType::kForward);
                 auto new_group_request_id =
                   msg.parameters.GetOptional<std::uint64_t>(messages::ParameterType::kNewGroupRequest);
 
+                const auto publisher_default_group_order =
+                  msg.track_extensions
+                    .GetOptional<messages::GroupOrder>(messages::ExtensionType::kDefaultPublisherGroupOrder)
+                    .value_or(messages::GroupOrder::kAscending);
                 auto dynamic_groups = msg.track_extensions.GetOptional<bool>(messages::ExtensionType::kDynamicGroups);
 
                 messages::PublishAttributes attrs;
                 attrs.track_full_name = tfn;
                 attrs.track_alias = msg.track_alias;
                 attrs.forward = forward;
-                attrs.group_order = group_order;
+                attrs.group_order = std::nullopt;
+                attrs.publisher_default_group_order = publisher_default_group_order;
                 attrs.expires = std::chrono::milliseconds(expires);
                 attrs.is_publisher_initiated = true;
                 attrs.new_group_request_id = new_group_request_id;
@@ -618,7 +635,12 @@ namespace quicr {
                 }
 
                 if (auto h = fetch_it->second.Get<FetchTrackHandler>()) {
+                    const auto publisher_default_group_order =
+                      msg.track_extensions
+                        .GetOptional<messages::GroupOrder>(messages::ExtensionType::kDefaultPublisherGroupOrder)
+                        .value_or(messages::GroupOrder::kAscending);
                     h->SetLatestLocation(msg.end_location);
+                    h->SetPublisherDefaultGroupOrder(publisher_default_group_order);
                     h->SetStatus(FetchTrackHandler::Status::kOk);
                 }
 
@@ -657,10 +679,12 @@ namespace quicr {
 
                         auto priority = msg.parameters.Get<uint8_t>(messages::ParameterType::kSubscriberPriority);
                         auto group_order =
-                          msg.parameters.Get<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
+                          msg.parameters.GetOptional<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
 
                         messages::StandaloneFetchAttributes attrs = { .priority = priority,
                                                                       .group_order = group_order,
+                                                                      .publisher_default_group_order =
+                                                                        messages::GroupOrder::kAscending,
                                                                       .start_location = msg.group_0->standalone.start,
                                                                       .end_location = end_location };
                         StandaloneFetchReceived(conn_ctx.connection_handle, msg.request_id, tfn, attrs);
@@ -684,11 +708,12 @@ namespace quicr {
 
                         auto priority = msg.parameters.Get<uint8_t>(messages::ParameterType::kSubscriberPriority);
                         auto group_order =
-                          msg.parameters.Get<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
+                          msg.parameters.GetOptional<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
 
                         messages::JoiningFetchAttributes attrs = {
                             .priority = priority,
                             .group_order = group_order,
+                            .publisher_default_group_order = messages::GroupOrder::kAscending,
                             .joining_request_id = msg.group_1->joining.request_id,
                             .relative = relative_joining,
                             .joining_start = msg.group_1->joining.joining_start,
@@ -748,7 +773,8 @@ namespace quicr {
                 auto priority = msg.parameters.Get<uint8_t>(messages::ParameterType::kSubscriberPriority);
                 auto delivery_timeout = msg.parameters.Get<std::uint64_t>(messages::ParameterType::kDeliveryTimeout);
                 auto expires = msg.parameters.Get<std::uint64_t>(messages::ParameterType::kExpires);
-                auto group_order = msg.parameters.Get<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
+                auto group_order =
+                  msg.parameters.GetOptional<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
                 auto forward = msg.parameters.Get<bool>(messages::ParameterType::kForward);
 
                 messages::Filter filter; // TODO: Support more filters.

--- a/src/ctrl_message_types.cpp
+++ b/src/ctrl_message_types.cpp
@@ -88,6 +88,10 @@ namespace quicr::messages {
     {
         std::uint64_t uvalue;
         buffer = buffer >> uvalue;
+        if (uvalue < static_cast<std::uint64_t>(GroupOrder::kAscending) ||
+            uvalue > static_cast<std::uint64_t>(GroupOrder::kDescending)) {
+            throw ProtocolViolationException("Invalid group order");
+        }
         value = static_cast<GroupOrder>(uvalue);
         return buffer;
     }

--- a/src/ctrl_message_types.cpp
+++ b/src/ctrl_message_types.cpp
@@ -80,6 +80,9 @@ namespace quicr::messages {
 
     Bytes& operator<<(Bytes& buffer, GroupOrder value)
     {
+        if (value != GroupOrder::kAscending && value != GroupOrder::kDescending) {
+            throw ProtocolViolationException("Invalid group order");
+        }
         buffer << static_cast<std::uint64_t>(value);
         return buffer;
     }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -145,8 +145,12 @@ namespace quicr {
 
                 if (!subscribe_response.is_publisher_initiated) {
                     // Send the ok.
-                    SendSubscribeOk(
-                      conn_it->second, request_id, track_alias, kSubscribeExpires, subscribe_response.largest_location);
+                    SendSubscribeOk(conn_it->second,
+                                    request_id,
+                                    track_alias,
+                                    kSubscribeExpires,
+                                    subscribe_response.largest_location,
+                                    subscribe_response.publisher_default_group_order);
                 }
                 break;
             }
@@ -195,7 +199,7 @@ namespace quicr {
     void Server::ResolveFetch(ConnectionHandle connection_handle,
                               uint64_t request_id,
                               std::uint8_t priority,
-                              messages::GroupOrder group_order,
+                              std::optional<messages::GroupOrder> group_order,
                               const FetchResponse& response)
     {
         auto error_code = messages::ErrorCode::kInternalError;
@@ -207,7 +211,11 @@ namespace quicr {
 
         switch (response.reason_code) {
             case FetchResponse::ReasonCode::kOk:
-                SendFetchOk(conn_it->second, request_id, group_order, priority, response.largest_location.value());
+                SendFetchOk(conn_it->second,
+                            request_id,
+                            response.publisher_default_group_order,
+                            priority,
+                            response.largest_location.value());
                 return;
 
             case FetchResponse::ReasonCode::kInvalidRange:
@@ -379,7 +387,9 @@ namespace quicr {
 
                 auto delivery_timeout = msg.parameters.Get<std::uint64_t>(messages::ParameterType::kDeliveryTimeout);
                 auto priority = msg.parameters.Get<uint8_t>(messages::ParameterType::kSubscriberPriority);
-                auto group_order = msg.parameters.Get<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
+                auto group_order =
+                  msg.parameters.GetOptional<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
+                const auto publisher_default_group_order = messages::GroupOrder::kAscending;
                 auto forward = msg.parameters.Get<bool>(messages::ParameterType::kForward);
                 auto new_group_request_id =
                   msg.parameters.GetOptional<std::uint64_t>(messages::ParameterType::kNewGroupRequest);
@@ -398,6 +408,7 @@ namespace quicr {
                                   {
                                     .priority = priority,
                                     .group_order = group_order,
+                                    .publisher_default_group_order = publisher_default_group_order,
                                     .delivery_timeout = std::chrono::milliseconds{ delivery_timeout },
                                     .expires = std::chrono::milliseconds{ delivery_timeout },
                                     .filter = filter,
@@ -433,7 +444,12 @@ namespace quicr {
                 }
 
                 if (auto handler = sub_it->second.Get<SubscribeTrackHandler>()) {
+                    const auto publisher_default_group_order =
+                      msg.track_extensions
+                        .GetOptional<messages::GroupOrder>(messages::ExtensionType::kDefaultPublisherGroupOrder)
+                        .value_or(messages::GroupOrder::kAscending);
                     handler->SetReceivedTrackAlias(msg.track_alias);
+                    handler->SetPublisherDefaultGroupOrder(publisher_default_group_order);
                     handler->SetStatus(SubscribeTrackHandler::Status::kOk);
                     conn_ctx.sub_by_recv_track_alias[msg.track_alias] = handler;
                 }
@@ -659,7 +675,12 @@ namespace quicr {
                 }
 
                 if (auto h = fetch_it->second.Get<FetchTrackHandler>()) {
+                    const auto publisher_default_group_order =
+                      msg.track_extensions
+                        .GetOptional<messages::GroupOrder>(messages::ExtensionType::kDefaultPublisherGroupOrder)
+                        .value_or(messages::GroupOrder::kAscending);
                     h->SetLatestLocation(msg.end_location);
+                    h->SetPublisherDefaultGroupOrder(publisher_default_group_order);
                     h->SetStatus(FetchTrackHandler::Status::kOk);
                 }
 
@@ -698,11 +719,12 @@ namespace quicr {
 
                         auto priority = msg.parameters.Get<uint8_t>(messages::ParameterType::kSubscriberPriority);
                         auto group_order =
-                          msg.parameters.Get<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
+                          msg.parameters.GetOptional<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
 
                         messages::StandaloneFetchAttributes attrs = {
                             .priority = priority,
                             .group_order = group_order,
+                            .publisher_default_group_order = messages::GroupOrder::kAscending,
                             .start_location = msg.group_0->standalone.start,
                             .end_location = end_location,
                         };
@@ -730,11 +752,12 @@ namespace quicr {
                         FullTrackName tfn = subscribe_state->second.track_full_name;
                         auto priority = msg.parameters.Get<uint8_t>(messages::ParameterType::kSubscriberPriority);
                         auto group_order =
-                          msg.parameters.Get<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
+                          msg.parameters.GetOptional<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
 
                         messages::JoiningFetchAttributes attrs = {
                             .priority = priority,
                             .group_order = group_order,
+                            .publisher_default_group_order = messages::GroupOrder::kAscending,
                             .joining_request_id = msg.group_1->joining.request_id,
                             .relative = relative_joining,
                             .joining_start = msg.group_1->joining.joining_start,
@@ -789,14 +812,18 @@ namespace quicr {
                 bool dynamic_groups = true; // TODO: This has moved to extensions/properties get from there
                 auto delivery_timeout = msg.parameters.Get<std::uint64_t>(messages::ParameterType::kDeliveryTimeout);
                 auto expires = msg.parameters.Get<std::uint64_t>(messages::ParameterType::kExpires);
-                auto group_order = msg.parameters.Get<messages::GroupOrder>(messages::ParameterType::kGroupOrder);
+                const auto publisher_default_group_order =
+                  msg.track_extensions
+                    .GetOptional<messages::GroupOrder>(messages::ExtensionType::kDefaultPublisherGroupOrder)
+                    .value_or(messages::GroupOrder::kAscending);
                 auto forward = msg.parameters.Get<bool>(messages::ParameterType::kForward);
 
                 messages::PublishAttributes attributes;
                 attributes.track_full_name = tfn;
                 attributes.track_alias = msg.track_alias;
                 attributes.priority = 0;
-                attributes.group_order = group_order;
+                attributes.group_order = std::nullopt;
+                attributes.publisher_default_group_order = publisher_default_group_order;
                 attributes.delivery_timeout = std::chrono::milliseconds(delivery_timeout);
                 attributes.expires = std::chrono::milliseconds(expires);
                 attributes.forward = forward;

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -510,7 +510,7 @@ namespace quicr {
                                   const FullTrackName& tfn,
                                   TrackHash th, // TODO: This is only for a debug message, should be removed
                                   std::uint8_t priority,
-                                  GroupOrder group_order,
+                                  std::optional<GroupOrder> group_order,
                                   const Filter& filter,
                                   std::optional<std::chrono::milliseconds> delivery_timeout)
     try {
@@ -525,7 +525,7 @@ namespace quicr {
          */
         auto params = Parameters{}
                         .Add(ParameterType::kSubscriberPriority, priority)
-                        .Add(ParameterType::kGroupOrder, group_order)
+                        .AddOptional(ParameterType::kGroupOrder, group_order)
                         .Add(ParameterType::kForward, 1)
                         .AddOptional(ParameterType::kDeliveryTimeout, delivery_timeout);
 
@@ -595,7 +595,7 @@ namespace quicr {
                                   messages::RequestID request_id,
                                   bool forward,
                                   std::uint8_t priority,
-                                  messages::GroupOrder group_order,
+                                  std::optional<messages::GroupOrder> group_order,
                                   const messages::Filter& filter)
     try {
         /* Available parameters:
@@ -609,7 +609,7 @@ namespace quicr {
          */
         auto params = Parameters{}
                         .Add(ParameterType::kSubscriberPriority, priority)
-                        .Add(ParameterType::kGroupOrder, group_order)
+                        .AddOptional(ParameterType::kGroupOrder, group_order)
                         .Add(GetFilterParameterType(filter), filter)
                         .Add(ParameterType::kForward, forward);
 
@@ -630,7 +630,8 @@ namespace quicr {
                                     uint64_t request_id,
                                     uint64_t track_alias,
                                     uint64_t expires,
-                                    const std::optional<Location>& largest_location)
+                                    const std::optional<Location>& largest_location,
+                                    messages::GroupOrder publisher_default_group_order)
     try {
         auto params = Parameters{}
                         .Add(ParameterType::kExpires, expires)
@@ -639,7 +640,7 @@ namespace quicr {
         auto extensions = TrackExtensions{}
                             .Add(ExtensionType::kDeliveryTimeout, 0)
                             .Add(ExtensionType::kMaxCacheDuration, 0)
-                            .Add(ExtensionType::kDefaultPublisherGroupOrder, GroupOrder::kAscending)
+                            .Add(ExtensionType::kDefaultPublisherGroupOrder, publisher_default_group_order)
                             .Add(ExtensionType::kDefaultPublisherPriority, 1)
                             .Add(ExtensionType::kDynamicGroups, true);
 
@@ -773,7 +774,7 @@ namespace quicr {
                               uint64_t request_id,
                               const FullTrackName& tfn,
                               std::uint8_t priority,
-                              messages::GroupOrder group_order,
+                              std::optional<messages::GroupOrder> group_order,
                               const messages::Location& start_location,
                               const messages::FetchEndLocation& end_location)
     try {
@@ -789,8 +790,9 @@ namespace quicr {
          * - SUBSCRIBER PRIORITY (0x20): Priority of the fetch response relative to other data.
          * - GROUP ORDER (0x22): Preference for the order of groups in the fetch response.
          */
-        auto params =
-          Parameters{}.Add(ParameterType::kSubscriberPriority, priority).Add(ParameterType::kGroupOrder, group_order);
+        auto params = Parameters{}
+                        .Add(ParameterType::kSubscriberPriority, priority)
+                        .AddOptional(ParameterType::kGroupOrder, group_order);
 
         Bytes buffer;
         buffer << Fetch(request_id, messages::FetchType::kStandalone, group_0, std::nullopt, params);
@@ -804,7 +806,7 @@ namespace quicr {
     void Transport::SendJoiningFetch(ConnectionContext& conn_ctx,
                                      uint64_t request_id,
                                      std::uint8_t priority,
-                                     messages::GroupOrder group_order,
+                                     std::optional<messages::GroupOrder> group_order,
                                      uint64_t joining_request_id,
                                      messages::GroupId joining_start,
                                      bool absolute)
@@ -816,8 +818,9 @@ namespace quicr {
          * - SUBSCRIBER PRIORITY (0x20): Priority of the fetch response relative to other data.
          * - GROUP ORDER (0x22): Preference for the order of groups in the fetch response.
          */
-        auto params =
-          Parameters{}.Add(ParameterType::kSubscriberPriority, priority).Add(ParameterType::kGroupOrder, group_order);
+        auto params = Parameters{}
+                        .Add(ParameterType::kSubscriberPriority, priority)
+                        .AddOptional(ParameterType::kGroupOrder, group_order);
 
         Bytes buffer;
         buffer << Fetch(request_id,
@@ -847,7 +850,7 @@ namespace quicr {
 
     void Transport::SendFetchOk(ConnectionContext& conn_ctx,
                                 uint64_t request_id,
-                                GroupOrder group_order,
+                                GroupOrder publisher_default_group_order,
                                 bool end_of_track,
                                 Location largest_location)
     try {
@@ -857,12 +860,12 @@ namespace quicr {
         auto extensions = TrackExtensions{}
                             .Add(ExtensionType::kDeliveryTimeout, 0)
                             .Add(ExtensionType::kMaxCacheDuration, 0)
-                            .Add(ExtensionType::kDefaultPublisherGroupOrder, group_order)
+                            .Add(ExtensionType::kDefaultPublisherGroupOrder, publisher_default_group_order)
                             .Add(ExtensionType::kDefaultPublisherPriority, 1)
                             .Add(ExtensionType::kDynamicGroups, true);
 
         Bytes buffer;
-        buffer << FetchOk(request_id, end_of_track, largest_location, params, {});
+        buffer << FetchOk(request_id, end_of_track, largest_location, params, extensions);
 
         SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), buffer);
     } catch (const std::exception& e) {
@@ -1248,6 +1251,7 @@ namespace quicr {
                     handler->SetReceivedTrackAlias(attributes.track_alias);
                     handler->SetPriority(attributes.priority);
                     handler->SetDeliveryTimeout(attributes.delivery_timeout);
+                    handler->SetPublisherDefaultGroupOrder(attributes.publisher_default_group_order);
                     handler->SupportNewGroupRequest(attributes.dynamic_groups);
 
                     SubscribeTrack(connection_handle, std::move(handler));

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -163,7 +163,7 @@ class TestSubscribeHandler : public SubscribeTrackHandler
 
     static std::shared_ptr<TestSubscribeHandler> Create(const FullTrackName& full_track_name,
                                                         std::uint8_t priority,
-                                                        messages::GroupOrder group_order,
+                                                        std::optional<messages::GroupOrder> group_order,
                                                         const messages::Filter& filter = std::monostate{})
     {
         return std::shared_ptr<TestSubscribeHandler>(
@@ -202,7 +202,7 @@ class TestSubscribeHandler : public SubscribeTrackHandler
   protected:
     TestSubscribeHandler(const FullTrackName& full_track_name,
                          std::uint8_t priority,
-                         messages::GroupOrder group_order,
+                         std::optional<messages::GroupOrder> group_order,
                          const messages::Filter& filter)
       : SubscribeTrackHandler(full_track_name, priority, group_order, filter)
     {
@@ -276,8 +276,7 @@ TEST_CASE("Integration - Subscribe")
         ftn.name_space = TrackNamespace({ "namespace" });
         ftn.name = { 1, 2, 3 };
         const messages::Filter filter = messages::TrackFilter{ 1, 2, 3, 4 };
-        const auto handler =
-          SubscribeTrackHandler::Create(ftn, 0, messages::GroupOrder::kOriginalPublisherOrder, filter);
+        const auto handler = SubscribeTrackHandler::Create(ftn, 0, std::nullopt, filter);
 
         // When we subscribe, server should receive a subscribe.
         std::promise<TestServer::SubscribeDetails> promise;
@@ -330,8 +329,7 @@ TEST_CASE("Integration - Fetch")
         FullTrackName ftn;
         ftn.name_space = TrackNamespace({ "namespace" });
         ftn.name = { 1, 2, 3 };
-        const auto handler = FetchTrackHandler::Create(
-          ftn, 0, messages::GroupOrder::kOriginalPublisherOrder, { 0, 0 }, { 0, std::nullopt });
+        const auto handler = FetchTrackHandler::Create(ftn, 0, std::nullopt, { 0, 0 }, { 0, std::nullopt });
         client->FetchTrack(handler);
     };
 
@@ -352,8 +350,7 @@ TEST_CASE("Integration - Handlers with no transport")
 {
     // Subscribe.
     {
-        const auto handler =
-          SubscribeTrackHandler::Create(FullTrackName(), 0, messages::GroupOrder::kOriginalPublisherOrder);
+        const auto handler = SubscribeTrackHandler::Create(FullTrackName(), 0, std::nullopt);
         handler->Pause();
         handler->Resume();
         handler->RequestNewGroup();
@@ -377,8 +374,7 @@ TEST_CASE("Integration - Handlers with no transport")
 
     // Fetch.
     {
-        const auto handler = FetchTrackHandler::Create(
-          FullTrackName(), 0, messages::GroupOrder::kOriginalPublisherOrder, { 0, 0 }, { 0, std::nullopt });
+        const auto handler = FetchTrackHandler::Create(FullTrackName(), 0, std::nullopt, { 0, 0 }, { 0, std::nullopt });
         handler->Pause();
         handler->Resume();
         handler->RequestNewGroup();
@@ -614,7 +610,7 @@ TEST_CASE("Integration - Subscribe Namespace with matching track")
         std::promise<FullTrackName> publish_promise;
         auto publish_future = publish_promise.get_future();
         messages::PublishAttributes publish_attributes;
-        publish_attributes.group_order = quicr::messages::GroupOrder::kOriginalPublisherOrder;
+        publish_attributes.group_order = std::nullopt;
         publish_attributes.track_alias = existing_track_hash.track_fullname_hash;
 
         // TODO: Validate full attribute round-trip.
@@ -826,7 +822,7 @@ class TestFetchTrackHandler final : public FetchTrackHandler
 
     TestFetchTrackHandler(const FullTrackName& full_track_name,
                           const std::uint8_t priority,
-                          const messages::GroupOrder group_order,
+                          const std::optional<messages::GroupOrder> group_order,
                           const messages::Location& start_location,
                           const messages::FetchEndLocation& end_location)
       : FetchTrackHandler(full_track_name, priority, group_order, start_location, end_location)
@@ -835,7 +831,7 @@ class TestFetchTrackHandler final : public FetchTrackHandler
 
     static std::shared_ptr<TestFetchTrackHandler> Create(const FullTrackName& full_track_name,
                                                          const std::uint8_t priority,
-                                                         const messages::GroupOrder group_order,
+                                                         const std::optional<messages::GroupOrder> group_order,
                                                          const messages::Location& start_location,
                                                          const messages::FetchEndLocation& end_location)
     {
@@ -897,8 +893,8 @@ TEST_CASE("Integration - Fetch object roundtrip")
 
         server->SetFetchResponseData(cached);
 
-        auto fetch_handler = TestFetchTrackHandler::Create(
-          ftn, 0, messages::GroupOrder::kOriginalPublisherOrder, { fetch_group, 0 }, { fetch_group, std::nullopt });
+        auto fetch_handler =
+          TestFetchTrackHandler::Create(ftn, 0, std::nullopt, { fetch_group, 0 }, { fetch_group, std::nullopt });
 
         client->FetchTrack(fetch_handler);
 
@@ -968,7 +964,7 @@ TEST_CASE("Integration - Subgroup and Stream Testing")
         constexpr std::size_t total_messages = num_groups * messages_per_group; // 120
 
         // Create subscribe handler that tracks received objects
-        auto sub_handler = TestSubscribeHandler::Create(ftn, 3, messages::GroupOrder::kOriginalPublisherOrder);
+        auto sub_handler = TestSubscribeHandler::Create(ftn, 3, std::nullopt);
 
         // Set up promise for subscriber receiving all messages
         std::promise<void> all_received_promise;
@@ -1194,7 +1190,7 @@ TEST_CASE("Integration - New subgroup preserves object IDs")
         REQUIRE(pub_ready);
 
         // Subscriber.
-        auto sub_handler = TestSubscribeHandler::Create(ftn, 3, messages::GroupOrder::kOriginalPublisherOrder);
+        auto sub_handler = TestSubscribeHandler::Create(ftn, 3, std::nullopt);
         std::promise<void> all_received_promise;
         auto all_received_future = all_received_promise.get_future();
         constexpr std::size_t total_objects = 6;
@@ -1293,7 +1289,7 @@ TEST_CASE("Integration - Dynamic groups support roundtrip")
         REQUIRE(pub_ready);
 
         // Subscribe to the track and wait for setup.
-        const auto sub_handler = SubscribeTrackHandler::Create(ftn, 0, messages::GroupOrder::kOriginalPublisherOrder);
+        const auto sub_handler = SubscribeTrackHandler::Create(ftn, 0, std::nullopt);
         CHECK_NOTHROW(subscriber->SubscribeTrack(sub_handler));
         const bool sub_ready =
           WaitFor([&sub_handler]() { return sub_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; });

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -243,7 +243,11 @@ TestServer::StandaloneFetchReceived(const ConnectionHandle connection_handle,
 
     // Publish the response
     auto pub_fetch_handler =
-      PublishFetchHandler::Create(track_full_name, attrs.priority, request_id, attrs.group_order, 500);
+      PublishFetchHandler::Create(track_full_name,
+                                  attrs.priority,
+                                  request_id,
+                                  attrs.group_order.value_or(attrs.publisher_default_group_order),
+                                  500);
     BindFetchTrack(connection_handle, pub_fetch_handler);
     for (size_t i = 0; i < fetch_response_data_.size(); ++i) {
         pub_fetch_handler->PublishObject(fetch_response_data_[i].headers, fetch_response_data_[i].payload);

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -378,6 +378,14 @@ TEST_CASE("Fetch Message encode/decode")
     }
 }
 
+TEST_CASE("GroupOrder encode rejects invalid values")
+{
+    Bytes buffer;
+
+    CHECK_THROWS_AS(buffer << static_cast<GroupOrder>(0), ProtocolViolationException);
+    CHECK_THROWS_AS(buffer << static_cast<GroupOrder>(3), ProtocolViolationException);
+}
+
 TEST_CASE("FetchOk/Error/Cancel Message encode/decode")
 {
     auto fetch_ok = FetchOk{};

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -198,9 +198,9 @@ TEST_CASE("SubscribeOk Message encode/decode")
     auto extensions = TrackExtensions{}
                         .Add(ExtensionType::kDeliveryTimeout, 0)
                         .Add(ExtensionType::kMaxCacheDuration, 0)
-                        .Add(ExtensionType::kDefaultPublisherGroupOrder, GroupOrder::kAscending)
+                        .AddImmutable(ExtensionType::kDefaultPublisherGroupOrder, GroupOrder::kAscending)
                         .Add(ExtensionType::kDefaultPublisherPriority, 1)
-                        .Add(ExtensionType::kDynamicGroups, true);
+                        .AddImmutable(ExtensionType::kDynamicGroups, true);
 
     Bytes buffer;
     const auto track_alias = uint64_t(kTrackAliasAliceVideo);
@@ -222,8 +222,8 @@ TEST_CASE("SubscribeOk Message encode/decode")
     CHECK_EQ(0, subscribe_ok_out.track_extensions.Get<std::uint64_t>(ExtensionType::kMaxCacheDuration));
     CHECK_EQ(1, subscribe_ok_out.track_extensions.Get<std::uint64_t>(ExtensionType::kDefaultPublisherPriority));
     CHECK_EQ(GroupOrder::kAscending,
-             subscribe_ok_out.track_extensions.Get<GroupOrder>(ExtensionType::kDefaultPublisherGroupOrder));
-    CHECK_EQ(true, subscribe_ok_out.track_extensions.Get<bool>(ExtensionType::kDynamicGroups));
+             subscribe_ok_out.track_extensions.GetImmutable<GroupOrder>(ExtensionType::kDefaultPublisherGroupOrder));
+    CHECK_EQ(true, subscribe_ok_out.track_extensions.GetImmutable<bool>(ExtensionType::kDynamicGroups));
 }
 
 TEST_CASE("Unsubscribe  Message encode/decode")

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -198,9 +198,9 @@ TEST_CASE("SubscribeOk Message encode/decode")
     auto extensions = TrackExtensions{}
                         .Add(ExtensionType::kDeliveryTimeout, 0)
                         .Add(ExtensionType::kMaxCacheDuration, 0)
-                        .AddImmutable(ExtensionType::kDefaultPublisherGroupOrder, GroupOrder::kAscending)
+                        .Add(ExtensionType::kDefaultPublisherGroupOrder, GroupOrder::kAscending)
                         .Add(ExtensionType::kDefaultPublisherPriority, 1)
-                        .AddImmutable(ExtensionType::kDynamicGroups, true);
+                        .Add(ExtensionType::kDynamicGroups, true);
 
     Bytes buffer;
     const auto track_alias = uint64_t(kTrackAliasAliceVideo);
@@ -222,8 +222,8 @@ TEST_CASE("SubscribeOk Message encode/decode")
     CHECK_EQ(0, subscribe_ok_out.track_extensions.Get<std::uint64_t>(ExtensionType::kMaxCacheDuration));
     CHECK_EQ(1, subscribe_ok_out.track_extensions.Get<std::uint64_t>(ExtensionType::kDefaultPublisherPriority));
     CHECK_EQ(GroupOrder::kAscending,
-             subscribe_ok_out.track_extensions.GetImmutable<GroupOrder>(ExtensionType::kDefaultPublisherGroupOrder));
-    CHECK_EQ(true, subscribe_ok_out.track_extensions.GetImmutable<bool>(ExtensionType::kDynamicGroups));
+             subscribe_ok_out.track_extensions.Get<GroupOrder>(ExtensionType::kDefaultPublisherGroupOrder));
+    CHECK_EQ(true, subscribe_ok_out.track_extensions.Get<bool>(ExtensionType::kDynamicGroups));
 }
 
 TEST_CASE("Unsubscribe  Message encode/decode")


### PR DESCRIPTION
Group order was not quite right, and I figured removing the original order and modelling it as an optional matches the data model in the spec better, otherwise we might encode 0x0 on the wire as a group order, which is invalid. Also added the publisher side track extension API. There were a couple of places we were looking for group order where it didn't make sense, and those attribute structures still let you model invalid states, but I think this is cleaner. 

This also adds the publishers group order to use the proper track extension. 