### PR TITLE
Stop status overwrite

### DIFF
--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -21,7 +21,8 @@ namespace quicr {
             return PublishObjectStatus::kInternalError;
         }
 
-        switch (GetStatus()) {
+        const auto status = GetStatus();
+        switch (status) {
             case Status::kOk:
                 break;
 
@@ -45,13 +46,16 @@ namespace quicr {
                 return PublishObjectStatus::kNotAuthorized;
             case Status::kNewGroupRequested:
                 [[fallthrough]];
-            case Status::kSubscriptionUpdated:
+            case Status::kSubscriptionUpdated: {
                 // reset the status to ok to imply change
                 if (!is_new_stream) {
                     break;
                 }
-                publish_status_.store(Status::kOk, std::memory_order_release);
+                auto current = status;
+                publish_status_.compare_exchange_strong(
+                  current, Status::kOk, std::memory_order_acq_rel, std::memory_order_acquire);
                 break;
+            }
             case Status::kPendingPublishOk:
                 publish_track_metrics_.objects_dropped_not_ok++;
                 return PublishObjectStatus::kPendingPublishOk;
@@ -196,7 +200,8 @@ namespace quicr {
             stream_id = subgroup_it->second.stream_id;
         }
 
-        switch (GetStatus()) {
+        const auto status = GetStatus();
+        switch (status) {
             case Status::kOk:
                 break;
 
@@ -218,19 +223,25 @@ namespace quicr {
             case Status::kAnnounceNotAuthorized:
                 publish_track_metrics_.objects_dropped_not_ok++;
                 return PublishObjectStatus::kNotAuthorized;
-            case Status::kNewGroupRequested:
+            case Status::kNewGroupRequested: {
                 // reset the status to ok to imply change
-                publish_status_.store(Status::kOk, std::memory_order_release);
+                auto current = status;
+                publish_status_.compare_exchange_strong(
+                  current, Status::kOk, std::memory_order_acq_rel, std::memory_order_acquire);
                 break;
-            case Status::kSubscriptionUpdated:
+            }
+            case Status::kSubscriptionUpdated: {
 
                 /*
                  * TODO: Need to revisit the below since subgroups doesn't really support this
                  * Always start a new stream on subscription update to support peering/pipelining
                  */
 
-                publish_status_.store(Status::kOk, std::memory_order_release);
+                auto current = status;
+                publish_status_.compare_exchange_strong(
+                  current, Status::kOk, std::memory_order_acq_rel, std::memory_order_acquire);
                 break;
+            }
             default:
                 publish_track_metrics_.objects_dropped_not_ok++;
                 return PublishObjectStatus::kInternalError;


### PR DESCRIPTION
Sometimes we "consume" a temporary status like `kNewGroupRequested` - reverting the status to `kOk` on the app's thread when they call `PublishObject()`. However, this can overwrite a remote status update that is set from the libquicr thread, while `PublishObject` is running. This change ensures we will only flip the status to `kOk` when consuming a temporary status when the current handler status is still said temporary status at the point of flipping it. 

e.g previously, the following sequence could occur. 

1. New Group Requested
2. Publish Object
3. Remote status event changes to some other status mid publish object call.
4. Publish Object call flips to `kOk` assuming it's still New Group Requested. 

Now 4 will not happen, because the strong exchange will not flip to kOk if the current status is not the New Group Requested status we are consuming.

Note that the object that was proposed to be published with a valid status will still be published even if the status has been changed to a non-publishing one in the meantime. This is an open question, but it's the existing behaviour and I didn't change it. fwiw I don't think we need the strictness and the complexity that would come with it(?)