### PR TITLE
Prior object gap

### DIFF
--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -417,6 +417,10 @@ namespace quicr {
         // Key is group and subgroup id
         std::map<std::uint64_t, std::map<std::uint64_t, StreamInfo>> stream_info_by_group_;
 
+        // Per group object tracking.
+        // TODO(RichLogan): Cleanup on EndGroup().
+        std::map<std::uint64_t, std::uint64_t> last_object_id_by_group_;
+
         std::optional<uint64_t> track_alias_;
         messages::Location largest_location_;
 

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -184,21 +184,6 @@ namespace quicr {
             if (object_id_delta)
                 object_id_delta--; // Adjust for delta in missing objects
 
-            // Prior Object ID Gap.
-            const auto group_last_it = last_object_id_by_group_.find(object_headers.group_id);
-            if (group_last_it != last_object_id_by_group_.end()) {
-                prior_object_id_gap = object_headers.object_id > group_last_it->second
-                                        ? object_headers.object_id - group_last_it->second
-                                        : 0;
-                if (prior_object_id_gap) {
-                    prior_object_id_gap--;
-                }
-                group_last_it->second = object_headers.object_id;
-            } else {
-                prior_object_id_gap = object_headers.object_id;
-                last_object_id_by_group_.emplace(object_headers.group_id, object_headers.object_id);
-            }
-
             if (group_id_delta) {
                 // Group change, reset pending new group request
                 pending_new_group_request_id_ = std::nullopt;
@@ -253,6 +238,20 @@ namespace quicr {
 
         if (object_headers.track_mode.has_value() && object_headers.track_mode != default_track_mode_) {
             SetDefaultTrackMode(*object_headers.track_mode);
+        }
+
+        // Prior Object ID Gap.
+        const auto group_last_it = last_object_id_by_group_.find(object_headers.group_id);
+        if (group_last_it != last_object_id_by_group_.end()) {
+            prior_object_id_gap =
+              object_headers.object_id > group_last_it->second ? object_headers.object_id - group_last_it->second : 0;
+            if (prior_object_id_gap) {
+                prior_object_id_gap--;
+            }
+            group_last_it->second = object_headers.object_id;
+        } else {
+            prior_object_id_gap = object_headers.object_id;
+            last_object_id_by_group_.emplace(object_headers.group_id, object_headers.object_id);
         }
 
         auto object_extensions = object_headers.extensions;

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -144,6 +144,7 @@ namespace quicr {
         bool is_stream_header_needed{ false };
         uint64_t group_id_delta{ 0 };
         uint64_t object_id_delta{ 0 };
+        uint64_t prior_object_id_gap{ 0 };
         uint64_t stream_id{ 0 };
 
         if (default_track_mode_ == TrackMode::kStream) {
@@ -182,6 +183,21 @@ namespace quicr {
 
             if (object_id_delta)
                 object_id_delta--; // Adjust for delta in missing objects
+
+            // Prior Object ID Gap.
+            const auto group_last_it = last_object_id_by_group_.find(object_headers.group_id);
+            if (group_last_it != last_object_id_by_group_.end()) {
+                prior_object_id_gap = object_headers.object_id > group_last_it->second
+                                        ? object_headers.object_id - group_last_it->second
+                                        : 0;
+                if (prior_object_id_gap) {
+                    prior_object_id_gap--;
+                }
+                group_last_it->second = object_headers.object_id;
+            } else {
+                prior_object_id_gap = object_headers.object_id;
+                last_object_id_by_group_.emplace(object_headers.group_id, object_headers.object_id);
+            }
 
             if (group_id_delta) {
                 // Group change, reset pending new group request
@@ -255,8 +271,8 @@ namespace quicr {
                   value_bytes);
             }
 
-            if (object_id_delta > 0) {
-                const std::uint64_t value = object_id_delta;
+            if (prior_object_id_gap > 0) {
+                const std::uint64_t value = prior_object_id_gap;
                 std::vector<std::uint8_t> value_bytes(sizeof(value));
                 memcpy(value_bytes.data(), &value, sizeof(value));
                 if (not object_extensions.has_value()) {

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1391,7 +1391,7 @@ TEST_CASE("Integration - Prior Object ID Gap")
 {
     auto server = MakeTestServer(std::nullopt, 2);
 
-    auto test_prior_object_id_gap = [&](const std::string& protocol_scheme) {
+    auto test_prior_object_id_gap = [&](const std::string& protocol_scheme, const TrackMode mode) {
         auto subscriber_client = MakeTestClient(true, std::nullopt, protocol_scheme);
         auto publisher_client = MakeTestClient(true, std::nullopt, protocol_scheme);
 
@@ -1400,7 +1400,7 @@ TEST_CASE("Integration - Prior Object ID Gap")
         ftn.name = { 0x01 };
 
         // Publisher.
-        auto pub_handler = PublishTrackHandler::Create(ftn, TrackMode::kStream, 3, 1000, { 0, 0 });
+        auto pub_handler = PublishTrackHandler::Create(ftn, mode, 3, 1000, { 0, 0 });
         publisher_client->PublishTrack(pub_handler);
         const bool pub_ready = WaitFor([&pub_handler]() { return pub_handler->CanPublish(); });
         REQUIRE(pub_ready);
@@ -1425,7 +1425,7 @@ TEST_CASE("Integration - Prior Object ID Gap")
                                       .status = ObjectStatus::kAvailable,
                                       .priority = 3,
                                       .ttl = 1000,
-                                      .track_mode = TrackMode::kStream,
+                                      .track_mode = mode,
                                       .extensions = std::nullopt,
                                       .immutable_extensions = std::nullopt };
             auto status = pub_handler->PublishObject(headers, payload);
@@ -1495,13 +1495,25 @@ TEST_CASE("Integration - Prior Object ID Gap")
 
     SUBCASE("Raw QUIC")
     {
-        CAPTURE("Raw QUIC");
-        test_prior_object_id_gap("moq");
+        SUBCASE("Stream")
+        {
+            test_prior_object_id_gap("moq", TrackMode::kStream);
+        }
+        SUBCASE("Datagram")
+        {
+            test_prior_object_id_gap("moq", TrackMode::kDatagram);
+        }
     }
 
     SUBCASE("WebTransport")
     {
-        CAPTURE("WebTransport");
-        test_prior_object_id_gap("https");
+        SUBCASE("Stream")
+        {
+            test_prior_object_id_gap("https", TrackMode::kStream);
+        }
+        SUBCASE("Datagram")
+        {
+            test_prior_object_id_gap("https", TrackMode::kDatagram);
+        }
     }
 }

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <future>
 #include <iostream>
@@ -159,6 +160,7 @@ class TestSubscribeHandler : public SubscribeTrackHandler
         uint64_t object_id;
         ObjectStatus status;
         std::vector<uint8_t> data;
+        std::optional<Extensions> extensions;
     };
 
     static std::shared_ptr<TestSubscribeHandler> Create(const FullTrackName& full_track_name,
@@ -218,7 +220,8 @@ class TestSubscribeHandler : public SubscribeTrackHandler
                                           .subgroup_id = object_headers.subgroup_id,
                                           .object_id = object_headers.object_id,
                                           .status = object_headers.status,
-                                          .data = std::vector<uint8_t>(data.begin(), data.end()) });
+                                          .data = std::vector<uint8_t>(data.begin(), data.end()),
+                                          .extensions = object_headers.extensions });
 
             // Check if we've reached the target count
             if (object_count_promise_.has_value() && received_objects_.size() >= target_object_count_) {
@@ -1381,5 +1384,124 @@ TEST_CASE("Integration - Dynamic groups support roundtrip")
     SUBCASE("WebTransport - Publisher initiated")
     {
         test_dynamic_groups_publisher_initiated("https");
+    }
+}
+
+TEST_CASE("Integration - Prior Object ID Gap")
+{
+    auto server = MakeTestServer(std::nullopt, 2);
+
+    auto test_prior_object_id_gap = [&](const std::string& protocol_scheme) {
+        auto subscriber_client = MakeTestClient(true, std::nullopt, protocol_scheme);
+        auto publisher_client = MakeTestClient(true, std::nullopt, protocol_scheme);
+
+        FullTrackName ftn;
+        ftn.name_space = TrackNamespace(std::vector<std::string>{ "test", "prior_object_gap" });
+        ftn.name = { 0x01 };
+
+        // Publisher.
+        auto pub_handler = PublishTrackHandler::Create(ftn, TrackMode::kStream, 3, 1000, { 0, 0 });
+        publisher_client->PublishTrack(pub_handler);
+        const bool pub_ready = WaitFor([&pub_handler]() { return pub_handler->CanPublish(); });
+        REQUIRE(pub_ready);
+
+        // Subscriber.
+        auto sub_handler = TestSubscribeHandler::Create(ftn, 3, std::nullopt);
+        std::promise<void> all_received_promise;
+        auto all_received_future = all_received_promise.get_future();
+        constexpr std::size_t total_objects = 5;
+        sub_handler->SetObjectCountPromise(total_objects, std::move(all_received_promise));
+        subscriber_client->SubscribeTrack(sub_handler);
+        const bool sub_ready =
+          WaitFor([&sub_handler]() { return sub_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; });
+        REQUIRE(sub_ready);
+
+        auto publish_object = [&](uint64_t group_id, uint64_t subgroup_id, uint64_t object_id) {
+            std::vector<uint8_t> payload = { static_cast<uint8_t>(object_id) };
+            ObjectHeaders headers = { .group_id = group_id,
+                                      .object_id = object_id,
+                                      .subgroup_id = subgroup_id,
+                                      .payload_length = payload.size(),
+                                      .status = ObjectStatus::kAvailable,
+                                      .priority = 3,
+                                      .ttl = 1000,
+                                      .track_mode = TrackMode::kStream,
+                                      .extensions = std::nullopt,
+                                      .immutable_extensions = std::nullopt };
+            auto status = pub_handler->PublishObject(headers, payload);
+            REQUIRE_EQ(status, PublishTrackHandler::PublishObjectStatus::kOk);
+        };
+
+        // Subgroup 0: objects 0, 1. No gap.
+        publish_object(0, 0, 0);
+        publish_object(0, 0, 1);
+        pub_handler->EndSubgroup(0, 0, true);
+
+        // Subgroup 1: object 2. No gap.
+        publish_object(0, 1, 2);
+
+        // Subgroup 1: object 5. Gap 2.
+        publish_object(0, 1, 5);
+        pub_handler->EndSubgroup(0, 1, true);
+
+        // Subgroup 2: object 7. Gap 1.
+        publish_object(0, 2, 7);
+        pub_handler->EndSubgroup(0, 2, true);
+
+        auto receive_status = all_received_future.wait_for(std::chrono::milliseconds(3000));
+        REQUIRE(receive_status == std::future_status::ready);
+        const auto received = sub_handler->GetReceivedObjects();
+        REQUIRE_EQ(received.size(), total_objects);
+
+        constexpr auto gap_key = static_cast<std::uint64_t>(messages::ExtensionType::kPriorObjectIdGap);
+
+        auto get_gap = [&](const TestSubscribeHandler::ReceivedObject& obj) -> std::optional<std::uint64_t> {
+            if (!obj.extensions.has_value() || !obj.extensions->contains(gap_key)) {
+                return std::nullopt;
+            }
+            const auto& values = obj.extensions->at(gap_key);
+            if (values.empty()) {
+                return std::nullopt;
+            }
+            std::uint64_t gap = 0;
+            std::memcpy(&gap, values[0].data(), std::min(values[0].size(), sizeof(gap)));
+            return gap;
+        };
+
+        // Object 0: no gap.
+        CHECK_EQ(received[0].object_id, 0);
+        CHECK_MESSAGE(!get_gap(received[0]).has_value(), "Object 0 should have no gap");
+
+        // Object 1: no gap.
+        CHECK_EQ(received[1].object_id, 1);
+        CHECK_MESSAGE(!get_gap(received[1]).has_value(), "Object 1 should have no gap");
+
+        // Object 2: no gap.
+        CHECK_EQ(received[2].object_id, 2);
+        CHECK_MESSAGE(!get_gap(received[2]).has_value(), "Object 2 should have no gap (group already has 0 and 1)");
+
+        // Object 5: gap = 2 (intra-subgroup).
+        CHECK_EQ(received[3].object_id, 5);
+        auto gap_5 = get_gap(received[3]);
+        REQUIRE_MESSAGE(gap_5.has_value(), "Object 5 should have a gap (objects 3-4 missing)");
+        CHECK_EQ(*gap_5, 2);
+
+        // Object 7: gap = 1 (inter-subgroup).
+        CHECK_EQ(received[4].object_id, 7);
+        auto gap_7 = get_gap(received[4]);
+        REQUIRE_MESSAGE(gap_7.has_value(), "Object 7 should have a gap (object 6 missing)");
+        CHECK_EQ(*gap_7, 1);
+    };
+
+    SUBCASE("Raw QUIC")
+    {
+        CAPTURE("Raw QUIC");
+        test_prior_object_id_gap("moq");
+    }
+
+    SUBCASE("WebTransport")
+    {
+        CAPTURE("WebTransport");
+        test_prior_object_id_gap("https");
     }
 }


### PR DESCRIPTION
It looks like prior object gab was being calculated using the existing object ID delta - but that is on a per-subgroup level, not at the group level that the prior object ID should be described at.

It was also not being sent on datagram, fixed that while I was there. 

Added a test for various gap scenarios, datagram and stream. 