### PR TITLE
Guard filter param

### DIFF
--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -621,8 +621,11 @@ namespace quicr {
         auto params = Parameters{}
                         .Add(ParameterType::kSubscriberPriority, priority)
                         .AddOptional(ParameterType::kGroupOrder, group_order)
-                        .Add(GetFilterParameterType(filter), filter)
                         .Add(ParameterType::kForward, forward);
+
+        if (const auto filter_type = GetFilterParameterType(filter); filter_type != ParameterType::kInvalid) {
+            params.Add(filter_type, filter);
+        }
 
         Bytes buffer;
         buffer << PublishOk(request_id, params);

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -723,7 +723,10 @@ namespace quicr {
          * - FORWARD (0x10)
          */
         const auto& filter = handler->GetFilter();
-        auto params = Parameters{}.Add(GetFilterParameterType(filter), filter);
+        Parameters params;
+        if (const auto filter_type = GetFilterParameterType(filter); filter_type != ParameterType::kInvalid) {
+            params.Add(filter_type, filter);
+        }
 
         Bytes buffer;
         buffer << messages::SubscribeNamespace(rid, prefix, SubscribeOptions::kBoth, params);


### PR DESCRIPTION
`GetFilterParameterType()` can return `kInvalid` when there's no filter. The caller MUST check this and not send `kInvalid` as a parameter on the wire if that is the case. SUBSCRIBE was doing this correctly, but SUBSCRIBE_NAMESPACE and PUBLISH_OK were not. 

Possibly filters could be optional, return nullopt on no filter, and throw on an invalid, maybe that might reduce the chance of this happening, but probably not.

This fixes an interop bug against OpenMoQ. 