### PR TITLE
Improve Message

### DIFF
--- a/include/quicr/detail/message.h
+++ b/include/quicr/detail/message.h
@@ -49,6 +49,11 @@ namespace quicr::messages {
         {
             UintVar type_bytes(static_cast<std::uint64_t>(type));
             _bytes->insert(_bytes->begin(), type_bytes.begin(), type_bytes.end());
+
+            if (_length_bytes_offset.has_value()) {
+                _length_bytes_offset = type_bytes.size();
+            }
+
             return *this;
         }
 

--- a/include/quicr/detail/message.h
+++ b/include/quicr/detail/message.h
@@ -10,6 +10,12 @@
 #include <vector>
 
 namespace quicr::messages {
+    /**
+     * @brief Generic message buffer formatting class.
+     *
+     * @details Generic message type that formats a message into a byte buffer in a declarative manner. The intent is
+     *          to call it via the Builder Pattern methods in a way that lays out the format of message obviously.
+     */
     class Message
     {
       public:
@@ -21,28 +27,49 @@ namespace quicr::messages {
             }
         }
 
+        /**
+         * @brief Checks if the message was built with the payload length written near the front.
+         * @returns True if the message has space reserved for the payload size near the front, false otherwise.
+         */
+        constexpr bool HasPrependedLength() const noexcept { return _length_bytes_offset.has_value(); }
+
+        /**
+         * @brief Prepends a message type at the front of the byte buffer.
+         *
+         * @tparam T The enumeration/integral type of the message type.
+         *
+         * @param type The type of message to be written at the front of the buffer.
+         * @returns A reference to the message currently being built.
+         *
+         * @note When building a message, this should be the first method called.
+         */
         template<typename T>
-            requires std::is_enum_v<T>
-        Message(T type,
-                std::shared_ptr<std::vector<std::uint8_t>> buffer = std::make_shared<std::vector<std::uint8_t>>())
-          : Message(std::move(buffer))
+            requires std::is_enum_v<T> || std::is_integral_v<T>
+        inline Message& PrependType(T type)
         {
-            auto type_bytes = UintVar(static_cast<std::uint64_t>(type));
-            _bytes->insert(_bytes->end(), type_bytes.begin(), type_bytes.end());
+            UintVar type_bytes(static_cast<std::uint64_t>(type));
+            _bytes->insert(_bytes->begin(), type_bytes.begin(), type_bytes.end());
+            return *this;
         }
 
-        constexpr bool IncludesLength() const noexcept { return _length_reserved; }
-
+        /**
+         * @brief Inserts a std::uint16_t near the front of the byte buffer for the payload length.
+         * @returns A reference to the message currently being built.
+         */
         inline Message& ReserveLength()
         {
-            if (_length_reserved) {
+            if (_length_bytes_offset.has_value()) {
                 return *this;
             }
 
-            const std::size_t type_size = UintVar(_bytes->front()).size();
-            _bytes->insert(std::next(_bytes->begin(), type_size), { 0, 0 });
+            if (_bytes->empty()) {
+                _length_bytes_offset = 0;
+            } else {
+                _length_bytes_offset = UintVar::Size(_bytes->front());
+            }
 
-            _length_reserved = true;
+            _bytes->insert(std::next(_bytes->begin(), _length_bytes_offset.value()), { 0, 0 });
+
             return *this;
         }
 
@@ -68,8 +95,8 @@ namespace quicr::messages {
 
         inline const std::shared_ptr<std::vector<uint8_t>>& ToBytes() const noexcept
         {
-            if (_length_reserved) {
-                const std::size_t type_size = UintVar(_bytes->front()).size();
+            if (_length_bytes_offset.has_value()) {
+                const std::size_t type_size = UintVar::Size(_bytes->front());
                 const std::uint16_t payload_size =
                   SwapBytes(static_cast<std::uint16_t>(_bytes->size() - type_size - sizeof(std::uint16_t)));
                 std::memcpy(_bytes->data() + type_size, &payload_size, sizeof(std::uint16_t));
@@ -80,6 +107,12 @@ namespace quicr::messages {
 
         inline std::span<const std::uint8_t> ToByteSpan() const noexcept { return *ToBytes(); }
 
+        void Clear() noexcept
+        {
+            _bytes->clear();
+            _length_bytes_offset = std::nullopt;
+        }
+
         template<typename Field>
         [[nodiscard]] static inline Field ParseField(std::span<const std::uint8_t>& buffer)
         {
@@ -89,7 +122,7 @@ namespace quicr::messages {
         }
 
       private:
-        bool _length_reserved = false;
+        std::optional<std::size_t> _length_bytes_offset;
         mutable std::shared_ptr<std::vector<std::uint8_t>> _bytes;
     };
 }

--- a/include/quicr/detail/message.h
+++ b/include/quicr/detail/message.h
@@ -96,10 +96,9 @@ namespace quicr::messages {
         inline const std::shared_ptr<std::vector<uint8_t>>& ToBytes() const noexcept
         {
             if (_length_bytes_offset.has_value()) {
-                const std::size_t type_size = UintVar::Size(_bytes->front());
-                const std::uint16_t payload_size =
-                  SwapBytes(static_cast<std::uint16_t>(_bytes->size() - type_size - sizeof(std::uint16_t)));
-                std::memcpy(_bytes->data() + type_size, &payload_size, sizeof(std::uint16_t));
+                const std::uint16_t payload_size = SwapBytes(
+                  static_cast<std::uint16_t>(_bytes->size() - _length_bytes_offset.value() - sizeof(std::uint16_t)));
+                std::memcpy(_bytes->data() + _length_bytes_offset.value(), &payload_size, sizeof(std::uint16_t));
             }
 
             return _bytes;

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -556,7 +556,7 @@ namespace quicr {
                          messages::ControlMessageType type,
                          Fields&&... args)
         {
-            messages::Message msg = messages::Message{ type }.ReserveLength();
+            messages::Message msg = messages::Message{}.PrependType(type).ReserveLength();
 
             (msg.Append(args), ...);
 


### PR DESCRIPTION
Cleans up the message builder to not require the order of type or length be correctly called for them to be inserted at the correct positions.