### PR TITLE
Thread safe publish status

### DIFF
--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 #include <quicr/detail/base_track_handler.h>
 #include <quicr/detail/messages.h>
@@ -214,7 +215,7 @@ namespace quicr {
          *
          * @return Status of publish
          */
-        constexpr Status GetStatus() const noexcept { return publish_status_; }
+        Status GetStatus() const noexcept { return publish_status_.load(std::memory_order_acquire); }
 
         /**
          * Get the largest location
@@ -240,9 +241,9 @@ namespace quicr {
          *
          * @return true to indicate that the publisher can publish, false if the publisher cannot
          */
-        constexpr bool CanPublish() const noexcept
+        bool CanPublish() const noexcept
         {
-            switch (publish_status_) {
+            switch (GetStatus()) {
                 case Status::kOk:
                 case Status::kNewGroupRequested:
                 case Status::kSubscriptionUpdated:
@@ -371,11 +372,10 @@ namespace quicr {
          */
         void SetStatus(Status status) noexcept
         {
-            if (publish_status_ == status) {
+            const auto previous = publish_status_.exchange(status, std::memory_order_acq_rel);
+            if (previous == status) {
                 return;
             }
-
-            publish_status_ = status;
             StatusChanged(status);
         }
 
@@ -398,7 +398,7 @@ namespace quicr {
         // --------------------------------------------------------------------------
         // Member variables
         // --------------------------------------------------------------------------
-        Status publish_status_{ Status::kNotAnnounced };
+        std::atomic<Status> publish_status_{ Status::kNotAnnounced };
         TrackMode default_track_mode_;
         std::optional<messages::StreamHeaderProperties> stream_mode_;
         uint8_t default_priority_; // Set by caller and is used when priority is not specified

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -21,7 +21,7 @@ namespace quicr {
             return PublishObjectStatus::kInternalError;
         }
 
-        switch (publish_status_) {
+        switch (GetStatus()) {
             case Status::kOk:
                 break;
 
@@ -50,7 +50,7 @@ namespace quicr {
                 if (!is_new_stream) {
                     break;
                 }
-                publish_status_ = Status::kOk;
+                publish_status_.store(Status::kOk, std::memory_order_release);
                 break;
             case Status::kPendingPublishOk:
                 publish_track_metrics_.objects_dropped_not_ok++;
@@ -196,7 +196,7 @@ namespace quicr {
             stream_id = subgroup_it->second.stream_id;
         }
 
-        switch (publish_status_) {
+        switch (GetStatus()) {
             case Status::kOk:
                 break;
 
@@ -220,7 +220,7 @@ namespace quicr {
                 return PublishObjectStatus::kNotAuthorized;
             case Status::kNewGroupRequested:
                 // reset the status to ok to imply change
-                publish_status_ = Status::kOk;
+                publish_status_.store(Status::kOk, std::memory_order_release);
                 break;
             case Status::kSubscriptionUpdated:
 
@@ -229,7 +229,7 @@ namespace quicr {
                  * Always start a new stream on subscription update to support peering/pipelining
                  */
 
-                publish_status_ = Status::kOk;
+                publish_status_.store(Status::kOk, std::memory_order_release);
                 break;
             default:
                 publish_track_metrics_.objects_dropped_not_ok++;


### PR DESCRIPTION
Make publish status explicitly thread safe. While the `uint8_t` backing storage is atomic already (and with this change should compile to the same instructions), the memory ordering should provide better guarantees of what state changes are visible when the corresponding status changes. I have explicitly done acq/rel here because I don't think we need the seqcst cost, even though it's not a hot path anyway. 

Bear in mind that there is an existing ability for status updates to be lost in a certain way, if they race, which is still present here. We need some more thought around that in order to decide what the semantics are for racing status updates while a publish is in flight. 