### PR TITLE
Draft 18 varint

### DIFF
--- a/benchmark/uintvar.cpp
+++ b/benchmark/uintvar.cpp
@@ -43,9 +43,8 @@ static void
 UIntVar_FromBytes(benchmark::State& state)
 {
     constexpr auto var = quicr::UintVar(0x123456789);
-    constexpr auto bytes = std::bit_cast<std::array<std::uint8_t, sizeof(uint64_t)>>(var);
     for ([[maybe_unused]] const auto& _ : state) {
-        auto value = quicr::UintVar(bytes);
+        auto value = quicr::UintVar(std::span{ var });
         benchmark::DoNotOptimize(value);
         benchmark::ClobberMemory();
     }

--- a/docs/api-guide.md
+++ b/docs/api-guide.md
@@ -43,7 +43,7 @@ requests low quality video and audio.
 
 ### Track Alias
 Track alias is a generated hash value of `namespace` and `name` in this implementation. It's a consistent hash that
-is globally unique.  The track alias is a `uint64_t` value (*62 bits max due to QUIC variable length integer*)
+is globally unique.  The track alias is a `uint64_t` value
 that represents the full track name. Track alias is used when encoding object and other MOQT messages instead of
 having to duplicate the large binary array of bytes for namespace and name. The application can choose to
 specify the track alias if it wishes to override the default hash.

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -37,7 +37,7 @@ low bandwidth video feed.
 
 ### Track Alias
 Track alias is a generated hash value of `namespace` and `name` in this implementation. It's a consistent hash that
-is globally unique.  The track alias is a `uint64_t` value (*62 bits max due to QUIC variable length integer*)
+is globally unique.  The track alias is a `uint64_t` value
 that represents the track fullname. Track alias is used when encoding object and other MOQT messages instead of
 having to duplicate the large binary array of bytes for namespace and name.
 

--- a/include/quicr/detail/base_track_handler.h
+++ b/include/quicr/detail/base_track_handler.h
@@ -181,7 +181,7 @@ namespace quicr {
          * @details MoQ instance sets the request id based on subscribe track method call. Request
          *      id is specific to the connection, so it must be set by the moq instance/connection.
          *
-         * @param request_id          62bit request ID
+         * @param request_id          64bit request ID
          */
         void SetRequestId(std::optional<uint64_t> request_id) { request_id_ = request_id; }
 

--- a/include/quicr/detail/ctrl_message_types.h
+++ b/include/quicr/detail/ctrl_message_types.h
@@ -253,7 +253,7 @@ namespace quicr::messages {
             buffer = buffer.subspan(uvar.size());
             std::uint64_t val(uvar);
             const auto* p = reinterpret_cast<const std::uint8_t*>(&val);
-            kvp.value.assign(p, p + uvar.size());
+            kvp.value.assign(p, p + sizeof(val));
         }
     }
 

--- a/include/quicr/detail/uintvar.h
+++ b/include/quicr/detail/uintvar.h
@@ -5,13 +5,14 @@
 
 #include "utilities.h"
 
+#include <algorithm>
+#include <array>
 #include <bit>
 #include <cstdint>
-#include <cstring>
 #include <source_location>
 #include <span>
 #include <stdexcept>
-#include <vector>
+#include <string>
 
 namespace quicr {
 
@@ -30,31 +31,27 @@ namespace quicr {
     class UintVar
     {
       public:
-        constexpr UintVar(uint64_t value, const std::source_location caller = std::source_location::current())
-          : be_value_{ std::bit_cast<std::array<std::uint8_t, sizeof(std::uint64_t)>>(SwapBytes(value)) }
+        constexpr UintVar(uint64_t value) noexcept
+          : be_value_{ 0 }
         {
-            constexpr uint64_t k14bitLength = (static_cast<uint64_t>(-1) << (64 - 6) >> (64 - 6));
-            constexpr uint64_t k30bitLength = (static_cast<uint64_t>(-1) << (64 - 14) >> (64 - 14));
-            constexpr uint64_t k62bitLength = (static_cast<uint64_t>(-1) << (64 - 30) >> (64 - 30));
+            // How many bytes do we need to store this value?
+            const auto bits = std::bit_width(value);
+            const std::size_t length = std::min<std::size_t>(kMaxEncodedSize, bits == 0 ? 1 : (bits + 6) / 7);
 
-            if (be_value_.front() & 0xC0u) { // Check if invalid
-                throw UintVarInvalidArgException("Value greater than uintvar maximum", caller);
+            // Max is 1 byte of 1s, 8 bytes of value.
+            if (length == kMaxEncodedSize) {
+                const auto bytes = std::bit_cast<std::array<std::uint8_t, sizeof(value)>>(SwapBytes(value));
+                std::copy(bytes.begin(), bytes.end(), std::next(be_value_.begin()));
+                be_value_.front() = 0xFF;
+                return;
             }
 
-            std::uint64_t be_v = std::bit_cast<std::uint64_t>(be_value_);
-            if (value > k62bitLength) { // 62 bit encoding (8 bytes)
-                be_v |= 0xC0ull;
-            } else if (value > k30bitLength) { // 30 bit encoding (4 bytes)
-                be_v >>= 32;
-                be_v |= 0x80ull;
-            } else if (value > k14bitLength) { // 14 bit encoding (2 bytes)
-                be_v >>= 48;
-                be_v |= 0x40ull;
-            } else {
-                be_v >>= 56;
-            }
-
-            be_value_ = std::bit_cast<std::array<std::uint8_t, sizeof(std::uint64_t)>>(be_v);
+            // Otherwise length signalled by leading 1s, followed by compressed value.
+            const auto value_be = SwapBytes(value << ((sizeof(value) - length) * 8));
+            const auto bytes = std::bit_cast<std::array<std::uint8_t, sizeof(value)>>(value_be);
+            std::copy(bytes.begin(), bytes.end(), be_value_.begin());
+            const auto prefix = length == 1 ? 0u : static_cast<std::uint8_t>(0xFFu << (kMaxEncodedSize - length));
+            be_value_.front() |= static_cast<std::uint8_t>(prefix);
         }
 
         constexpr UintVar(std::span<const std::uint8_t> bytes,
@@ -64,15 +61,7 @@ namespace quicr {
             if (bytes.empty() || bytes.size() < Size(bytes.front())) {
                 throw UintVarInvalidArgException("Invalid bytes for uintvar", caller);
             }
-
-            const std::size_t size = Size(bytes.front());
-            if (std::is_constant_evaluated()) {
-                for (std::size_t i = 0; i < size; ++i) {
-                    be_value_[i] = bytes.data()[i];
-                }
-            } else {
-                std::memcpy(&be_value_, bytes.data(), size);
-            }
+            std::copy_n(bytes.data(), Size(bytes.front()), be_value_.begin());
         }
 
         constexpr UintVar(const UintVar&) noexcept = default;
@@ -89,21 +78,21 @@ namespace quicr {
 
         constexpr std::uint64_t Get() const noexcept
         {
-            return SwapBytes((std::bit_cast<std::uint64_t>(be_value_) & SwapBytes(uint64_t(~(~0x3Full << 56))))
-                             << (sizeof(uint64_t) - Size()) * 8);
+            // Read length of value in leading 1s, then value.
+            const auto length = Size();
+            const auto value_bits = length == kMaxEncodedSize ? 0 : 8 - length;
+            const auto mask = value_bits == 0 ? 0 : static_cast<std::uint8_t>((1u << value_bits) - 1);
+            std::uint64_t value = be_value_.front() & mask;
+            for (std::size_t i = 1; i < length; ++i) {
+                value = (value << 8) | be_value_[i];
+            }
+            return value;
         }
 
         static constexpr std::size_t Size(uint8_t msb_bytes) noexcept
         {
-            if ((msb_bytes & 0xC0) == 0xC0) {
-                return sizeof(uint64_t);
-            } else if ((msb_bytes & 0x80) == 0x80) {
-                return sizeof(uint32_t);
-            } else if ((msb_bytes & 0x40) == 0x40) {
-                return sizeof(uint16_t);
-            }
-
-            return sizeof(uint8_t);
+            const auto leading_ones = std::countl_one(msb_bytes);
+            return leading_ones == 8 ? kMaxEncodedSize : leading_ones + 1;
         }
 
         constexpr std::size_t Size() const noexcept { return UintVar::Size(be_value_.front()); }
@@ -120,6 +109,7 @@ namespace quicr {
         constexpr auto operator<=>(const UintVar&) const noexcept = default;
 
       private:
-        std::array<std::uint8_t, sizeof(std::uint64_t)> be_value_;
+        static constexpr std::size_t kMaxEncodedSize = sizeof(std::uint64_t) + 1;
+        std::array<std::uint8_t, kMaxEncodedSize> be_value_;
     };
 }

--- a/include/quicr/track_name.h
+++ b/include/quicr/track_name.h
@@ -338,8 +338,7 @@ struct std::hash<quicr::FullTrackName>
         quicr::hash_combine(h, std::hash<quicr::TrackNamespace>{}(ftn.name_space));
         quicr::hash_combine(h, std::hash<std::span<const std::uint8_t>>{}(ftn.name));
 
-        // TODO(tievens): Evaluate; change hash to be more than 62 bits to avoid collisions
-        return (h << 2) >> 2;
+        return h;
     }
 };
 
@@ -350,7 +349,7 @@ namespace quicr {
         TrackNamespaceHash track_namespace_hash = 0; // 64bit hash of namespace
         TrackNameHash track_name_hash = 0;           // 64bit hash of name
 
-        uint64_t track_fullname_hash = 0; // 62bit of namespace+name
+        uint64_t track_fullname_hash = 0; // 64bit hash of namespace+name
 
         TrackHash(const uint64_t name_space, const uint64_t name) noexcept
           : track_namespace_hash{ name_space }
@@ -358,9 +357,6 @@ namespace quicr {
         {
             hash_combine(track_fullname_hash, track_namespace_hash);
             hash_combine(track_fullname_hash, track_name_hash);
-
-            // TODO(tievens): Evaluate; change hash to be more than 62 bits to avoid collisions
-            track_fullname_hash = (track_fullname_hash << 2) >> 2;
         }
 
         TrackHash(const FullTrackName& ftn) noexcept

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -897,7 +897,6 @@ namespace quicr {
         track_handler->connection_handle_ = conn_id;
 
         // Track hash is the track alias for now.
-        // TODO(tievens): Evaluate; change hash to be more than 62 bits to avoid collisions
         auto th = TrackHash(tfn);
 
         auto proposed_track_alias = track_handler->GetTrackAlias();

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -7,6 +7,7 @@
 #include <any>
 #include <doctest/doctest.h>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <string>
 #include <sys/socket.h>
@@ -371,13 +372,15 @@ TEST_CASE("uint16_t encode/decode")
 TEST_CASE("KeyValuePair even-type round-trip preserves values")
 {
     const std::vector<std::uint64_t> test_values = {
-        0,      1,
-        63, // Max 1-byte varint
-        64, // Min 2-byte varint
-        127,    128, 255,
-        16383, // Max 2-byte varint
-        16384, // Min 4-byte varint
-        100000,
+        0,       1,
+        127, // Max 1-byte varint
+        128, // Min 2-byte varint
+        255,
+        16383,   // Max 2-byte varint
+        16384,   // Min 3-byte varint
+        2097151, // Max 3-byte varint
+        2097152, // Min 4-byte varint
+        100000,  std::numeric_limits<std::uint64_t>::max(),
     };
 
     for (const auto value : test_values) {
@@ -409,13 +412,15 @@ TEST_CASE("KeyValuePair even-type round-trip preserves values")
 TEST_CASE("TrackExtensions even-type round-trip preserves values")
 {
     const std::vector<std::uint64_t> test_values = {
-        0,      1,
-        63, // Max 1-byte varint
-        64, // Min 2-byte varint
-        127,    128, 255,
-        16383, // Max 2-byte varint
-        16384, // Min 4-byte varint
-        100000,
+        0,       1,
+        127, // Max 1-byte varint
+        128, // Min 2-byte varint
+        255,
+        16383,   // Max 2-byte varint
+        16384,   // Min 3-byte varint
+        2097151, // Max 3-byte varint
+        2097152, // Min 4-byte varint
+        100000,  std::numeric_limits<std::uint64_t>::max(),
     };
 
     for (const auto value : test_values) {

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -654,6 +654,12 @@ TEST_CASE("Fetch Stream Message encode/decode")
 
 TEST_CASE("Key Value Pair size")
 {
+    const auto serialized_size = [](const KeyValuePair<std::uint64_t>& kvp) {
+        Bytes serialized;
+        SerializeKvp(serialized, kvp, std::uint64_t{ 0 });
+        return serialized.size();
+    };
+
     SUBCASE("ODD")
     {
         // Odd should be uintvar bytes of type + uintvar bytes of value's length + n value bytes.
@@ -665,6 +671,7 @@ TEST_CASE("Key Value Pair size")
         const std::size_t expected_size = kvp_type.size() + UintVar(kvp.value.size()).size() + kvp.value.size();
         REQUIRE_EQ(expected_size, 5); // 1 byte for type, 1 byte for length, 3 bytes for value.
         CHECK_EQ(kvp.Size(0), expected_size);
+        CHECK_EQ(kvp.Size(0), serialized_size(kvp));
     }
 
     SUBCASE("1 Byte Value")
@@ -674,7 +681,7 @@ TEST_CASE("Key Value Pair size")
         const UintVar kvp_type = 2;
         kvp.type = kvp_type.Get();
         kvp.value = kUint1ByteValue;
-        CHECK_EQ(kvp.Size(0), 2); // 1 byte for type, 1 byte for value.
+        CHECK_EQ(kvp.Size(0), serialized_size(kvp));
     }
 
     SUBCASE("2 Byte Value")
@@ -684,7 +691,7 @@ TEST_CASE("Key Value Pair size")
         const UintVar kvp_type = 2;
         kvp.type = kvp_type.Get();
         kvp.value = kUint2ByteValue;
-        CHECK_EQ(kvp.Size(0), 3); // 1 byte for type, 2 bytes for value.
+        CHECK_EQ(kvp.Size(0), serialized_size(kvp));
     }
 
     SUBCASE("4 Byte Value")
@@ -694,7 +701,7 @@ TEST_CASE("Key Value Pair size")
         const UintVar kvp_type = 2;
         kvp.type = kvp_type.Get();
         kvp.value = kUint4ByteValue;
-        CHECK_EQ(kvp.Size(0), 5); // 1 byte for type, 4 bytes for value.
+        CHECK_EQ(kvp.Size(0), serialized_size(kvp));
     }
 
     SUBCASE("8 Byte Value")
@@ -704,7 +711,7 @@ TEST_CASE("Key Value Pair size")
         const UintVar kvp_type = 2;
         kvp.type = kvp_type.Get();
         kvp.value = kUint8ByteValue;
-        CHECK_EQ(kvp.Size(0), 9); // 1 byte for type, 8 bytes for value.
+        CHECK_EQ(kvp.Size(0), serialized_size(kvp));
     }
 }
 
@@ -833,7 +840,7 @@ TEST_CASE("Immutable Extensions not length prefixed")
 
     // First KVP: even type key, varint value.
     CHECK_EQ(buffer[idx++], even_type_key);
-    CHECK_EQ(buffer[idx++], 0x40); // Varint byte 1.
+    CHECK_EQ(buffer[idx++], 0x80); // Varint byte 1.
     CHECK_EQ(buffer[idx++], varint_value);
 
     // Second KVP: odd type key delta-encoded from even_type_key, byte array value.

--- a/test/uintvar.cpp
+++ b/test/uintvar.cpp
@@ -6,25 +6,52 @@
 #include "quicr/detail/uintvar.h"
 
 #include <limits>
+#include <vector>
 
 namespace var {
 
-    // integer values for valdiation tests
-    constexpr uint64_t kValue1Byte = 0x12;
-    constexpr uint64_t kValue2Byte = 0x1234;
-    constexpr uint64_t kValue4Byte = 0x123456;
-    constexpr uint64_t kValue8Byte = 0x123456789;
+    struct Vector
+    {
+        std::uint64_t value;
+        std::vector<std::uint8_t> bytes;
+    };
 
-    // Encoded values of the above for validation tests
-    const std::vector<uint8_t> kValue1ByteEncoded{ 0x12 };
-    const std::vector<uint8_t> kValue2ByteEncoded{ 0x52, 0x34 };
-    const std::vector<uint8_t> kValue4ByteEncoded{ 0x80, 0x12, 0x34, 0x56 };
-    const std::vector<uint8_t> kValue8ByteEncoded = { 0xC0, 0, 0, 0x1, 0x23, 0x45, 0x67, 0x89 };
+    const std::vector<Vector> kMinimalVectors = {
+        { 0x00, { 0x00 } },
+        { 0x7F, { 0x7F } },
+        { 0x80, { 0x80, 0x80 } },
+        { 0x3FFF, { 0xBF, 0xFF } },
+        { 0x4000, { 0xC0, 0x40, 0x00 } },
+        { 0x1FFFFF, { 0xDF, 0xFF, 0xFF } },
+        { 0x200000, { 0xE0, 0x20, 0x00, 0x00 } },
+        { 0xFFFFFFF, { 0xEF, 0xFF, 0xFF, 0xFF } },
+        { 0x10000000, { 0xF0, 0x10, 0x00, 0x00, 0x00 } },
+        { 0x7FFFFFFFF, { 0xF7, 0xFF, 0xFF, 0xFF, 0xFF } },
+        { 0x800000000, { 0xF8, 0x08, 0x00, 0x00, 0x00, 0x00 } },
+        { 0x3FFFFFFFFFF, { 0xFB, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
+        { 0x40000000000, { 0xFC, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00 } },
+        { 0x1FFFFFFFFFFFF, { 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
+        { 0x2000000000000, { 0xFE, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
+        { 0xFFFFFFFFFFFFFF, { 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
+        { 0x100000000000000, { 0xFF, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } },
+        { std::numeric_limits<std::uint64_t>::max(), { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
+    };
+
+    const std::vector<Vector> kSpecVectors = {
+        { 37, { 0x25 } },
+        { 37, { 0x80, 0x25 } },
+        { 15'293, { 0xBB, 0xBD } },
+        { 226'442'877, { 0xED, 0x7F, 0x3E, 0x7D } },
+        { 2'893'212'287'960, { 0xFA, 0xA1, 0xA0, 0xE4, 0x03, 0xD8 } },
+        { 151'288'809'941'952, { 0xFC, 0x89, 0x98, 0xAB, 0xC6, 0x6B, 0xC0 } },
+        { 70'423'237'261'249'041, { 0xFE, 0xFA, 0x31, 0x8F, 0xA8, 0xE3, 0xCA, 0x11 } },
+        { std::numeric_limits<std::uint64_t>::max(), { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF } },
+    };
 }
 
 TEST_CASE("Check UintVar")
 {
-    CHECK_EQ(sizeof(std::uint64_t), sizeof(quicr::UintVar));
+    CHECK_EQ(sizeof(std::uint64_t) + 1, sizeof(quicr::UintVar));
     CHECK(std::is_trivially_copy_constructible_v<quicr::UintVar>);
     CHECK(std::is_trivially_copy_assignable_v<quicr::UintVar>);
     CHECK(std::is_trivially_move_constructible_v<quicr::UintVar>);
@@ -33,54 +60,50 @@ TEST_CASE("Check UintVar")
 
 TEST_CASE("Encode/Decode UintVar Uint64")
 {
-    CHECK_EQ(var::kValue1Byte, uint64_t(quicr::UintVar(var::kValue1Byte)));
-    CHECK_EQ(var::kValue2Byte, uint64_t(quicr::UintVar(var::kValue2Byte)));
-    CHECK_EQ(var::kValue4Byte, uint64_t(quicr::UintVar(var::kValue4Byte)));
-    CHECK_EQ(var::kValue8Byte, uint64_t(quicr::UintVar(var::kValue8Byte)));
+    for (const auto& vector : var::kMinimalVectors) {
+        CAPTURE(vector.value);
+        CHECK_EQ(vector.value, uint64_t(quicr::UintVar(vector.value)));
+    }
 }
 
 TEST_CASE("Encode/Decode UintVar Bytes")
 {
-    CHECK_EQ(var::kValue1Byte, uint64_t(quicr::UintVar(std::span{ quicr::UintVar(var::kValue1Byte) })));
-    CHECK_EQ(var::kValue2Byte, uint64_t(quicr::UintVar(std::span{ quicr::UintVar(var::kValue2Byte) })));
-    CHECK_EQ(var::kValue4Byte, uint64_t(quicr::UintVar(std::span{ quicr::UintVar(var::kValue4Byte) })));
-    CHECK_EQ(var::kValue8Byte, uint64_t(quicr::UintVar(std::span{ quicr::UintVar(var::kValue8Byte) })));
+    for (const auto& vector : var::kMinimalVectors) {
+        CAPTURE(vector.value);
+        CHECK_EQ(vector.value, uint64_t(quicr::UintVar(std::span{ quicr::UintVar(vector.value) })));
+    }
 }
 
 TEST_CASE("Length of UintVar")
 {
-    CHECK_EQ(1, quicr::UintVar(var::kValue1Byte).Size());
-    CHECK_EQ(2, quicr::UintVar(var::kValue2Byte).Size());
-    CHECK_EQ(4, quicr::UintVar(var::kValue4Byte).Size());
-    CHECK_EQ(8, quicr::UintVar(var::kValue8Byte).Size());
-
-    CHECK_EQ(1, quicr::UintVar::Size(*quicr::UintVar(var::kValue1Byte).begin()));
-    CHECK_EQ(2, quicr::UintVar::Size(*quicr::UintVar(var::kValue2Byte).begin()));
-    CHECK_EQ(4, quicr::UintVar::Size(*quicr::UintVar(var::kValue4Byte).begin()));
-    CHECK_EQ(8, quicr::UintVar::Size(*quicr::UintVar(var::kValue8Byte).begin()));
+    for (const auto& [value, bytes] : var::kMinimalVectors) {
+        CAPTURE(value);
+        CHECK_EQ(bytes.size(), quicr::UintVar(value).Size());
+        CHECK_EQ(bytes.size(), quicr::UintVar::Size(bytes.front()));
+    }
 }
 
-TEST_CASE("Validate UintVar from Known UintVar Bytes")
+TEST_CASE("Validate UintVar from minimal bytes")
 {
-    const auto v_one_byte = quicr::UintVar(var::kValue1Byte);
-    const auto v_two_byte = quicr::UintVar(var::kValue2Byte);
-    const auto v_four_byte = quicr::UintVar(var::kValue4Byte);
-    const auto v_eight_byte = quicr::UintVar(var::kValue8Byte);
+    for (const auto& [value, bytes] : var::kMinimalVectors) {
+        CAPTURE(value);
+        CHECK_EQ(value, uint64_t(quicr::UintVar(bytes)));
 
-    CHECK_EQ(var::kValue1Byte, uint64_t(quicr::UintVar(var::kValue1ByteEncoded)));
-    CHECK_EQ(var::kValue2Byte, uint64_t(quicr::UintVar(var::kValue2ByteEncoded)));
-    CHECK_EQ(var::kValue4Byte, uint64_t(quicr::UintVar(var::kValue4ByteEncoded)));
-    CHECK_EQ(var::kValue8Byte, uint64_t(quicr::UintVar(var::kValue8ByteEncoded)));
+        const auto encoded = quicr::UintVar(value);
+        CHECK(std::vector<std::uint8_t>(encoded.begin(), encoded.end()) == bytes);
+    }
+}
 
-    CHECK(std::vector<uint8_t>(v_one_byte.begin(), v_one_byte.end()) == var::kValue1ByteEncoded);
-    CHECK(std::vector<uint8_t>(v_two_byte.begin(), v_two_byte.end()) == var::kValue2ByteEncoded);
-    CHECK(std::vector<uint8_t>(v_four_byte.begin(), v_four_byte.end()) == var::kValue4ByteEncoded);
-    CHECK(std::vector<uint8_t>(v_eight_byte.begin(), v_eight_byte.end()) == var::kValue8ByteEncoded);
+TEST_CASE("Validate UintVar from Draft 18 examples")
+{
+    for (const auto& [value, bytes] : var::kSpecVectors) {
+        CAPTURE(value);
+        CHECK_EQ(value, uint64_t(quicr::UintVar(bytes)));
+    }
 }
 
 TEST_CASE("UintVar Invalid Construction")
 {
-    CHECK_THROWS(quicr::UintVar(std::numeric_limits<uint64_t>::max()));
     CHECK_THROWS(quicr::UintVar(std::vector<uint8_t>{}));
     CHECK_THROWS(quicr::UintVar(std::vector<uint8_t>{ 0xFF, 0xFF }));
 }

--- a/test/uintvar.cpp
+++ b/test/uintvar.cpp
@@ -76,29 +76,29 @@ TEST_CASE("Encode/Decode UintVar Bytes")
 
 TEST_CASE("Length of UintVar")
 {
-    for (const auto& [value, bytes] : var::kMinimalVectors) {
-        CAPTURE(value);
-        CHECK_EQ(bytes.size(), quicr::UintVar(value).Size());
-        CHECK_EQ(bytes.size(), quicr::UintVar::Size(bytes.front()));
+    for (const auto& vector : var::kMinimalVectors) {
+        CAPTURE(vector.value);
+        CHECK_EQ(vector.bytes.size(), quicr::UintVar(vector.value).Size());
+        CHECK_EQ(vector.bytes.size(), quicr::UintVar::Size(vector.bytes.front()));
     }
 }
 
 TEST_CASE("Validate UintVar from minimal bytes")
 {
-    for (const auto& [value, bytes] : var::kMinimalVectors) {
-        CAPTURE(value);
-        CHECK_EQ(value, uint64_t(quicr::UintVar(bytes)));
+    for (const auto& vector : var::kMinimalVectors) {
+        CAPTURE(vector.value);
+        CHECK_EQ(vector.value, uint64_t(quicr::UintVar(vector.bytes)));
 
-        const auto encoded = quicr::UintVar(value);
-        CHECK(std::vector<std::uint8_t>(encoded.begin(), encoded.end()) == bytes);
+        const auto encoded = quicr::UintVar(vector.value);
+        CHECK(std::vector<std::uint8_t>(encoded.begin(), encoded.end()) == vector.bytes);
     }
 }
 
 TEST_CASE("Validate UintVar from Draft 18 examples")
 {
-    for (const auto& [value, bytes] : var::kSpecVectors) {
-        CAPTURE(value);
-        CHECK_EQ(value, uint64_t(quicr::UintVar(bytes)));
+    for (const auto& vector : var::kSpecVectors) {
+        CAPTURE(vector.value);
+        CHECK_EQ(vector.value, uint64_t(quicr::UintVar(vector.bytes)));
     }
 }
 


### PR DESCRIPTION
Adds draft 18 varint. Because we can now handle a full 64 bit varint, some things go away (like exceptions in the value ctor, hashes.

Benchmarks look to be either ~the same or better.

Added tests for the test vectors that are now in the draft.