### PR TITLE
Fix client side joining fetch handling

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -667,6 +667,7 @@ namespace quicr {
                         return true;
                     }
                     case messages::FetchType::kRelativeJoiningFetch: {
+                        relative_joining = true;
                         [[fallthrough]];
                     }
                     case messages::FetchType::kAbsoluteJoiningFetch: {

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1387,3 +1387,120 @@ TEST_CASE("Integration - Dynamic groups support roundtrip")
         test_dynamic_groups_publisher_initiated("https");
     }
 }
+
+/// Subscribe handler for JoiningFetch testing.
+class JoiningFetchSubscribeHandler final : public SubscribeTrackHandler
+{
+  public:
+    JoiningFetchSubscribeHandler(const FullTrackName& full_track_name, const JoiningFetch& jf)
+      : SubscribeTrackHandler(full_track_name, 0, messages::GroupOrder::kAscending, std::monostate{}, jf)
+    {
+    }
+
+    static std::shared_ptr<JoiningFetchSubscribeHandler> Create(const FullTrackName& full_track_name,
+                                                                const JoiningFetch& jf)
+    {
+        return std::make_shared<JoiningFetchSubscribeHandler>(full_track_name, jf);
+    }
+
+    void ObjectReceived(const ObjectHeaders&, BytesSpan, std::optional<messages::StreamHeaderProperties>) override {}
+    void StatusChanged(Status) override {}
+};
+
+TEST_CASE("Integration - Joining Fetch handling")
+{
+    const auto server = MakeTestServer();
+    constexpr std::uint64_t joining_start = 50;
+
+    // Client subscribes, server receives.
+    auto test_server_receives_joining_fetch = [&](bool expect_relative) {
+        auto client = MakeTestClient();
+
+        FullTrackName ftn;
+        ftn.name_space = TrackNamespace(std::vector<std::string>{ "test", "fetch" });
+        ftn.name = { 1, 2, 3 };
+
+        // Subscribe with a joining fetch
+        const SubscribeTrackHandler::JoiningFetch jf = {
+            .priority = 128,
+            .group_order = messages::GroupOrder::kAscending,
+            .parameters = {},
+            .joining_start = joining_start,
+            .absolute = !expect_relative,
+        };
+        const auto handler = JoiningFetchSubscribeHandler::Create(ftn, jf);
+        std::promise<TestServer::JoiningFetchDetails> promise;
+        auto future = promise.get_future();
+        server->SetJoiningFetchPromise(std::move(promise));
+        client->SubscribeTrack(handler);
+
+        // Validate correct joining fetch received.
+        auto status = future.wait_for(kDefaultTimeout);
+        REQUIRE(status == std::future_status::ready);
+        const auto& details = future.get();
+        CHECK_EQ(details.attributes.relative, expect_relative);
+        CHECK_EQ(details.attributes.joining_start, joining_start);
+    };
+
+    // Client publishes, server subscribes, client receives.
+    auto test_client_receives_joining_fetch = [&](bool expect_relative) {
+        auto client = MakeTestClient();
+
+        FullTrackName ftn;
+        ftn.name_space = TrackNamespace(std::vector<std::string>{ "test", "fetch" });
+        ftn.name = { 4, 5, 6 };
+
+        // Publish track.
+        std::promise<TestServer::SubscribeDetails> pub_received_promise;
+        auto pub_accepted_future = pub_received_promise.get_future();
+        server->SetPublishReceivedPromise(std::move(pub_received_promise));
+        const auto pub = PublishTrackHandler::Create(ftn, TrackMode::kStream, 0, 500, { 0, 0 });
+        client->PublishTrack(pub);
+        auto pub_status = pub_accepted_future.wait_for(kDefaultTimeout);
+        REQUIRE(pub_status == std::future_status::ready);
+        const auto pub_details = pub_accepted_future.get();
+
+        // Watch for the joining fetch callback.
+        std::promise<TestClient::JoiningFetchDetails> jf_promise;
+        auto jf_future = jf_promise.get_future();
+        client->SetJoiningFetchPromise(std::move(jf_promise));
+
+        // Server subscribes.
+        const SubscribeTrackHandler::JoiningFetch jf = {
+            .priority = 128,
+            .group_order = messages::GroupOrder::kAscending,
+            .parameters = {},
+            .joining_start = joining_start,
+            .absolute = !expect_relative,
+        };
+        auto sub_handler = JoiningFetchSubscribeHandler::Create(ftn, jf);
+        server->SubscribeTrack(pub_details.connection_handle, sub_handler);
+
+        // Validate correct joining fetch received.
+        auto jf_status = jf_future.wait_for(kDefaultTimeout);
+        REQUIRE(jf_status == std::future_status::ready);
+        const auto& details = jf_future.get();
+        CHECK_EQ(details.attributes.relative, expect_relative);
+        CHECK_EQ(details.attributes.joining_start, joining_start);
+    };
+
+    SUBCASE("Server receives relative joining fetch")
+    {
+        test_server_receives_joining_fetch(true);
+    }
+
+    SUBCASE("Server receives absolute joining fetch")
+    {
+        test_server_receives_joining_fetch(false);
+    }
+
+    SUBCASE("Client receives relative joining fetch")
+    {
+        test_client_receives_joining_fetch(true);
+    }
+
+    SUBCASE("Client receives absolute joining fetch")
+    {
+        test_client_receives_joining_fetch(false);
+    }
+}

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1444,9 +1444,8 @@ TEST_CASE("Integration - Joining Fetch handling")
         // Done.
         REQUIRE(WaitFor([&handler]() { return handler->GetStatus() == SubscribeTrackHandler::Status::kOk; },
                         kDefaultTimeout));
