### PR TITLE
Add ASAN and UBSAN options

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,55 @@
+name: Sanitizers
+
+on:
+  push:
+    branches: [ "main", "draft-18" ]
+  pull_request:
+    branches: [ "main", "draft-18" ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  integration-tests:
+    name: Integration Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04 ]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Configure GCC 12
+        run: |
+          echo "CC=/usr/bin/gcc-12" >> $GITHUB_ENV
+          echo "CXX=/usr/bin/g++-12" >> $GITHUB_ENV
+
+      - name: Configure CMake
+        run: >
+          cmake -B ${{ github.workspace }}/build
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
+          -DBUILD_TESTING=ON
+          -DQUICR_BUILD_TESTS=ON
+          -DQUICR_BUILD_BENCHMARKS=OFF
+          -DQUICR_BUILD_EXAMPLES=OFF
+          -DQUICR_BUILD_C_BRIDGE=OFF
+          -DQUICR_ENABLE_SANITIZERS=ON
+
+      - name: Build integration tests
+        run: >
+          cmake --build ${{ github.workspace }}/build
+          --config ${{ env.BUILD_TYPE }}
+          --target quicr_integration_test generate_test_certs
+          -j
+
+      - name: Run integration tests
+        run: >
+          ctest --test-dir ${{ github.workspace }}/build/test/integration_test
+          -C ${{ env.BUILD_TYPE }}
+          --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,22 @@ cmake_dependent_option(QUICR_BUILD_C_BRIDGE "Build C Bridge API for quicr" ON CM
 option(QUICR_BUILD_SHARED "Build quicr as a SHARED library" OFF)
 option(QUICR_BUILD_FUZZ "Build fuzzer targets" OFF)
 option(QUICR_BUILD_EXAMPLES "Build examples" OFF)
+option(QUICR_ENABLE_SANITIZERS "Build with ASAN and UBSAN" OFF)
 
 option(USE_MBEDTLS OFF)
 option(LINT "Perform linting with clang-tidy" OFF)
+
+if(QUICR_ENABLE_SANITIZERS)
+    if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang|GNU" OR NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+        message(FATAL_ERROR "QUICR_ENABLE_SANITIZERS requires Clang or GCC")
+    endif()
+    add_compile_options(
+        -fsanitize=address,undefined
+        -fno-omit-frame-pointer
+        -fno-sanitize-recover=undefined
+    )
+    add_link_options(-fsanitize=address,undefined)
+endif()
 
 if (NOT DEFINED ENV{IDF_PATH})
   find_package(Threads REQUIRED)

--- a/include/quicr/detail/attributes.h
+++ b/include/quicr/detail/attributes.h
@@ -18,50 +18,50 @@ namespace quicr::messages {
      */
     struct SubscribeAttributes
     {
-        std::uint8_t priority;                                              ///< Subscriber priority
+        std::uint8_t priority{ 0 };                                         ///< Subscriber priority
         std::optional<GroupOrder> group_order;                              ///< Subscriber group order
         GroupOrder publisher_default_group_order{ GroupOrder::kAscending }; ///< Publisher track default group order
-        std::chrono::milliseconds delivery_timeout;                         ///< Subscriber delivery timeout
-        std::chrono::milliseconds expires;                                  ///< Subscriber expiry in ms
-        Filter filter;                                                      /// Subscriber filter
-        std::uint8_t forward;                         ///< True to Resume/forward data, False to pause/stop data
+        std::chrono::milliseconds delivery_timeout{ 0 };                    ///< Subscriber delivery timeout
+        std::chrono::milliseconds expires{ 0 };                             ///< Subscriber expiry in ms
+        Filter filter{ std::monostate{} };                                  /// Subscriber filter
+        std::uint8_t forward{ 0 };                    ///< True to Resume/forward data, False to pause/stop data
         std::optional<uint64_t> new_group_request_id; ///< Indicates new group id is requested
-        bool is_publisher_initiated;                  ///< True will not send SUBSCRIBE_OK.
-        Location start_location;                      ///< Start location of group and object
+        bool is_publisher_initiated{ false };         ///< True will not send SUBSCRIBE_OK.
+        Location start_location{};                    ///< Start location of group and object
     };
 
     struct PublishAttributes : SubscribeAttributes
     {
         FullTrackName track_full_name;
-        std::uint64_t track_alias;
-        bool dynamic_groups = false;
+        std::uint64_t track_alias{ 0 };
+        bool dynamic_groups{ false };
     };
 
     struct FetchEndLocation
     {
         /// The group ID of the fetch's end location (inclusive).
-        GroupId group;
+        GroupId group{ 0 };
         /// The object ID of the fetch's end location (inclusive), or null for the whole group.
         std::optional<ObjectId> object;
     };
 
     struct StandaloneFetchAttributes
     {
-        std::uint8_t priority;                                              ///< Fetch priority
+        std::uint8_t priority{ 0 };                                         ///< Fetch priority
         std::optional<GroupOrder> group_order;                              ///< Fetch group order
         GroupOrder publisher_default_group_order{ GroupOrder::kAscending }; ///< Publisher track default group order
-        Location start_location;                                            ///< Fetch starting location in range
-        FetchEndLocation end_location;                                      ///< Fetch final location.
+        Location start_location{};                                          ///< Fetch starting location in range
+        FetchEndLocation end_location{};                                    ///< Fetch final location.
     };
 
     struct JoiningFetchAttributes
     {
-        std::uint8_t priority;                                              ///< Fetch priority
+        std::uint8_t priority{ 0 };                                         ///< Fetch priority
         std::optional<GroupOrder> group_order;                              ///< Fetch group order
         GroupOrder publisher_default_group_order{ GroupOrder::kAscending }; ///< Publisher track default group order
-        RequestID joining_request_id;                                       ///< Fetch joining request_id
-        bool relative{ false };      ///< True indicates relative to largest, False indicates absolute
-        std::uint64_t joining_start; ///< Fetch joining start
+        RequestID joining_request_id{ 0 };                                  ///< Fetch joining request_id
+        bool relative{ false };           ///< True indicates relative to largest, False indicates absolute
+        std::uint64_t joining_start{ 0 }; ///< Fetch joining start
     };
 
     struct SubscribeNamespaceAttributes

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -2566,6 +2566,7 @@ PicoQuicTransport::Shutdown()
         }
 
         picoquic_delete_network_thread(quic_network_thread_ctx_);
+        quic_network_thread_ctx_ = nullptr;
     }
 
     picoquic_runner_queue_.StopWaiting();