+        client->UnsubscribeTrack(handler);
         client->Disconnect();
-        REQUIRE(
-          WaitFor([&client]() { return client->GetStatus() == Transport::Status::kNotConnected; }, kDefaultTimeout));
     };
 
     // Client publishes, server subscribes, client receives.
@@ -1491,8 +1490,6 @@ TEST_CASE("Integration - Joining Fetch handling")
         CHECK_EQ(details.attributes.joining_start, joining_start);
 
         client->Disconnect();
-        REQUIRE(
-          WaitFor([&client]() { return client->GetStatus() == Transport::Status::kNotConnected; }, kDefaultTimeout));
     };
 
     SUBCASE("Server receives relative joining fetch")

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1440,6 +1440,13 @@ TEST_CASE("Integration - Joining Fetch handling")
         const auto& details = future.get();
         CHECK_EQ(details.attributes.relative, expect_relative);
         CHECK_EQ(details.attributes.joining_start, joining_start);
+
+        // Done.
+        REQUIRE(WaitFor([&handler]() { return handler->GetStatus() == SubscribeTrackHandler::Status::kOk; },
+                        kDefaultTimeout));
+        client->Disconnect();
+        REQUIRE(
+          WaitFor([&client]() { return client->GetStatus() == Transport::Status::kNotConnected; }, kDefaultTimeout));
     };
 
     // Client publishes, server subscribes, client receives.
@@ -1482,6 +1489,10 @@ TEST_CASE("Integration - Joining Fetch handling")
         const auto& details = jf_future.get();
         CHECK_EQ(details.attributes.relative, expect_relative);
         CHECK_EQ(details.attributes.joining_start, joining_start);
+
+        client->Disconnect();
+        REQUIRE(
+          WaitFor([&client]() { return client->GetStatus() == Transport::Status::kNotConnected; }, kDefaultTimeout));
     };
 
     SUBCASE("Server receives relative joining fetch")

--- a/test/integration_test/test_client.cpp
+++ b/test/integration_test/test_client.cpp
@@ -52,3 +52,14 @@ TestClient::PublishNamespaceStatusChanged(quicr::messages::RequestID request_id,
         publish_namespace_status_changed_->set_value(request_id);
     }
 }