@@ -2574,6 +2575,11 @@ PicoQuicTransport::Shutdown()
     if (cbNotifyThread_.joinable()) {
         SPDLOG_LOGGER_INFO(logger, "Closing transport callback notifier thread");
         cbNotifyThread_.join();
+    }
+
+    if (quic_ctx_ != nullptr) {
+        picoquic_free(quic_ctx_);
+        quic_ctx_ = nullptr;
     }
 
     tick_service_.reset();

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -577,8 +577,8 @@ namespace quicr {
          * Variables
          */
         picoquic_quic_config_t config_;
-        picoquic_quic_t* quic_ctx_;
-        picoquic_network_thread_ctx_t* quic_network_thread_ctx_;
+        picoquic_quic_t* quic_ctx_{ nullptr };
+        picoquic_network_thread_ctx_t* quic_network_thread_ctx_{ nullptr };
         picoquic_packet_loop_param_t quic_network_thread_params_{};
         int quic_loop_return_value_{ 0 };
         picoquic_tp_t local_tp_options_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 CPMAddPackage("gh:doctest/doctest@2.5.2")
 
+if(QUICR_ENABLE_SANITIZERS)
+    set(QUICR_SANITIZER_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/sanitizer_options.cpp")
+endif()
+
 add_executable(quicr_test
     cache.cpp
     client.cpp
@@ -17,6 +21,7 @@ add_executable(quicr_test
     track_handlers.cpp
     track_namespace.cpp
     uintvar.cpp
+    ${QUICR_SANITIZER_TEST_SRC}
 )
 
 target_include_directories(quicr_test PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,10 +3,6 @@
 
 CPMAddPackage("gh:doctest/doctest@2.5.2")
 
-if(QUICR_ENABLE_SANITIZERS)
-    set(QUICR_SANITIZER_TEST_SRC "${CMAKE_CURRENT_SOURCE_DIR}/sanitizer_options.cpp")
-endif()
-
 add_executable(quicr_test
     cache.cpp
     client.cpp
@@ -21,8 +17,11 @@ add_executable(quicr_test
     track_handlers.cpp
     track_namespace.cpp
     uintvar.cpp
-    ${QUICR_SANITIZER_TEST_SRC}
 )
+
+if(QUICR_ENABLE_SANITIZERS)
+    target_sources(quicr_test PRIVATE sanitizer_options.cpp)
+endif()
 
 target_include_directories(quicr_test PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(quicr_test PRIVATE quicr doctest::doctest)

--- a/test/integration_test/CMakeLists.txt
+++ b/test/integration_test/CMakeLists.txt
@@ -8,8 +8,13 @@ add_executable(quicr_integration_test
     test_server.cpp
     test_client.h
     test_client.cpp
-    ${QUICR_SANITIZER_TEST_SRC}
 )
+
+if(QUICR_ENABLE_SANITIZERS)
+    target_sources(quicr_integration_test PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/../sanitizer_options.cpp"
+    )
+endif()
 
 # Include directories
 target_include_directories(quicr_integration_test PRIVATE

--- a/test/integration_test/CMakeLists.txt
+++ b/test/integration_test/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(quicr_integration_test
     test_server.cpp
     test_client.h
     test_client.cpp
+    ${QUICR_SANITIZER_TEST_SRC}
 )
 
 # Include directories

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -517,6 +517,7 @@ StreamPerSubGroupObjectEncodeDecode(StreamHeaderProperties properties, Extension
         }
         // got one object
         object_count++;
+        std::destroy_at(&obj_out);
         std::construct_at(&obj_out);
         obj_out.properties.emplace(properties);
         in_buffer.Pop(in_buffer.Size());

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -5,7 +5,7 @@
 
 #include <any>
 #include <doctest/doctest.h>
-#include <memory>
+#include <optional>
 #include <string>
 #include <sys/socket.h>
 
@@ -487,39 +487,39 @@ StreamPerSubGroupObjectEncodeDecode(StreamHeaderProperties properties, Extension
         buffer << obj;
     }
 
-    StreamSubGroupObject obj_out;
-    obj_out.properties.emplace(properties);
+    std::optional<StreamSubGroupObject> obj_out;
+    obj_out.emplace();
+    obj_out->properties.emplace(properties);
     size_t object_count = 0;
     StreamBuffer<uint8_t> in_buffer;
     for (size_t i = 0; i < buffer.size(); i++) {
         in_buffer.Push(buffer.at(i));
-        bool done = in_buffer >> obj_out;
+        bool done = in_buffer >> *obj_out;
         if (!done) {
             continue;
         }
 
-        CHECK_EQ(obj_out.object_delta, objects[object_count].object_delta);
+        CHECK_EQ(obj_out->object_delta, objects[object_count].object_delta);
         if (empty_payload) {
-            CHECK_EQ(obj_out.object_status, objects[object_count].object_status);
+            CHECK_EQ(obj_out->object_status, objects[object_count].object_status);
         } else {
-            CHECK(obj_out.payload.size() > 0);
-            CHECK_EQ(obj_out.payload, objects[object_count].payload);
+            CHECK(obj_out->payload.size() > 0);
+            CHECK_EQ(obj_out->payload, objects[object_count].payload);
         }
 
         if (properties.extensions) {
             CompareExtensions(objects[object_count].extensions,
-                              obj_out.extensions,
+                              obj_out->extensions,
                               extensions == ExtensionTest::kBoth || extensions == ExtensionTest::kImmutable);
-            CHECK_EQ(obj_out.immutable_extensions, objects[object_count].immutable_extensions);
+            CHECK_EQ(obj_out->immutable_extensions, objects[object_count].immutable_extensions);
         } else {
-            CHECK_EQ(obj_out.extensions, std::nullopt);
-            CHECK_EQ(obj_out.immutable_extensions, std::nullopt);
+            CHECK_EQ(obj_out->extensions, std::nullopt);
+            CHECK_EQ(obj_out->immutable_extensions, std::nullopt);
         }
         // got one object
         object_count++;
-        std::destroy_at(&obj_out);
-        std::construct_at(&obj_out);
-        obj_out.properties.emplace(properties);
+        obj_out.emplace();
+        obj_out->properties.emplace(properties);
         in_buffer.Pop(in_buffer.Size());
     }
 

--- a/test/sanitizer_options.cpp
+++ b/test/sanitizer_options.cpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+// NOLINTBEGIN(readability-identifier-naming)
+
+extern "C" const char*
+__asan_default_options()
+{
+    return "detect_leaks=1";
+}
+
+extern "C" const char*
+__ubsan_default_options()
+{
+    return "print_stacktrace=1";
+}
+
+extern "C" const char*
+__lsan_default_suppressions()
+{
+    // The client owns the WebTransport h3 context but never frees it.
+    // Freeing it properly needs DeregisterWebTransport and CloseInternal
+    // untangled and refactored.
+    return "leak:picowt_connect_ex\n"
+           "leak:picowt_prepare_client_cnx\n"
+           "leak:picowt_create_stream_ctx\n"
+           "leak:picowt_set_control_stream\n"
+           "leak:h3zero_find_or_create_stream\n";
+}
+
+// NOLINTEND(readability-identifier-naming)


### PR DESCRIPTION
Add support for ASAN and UBSAN, fixes a possible use-after-free on fast shutdown (network thread ptr should go to nullptr) and a leak on shutdown (`picoquic_free`).

These attribute structs are going to go soon I'm sure, so these default values aren't really that important. 