+
+void
+TestClient::JoiningFetchReceived(quicr::ConnectionHandle connection_handle,
+                                 uint64_t request_id,
+                                 const FullTrackName& track_full_name,
+                                 const quicr::messages::JoiningFetchAttributes& attributes)
+{
+    if (joining_fetch_received_) {
+        joining_fetch_received_->set_value({ connection_handle, request_id, track_full_name, attributes });
+    }
+}

--- a/test/integration_test/test_client.h
+++ b/test/integration_test/test_client.h
@@ -1,11 +1,20 @@
 #include <future>
 #include <quicr/client.h>
+#include <quicr/detail/attributes.h>
 
 namespace quicr_test {
     class TestClient final : public quicr::Client
     {
       public:
         explicit TestClient(const quicr::ClientConfig& cfg);
+
+        struct JoiningFetchDetails
+        {
+            quicr::ConnectionHandle connection_handle;
+            uint64_t request_id;
+            quicr::FullTrackName track_full_name;
+            quicr::messages::JoiningFetchAttributes attributes;
+        };
 
         // Connection.
         void SetConnectedPromise(std::promise<quicr::ServerSetupAttributes> promise)
@@ -45,11 +54,22 @@ namespace quicr_test {
         void PublishNamespaceStatusChanged(quicr::messages::RequestID request_id,
                                            const quicr::PublishNamespaceStatus status) override;
 
+        // Joining fetch received.
+        void SetJoiningFetchPromise(std::promise<JoiningFetchDetails> promise)
+        {
+            joining_fetch_received_ = std::move(promise);
+        }
+        void JoiningFetchReceived(quicr::ConnectionHandle connection_handle,
+                                  uint64_t request_id,
+                                  const quicr::FullTrackName& track_full_name,
+                                  const quicr::messages::JoiningFetchAttributes& attributes) override;
+
       private:
         std::optional<std::promise<quicr::ServerSetupAttributes>> client_connected_;
         std::optional<std::promise<quicr::TrackNamespace>> publish_namespace_received_;
         std::optional<std::promise<quicr::FullTrackName>> publish_received_;
         std::optional<std::promise<quicr::messages::RequestID>> publish_namespace_status_changed_;
         std::shared_ptr<quicr::SubscribeTrackHandler> last_publish_received_sub_handler_;
+        std::optional<std::promise<JoiningFetchDetails>> joining_fetch_received_;
     };
 }

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -40,6 +40,11 @@ TestServer::PublishReceived(const ConnectionHandle connection_handle,
 {
     std::lock_guard lock(state_mutex_);
 
+    if (publish_received_promise_.has_value()) {
+        publish_received_promise_->set_value({ connection_handle, request_id, publish_attributes.track_full_name, {} });
+        publish_received_promise_.reset();
+    }
+
     const auto th = TrackHash(publish_attributes.track_full_name);
     const auto track_alias = th.track_fullname_hash;
 
@@ -211,6 +216,18 @@ TestServer::PublishNamespaceReceived(const ConnectionHandle connection_handle,
     // Accept the publish namespace by responding with OK
     const PublishNamespaceResponse response = { .reason_code = PublishNamespaceResponse::ReasonCode::kOk };
     ResolvePublishNamespace(connection_handle, publish_announce_attributes.request_id, track_namespace, {}, response);
+}
+
+void
+TestServer::JoiningFetchReceived(const ConnectionHandle connection_handle,
+                                 const uint64_t request_id,
+                                 const FullTrackName& track_full_name,
+                                 const messages::JoiningFetchAttributes& attributes)
+{
+    std::lock_guard lock(state_mutex_);
+    if (joining_fetch_promise_.has_value()) {
+        joining_fetch_promise_->set_value({ connection_handle, request_id, track_full_name, attributes });
+    }
 }
 
 void

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -17,12 +17,15 @@ namespace quicr_test {
     class TestSubscribeTrackHandler : public quicr::SubscribeTrackHandler
     {
       public:
-        TestSubscribeTrackHandler(const quicr::FullTrackName& full_track_name, bool is_publisher_initiated = false)
+        TestSubscribeTrackHandler(
+          const quicr::FullTrackName& full_track_name,
+          bool is_publisher_initiated = false,
+          const std::optional<quicr::SubscribeTrackHandler::JoiningFetch>& joining_fetch = std::nullopt)
           : SubscribeTrackHandler(full_track_name,
                                   3,
                                   quicr::messages::GroupOrder::kAscending,
                                   std::monostate{},
-                                  std::nullopt,
+                                  joining_fetch,
                                   is_publisher_initiated)
         {
         }
@@ -139,6 +142,20 @@ namespace quicr_test {
             std::vector<uint8_t> payload;
         };
 
+        struct JoiningFetchDetails
+        {
+            quicr::ConnectionHandle connection_handle;
+            uint64_t request_id;
+            quicr::FullTrackName track_full_name;
+            quicr::messages::JoiningFetchAttributes attributes;
+        };
+
+        // Set up promise for when a publish is received from a client
+        void SetPublishReceivedPromise(std::promise<SubscribeDetails> promise)
+        {
+            publish_received_promise_ = std::move(promise);
+        }
+
         // Set up promise for subscription event
         void SetSubscribePromise(std::promise<SubscribeDetails> promise) { subscribe_promise_ = std::move(promise); }
 
@@ -161,6 +178,12 @@ namespace quicr_test {
 
         // Set up data to respond with when a fetch is received
         void SetFetchResponseData(std::vector<FetchResponseData> data) { fetch_response_data_ = std::move(data); }
+
+        // Set up promise for joining fetch event
+        void SetJoiningFetchPromise(std::promise<JoiningFetchDetails> promise)
+        {
+            joining_fetch_promise_ = std::move(promise);
+        }
 
         void AddKnownPublishedNamespace(const quicr::TrackNamespace& track_namespace);
         void AddKnownPublishedTrack(const quicr::FullTrackName& track,
@@ -221,6 +244,11 @@ namespace quicr_test {
                                       const quicr::TrackNamespace& track_namespace,
                                       const quicr::PublishNamespaceAttributes& publish_announce_attributes) override;
 
+        void JoiningFetchReceived(quicr::ConnectionHandle connection_handle,
+                                  uint64_t request_id,
+                                  const quicr::FullTrackName& track_full_name,
+                                  const quicr::messages::JoiningFetchAttributes& attributes) override;
+
         void NewGroupRequested(const quicr::FullTrackName& track_full_name, quicr::messages::GroupId group_id) override;
 
       public:
@@ -229,9 +257,11 @@ namespace quicr_test {
       private:
         mutable std::mutex state_mutex_;
 
+        std::optional<std::promise<SubscribeDetails>> publish_received_promise_;
         std::optional<std::promise<SubscribeDetails>> subscribe_promise_;
         std::optional<std::promise<SubscribeNamespaceDetails>> subscribe_namespace_promise_;
         std::optional<std::promise<PublishNamespaceDetails>> publish_namespace_promise_;
+        std::optional<std::promise<JoiningFetchDetails>> joining_fetch_promise_;
         std::vector<quicr::TrackNamespace> known_published_namespaces_;
         std::shared_ptr<quicr::PublishNamespaceHandler> publish_namespace_handler_;
         struct AvailableTrack


### PR DESCRIPTION
Just something I noticed, no need to rush this in - just a 1 line fix to mark relative joining in the client path for relative joining fetch (the server.cpp equivalent path does correctly do this, which is what really matters in my use cases). 

The rest is just adding machinery to the integration tests to be able to watch joining fetch flows. 

This made me think again about collapsing the control message handling paths that are identical but separate between client and server, but like has been discussed before there is no point doing that when its all going to change with per-stream handling in >17, so we can make sure we take care of that then instead of dealing it with it now. 