### PR TITLE
draft-18: Control and Request Streams

### DIFF
--- a/include/quicr/detail/base_track_handler.h
+++ b/include/quicr/detail/base_track_handler.h
@@ -191,6 +191,18 @@ namespace quicr {
         std::optional<uint64_t> GetRequestId() const noexcept { return request_id_; }
 
         /**
+         * @brief Sets the data context Id
+         * @param data_ctx_id               Data context Id for control messages
+         */
+        void SetDataContextId(DataContextId data_ctx_id) { data_ctx_id_ = data_ctx_id; }
+
+        /**
+         * @brief Return the data context Id
+         * @return Data context id if set
+         */
+        std::optional<DataContextId> GetDataContextId() const noexcept { return data_ctx_id_; }
+
+        /**
          * @brief Get the full track name
          *
          * @details Gets the full track name
@@ -241,6 +253,11 @@ namespace quicr {
          *   or the next one that increments from last received ID.
          */
         std::optional<uint64_t> request_id_;
+
+        /**
+         * Data context ID (transport data context) that control messages are to be sent
+         */
+        std::optional<DataContextId> data_ctx_id_{ std::nullopt };
 
         std::weak_ptr<Transport> transport_;
     };

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -1197,9 +1197,7 @@ namespace quicr {
                              uint64_t expires,
                              const std::optional<messages::Location>& largest_location,
                              messages::GroupOrder publisher_default_group_order);
-        void SendUnsubscribe(ConnectionContext& conn_ctx,
-                             DataContextId data_ctx_id,
-                             messages::RequestID request_id);
+        void SendUnsubscribe(ConnectionContext& conn_ctx, DataContextId data_ctx_id, messages::RequestID request_id);
 
         /*===================================================================*/
         // Publish

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -1171,10 +1171,16 @@ namespace quicr {
         // Subscribe Namespace
         /*===================================================================*/
 
-        void SendSubscribeNamespace(ConnectionHandle conn_handle, std::shared_ptr<SubscribeNamespaceHandler> handler);
+        void SendSubscribeNamespace(ConnectionContext& conn_ctx,
+                                    DataContextId data_ctx_id,
+                                    messages::RequestID request_id,
+                                    const TrackNamespace& prefix,
+                                    const messages::Filter& filter,
+                                    messages::ControlMessageType type);
 
-        void SendUnsubscribeNamespace(ConnectionHandle conn_handle,
-                                      const std::shared_ptr<SubscribeNamespaceHandler>& handler);
+        void SendUnsubscribeNamespace(ConnectionContext& conn_ctx,
+                                      DataContextId data_ctx_id,
+                                      const TrackNamespace& prefix);
 
         /*===================================================================*/
         // Subscribe
@@ -1278,6 +1284,11 @@ namespace quicr {
                                   SubscribeTrackHandler& handler,
                                   bool remove_handler = true,
                                   bool send_unsubscribe = true);
+
+        void RemoveSubscribeNamespace(ConnectionContext& conn_ctx,
+                                      SubscribeNamespaceHandler& handler,
+                                      bool remove_handler = true,
+                                      bool send_unsubscribe = true);
 
         void CloseRequestHandler(ConnectionContext& conn_ctx,
                                  ConnectionHandle connection_handle,

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -1010,8 +1010,9 @@ namespace quicr {
             }
 
             ConnectionHandle connection_handle{ 0 };
-            std::optional<uint64_t> ctrl_data_ctx_id;
-            std::optional<uint64_t> ctrl_stream_id;
+            std::optional<uint64_t> tx_ctrl_data_ctx_id;
+            std::optional<uint64_t> tx_ctrl_stream_id;
+            std::optional<uint64_t> rx_ctrl_stream_id;
 
             bool setup_complete{ false }; ///< True if both client and server setup messages have completed
             bool closed{ false };

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -1038,6 +1038,7 @@ namespace quicr {
                 FullTrackName track_full_name;
                 TrackHash track_hash{ 0, 0 };
                 std::optional<messages::Location> largest_location{ std::nullopt };
+                DataContextId data_ctx_id{ 0 };
             };
 
             std::map<messages::RequestID, SubscribeContext> recv_req_id;
@@ -1133,10 +1134,12 @@ namespace quicr {
         /*===================================================================*/
 
         void SendRequestOk(ConnectionContext& conn_ctx,
+                           DataContextId data_ctx_id,
                            messages::RequestID request_id,
                            std::optional<messages::Location> largest_location = std::nullopt);
 
         void SendRequestUpdate(const ConnectionContext& conn_ctx,
+                               DataContextId data_ctx_id,
                                messages::RequestID request_id,
                                messages::RequestID existing_request_id,
                                TrackHash th,
@@ -1145,6 +1148,7 @@ namespace quicr {
                                bool forward);
 
         void SendRequestError(ConnectionContext& conn_ctx,
+                              DataContextId data_ctx_id,
                               messages::RequestID request_id,
                               messages::ErrorCode error,
                               std::chrono::milliseconds retry_interval,
@@ -1155,10 +1159,13 @@ namespace quicr {
         /*===================================================================*/
 
         void SendPublishNamespace(ConnectionContext& conn_ctx,
+                                  DataContextId data_ctx_id,
                                   messages::RequestID request_id,
                                   const TrackNamespace& track_namespace);
 
-        void SendPublishNamespaceDone(ConnectionContext& conn_ctx, messages::RequestID request_id);
+        void SendPublishNamespaceDone(ConnectionContext& conn_ctx,
+                                      DataContextId data_ctx_id,
+                                      messages::RequestID request_id);
 
         /*===================================================================*/
         // Subscribe Namespace
@@ -1174,6 +1181,7 @@ namespace quicr {
         /*===================================================================*/
 
         void SendSubscribe(ConnectionContext& conn_ctx,
+                           DataContextId data_ctx_id,
                            messages::RequestID request_id,
                            const FullTrackName& tfn,
                            TrackHash th,
@@ -1183,18 +1191,22 @@ namespace quicr {
                            std::optional<std::chrono::milliseconds> delivery_timeout);
 
         void SendSubscribeOk(ConnectionContext& conn_ctx,
+                             DataContextId data_ctx_id,
                              messages::RequestID request_id,
                              uint64_t track_alias,
                              uint64_t expires,
                              const std::optional<messages::Location>& largest_location,
                              messages::GroupOrder publisher_default_group_order);
-        void SendUnsubscribe(ConnectionContext& conn_ctx, messages::RequestID request_id);
+        void SendUnsubscribe(ConnectionContext& conn_ctx,
+                             DataContextId data_ctx_id,
+                             messages::RequestID request_id);
 
         /*===================================================================*/
         // Publish
         /*===================================================================*/
 
         void SendPublish(ConnectionContext& conn_ctx,
+                         DataContextId data_ctx_id,
                          messages::RequestID request_id,
                          const FullTrackName& tfn,
                          uint64_t track_alias,
@@ -1204,16 +1216,23 @@ namespace quicr {
                          bool support_new_group);
 
         void SendPublishDone(ConnectionContext& conn_ctx,
+                             DataContextId data_ctx_id,
                              messages::RequestID request_id,
                              messages::PublishDoneStatusCode status,
                              const std::string& reason);
 
         void SendPublishOk(ConnectionContext& conn_ctx,
+                           DataContextId data_ctx_id,
                            messages::RequestID request_id,
                            bool forward,
                            std::uint8_t priority,
                            std::optional<messages::GroupOrder> group_order,
                            const messages::Filter& filter);
+
+        std::optional<DataContextId> FindSubscribeNamespaceDataContext(const ConnectionContext& conn_ctx,
+                                                                       const TrackNamespace& track_namespace) const;
+
+        DataContextId ResponseDataContext(const ConnectionContext& conn_ctx, messages::RequestID request_id) const;
 
         /*===================================================================*/
         // Track Status

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -1278,7 +1278,20 @@ namespace quicr {
 
         void RemoveSubscribeTrack(ConnectionContext& conn_ctx,
                                   SubscribeTrackHandler& handler,
-                                  bool remove_handler = true);
+                                  bool remove_handler = true,
+                                  bool send_unsubscribe = true);
+
+        void CloseRequestHandler(ConnectionContext& conn_ctx,
+                                 ConnectionHandle connection_handle,
+                                 messages::RequestID request_id,
+                                 std::uint64_t stream_id,
+                                 StreamClosedFlag flag);
+
+        void ClosePublishTrackLocal(ConnectionContext& conn_ctx,
+                                    ConnectionHandle connection_handle,
+                                    PublishTrackHandler& handler,
+                                    std::uint64_t stream_id,
+                                    bool is_reset);
 
         std::shared_ptr<PublishTrackHandler> GetPubTrackHandler(ConnectionContext& conn_ctx, TrackHash& th);
 

--- a/include/quicr/subscribe_namespace_handler.h
+++ b/include/quicr/subscribe_namespace_handler.h
@@ -136,8 +136,6 @@ namespace quicr {
 
         std::optional<Error> error_{};
 
-        DataContextId data_ctx_id_{ 0 };
-
         friend class Transport;
     };
 }

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -188,16 +188,18 @@ namespace quicr {
     void SubscribeTrackHandler::Pause() noexcept
     {
         auto transport = GetTransport().lock();
-        if (!transport || status_ == Status::kPaused || status_ == Status::kNotConnected) {
+        if (!transport || status_ == Status::kPaused || status_ == Status::kNotConnected ||
+            !GetDataContextId().has_value()) {
             return;
         }
 
         status_ = Status::kPaused;
         auto& conn_ctx = transport->GetConnectionContext(GetConnectionId());
         transport->SendRequestUpdate(conn_ctx,
+                                     GetDataContextId().value(),
                                      conn_ctx.GetNextRequestId(),
                                      GetRequestId().value(),
-                                     GetFullTrackName(),
+                                     TrackHash(GetFullTrackName()),
                                      std::nullopt,
                                      GetPriority(),
                                      false);
@@ -206,7 +208,7 @@ namespace quicr {
     void SubscribeTrackHandler::Resume() noexcept
     {
         auto transport = GetTransport().lock();
-        if (!transport) {
+        if (!transport || !GetDataContextId().has_value()) {
             return;
         }
 
@@ -217,9 +219,10 @@ namespace quicr {
         status_ = Status::kOk;
         auto& conn_ctx = transport->GetConnectionContext(GetConnectionId());
         transport->SendRequestUpdate(conn_ctx,
+                                     GetDataContextId().value(),
                                      conn_ctx.GetNextRequestId(),
                                      GetRequestId().value(),
-                                     GetFullTrackName(),
+                                     TrackHash(GetFullTrackName()),
                                      std::nullopt,
                                      GetPriority(),
                                      true);
@@ -228,15 +231,16 @@ namespace quicr {
     void SubscribeTrackHandler::RequestNewGroup(uint64_t group_id) noexcept
     {
         auto transport = GetTransport().lock();
-        if (!transport || status_ != Status::kOk || !support_new_group_request_) {
+        if (!transport || status_ != Status::kOk || !support_new_group_request_ || !GetDataContextId().has_value()) {
             return;
         }
 
         auto& conn_ctx = transport->GetConnectionContext(GetConnectionId());
         transport->SendRequestUpdate(conn_ctx,
+                                     GetDataContextId().value(),
                                      conn_ctx.GetNextRequestId(),
                                      GetRequestId().value(),
-                                     GetFullTrackName(),
+                                     TrackHash(GetFullTrackName()),
                                      group_id,
                                      GetPriority(),
                                      true);

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1079,7 +1079,8 @@ namespace quicr {
 
     void Transport::RemoveSubscribeTrack(ConnectionContext& conn_ctx,
                                          SubscribeTrackHandler& handler,
-                                         bool remove_handler)
+                                         bool remove_handler,
+                                         bool send_unsubscribe)
     {
         auto handler_status = handler.GetStatus();
 
@@ -1090,7 +1091,7 @@ namespace quicr {
                 [[fallthrough]];
             case SubscribeTrackHandler::Status::kOk:
                 try {
-                    if (not handler.IsPublisherInitiated() && not conn_ctx.closed) {
+                    if (send_unsubscribe && not handler.IsPublisherInitiated() && not conn_ctx.closed) {
                         if (handler.GetDataContextId().has_value()) {
                             SendUnsubscribe(conn_ctx,
                                             handler.GetDataContextId().value(),
@@ -1119,6 +1120,113 @@ namespace quicr {
                 conn_ctx.sub_by_recv_track_alias.erase(handler.GetReceivedTrackAlias().value());
             }
         }
+    }
+
+    void Transport::ClosePublishTrackLocal(ConnectionContext& conn_ctx,
+                                           ConnectionHandle connection_handle,
+                                           PublishTrackHandler& handler,
+                                           std::uint64_t stream_id,
+                                           bool is_reset)
+    {
+        handler.StreamClosed(stream_id, is_reset);
+        handler.SetStatus(PublishTrackHandler::Status::kNotAnnounced);
+
+        const auto th = TrackHash(handler.GetFullTrackName());
+        conn_ctx.pub_tracks_by_track_alias.erase(th.track_fullname_hash);
+
+        if (handler.GetRequestId().has_value()) {
+            conn_ctx.recv_req_id.erase(*handler.GetRequestId());
+        }
+
+        if (auto pub_ns_it = conn_ctx.pub_tracks_by_name.find(th.track_namespace_hash);
+            pub_ns_it != conn_ctx.pub_tracks_by_name.end()) {
+            pub_ns_it->second.erase(th.track_name_hash);
+            if (pub_ns_it->second.empty()) {
+                conn_ctx.pub_tracks_by_name.erase(pub_ns_it);
+            }
+        }
+
+        if (handler.publish_data_ctx_id_ != 0) {
+            conn_ctx.pub_tracks_by_data_ctx_id.erase(handler.publish_data_ctx_id_);
+            quic_transport_->DeleteDataContext(connection_handle, handler.publish_data_ctx_id_);
+            handler.publish_data_ctx_id_ = 0;
+        }
+    }
+
+    void Transport::CloseRequestHandler(ConnectionContext& conn_ctx,
+                                        ConnectionHandle connection_handle,
+                                        messages::RequestID request_id,
+                                        std::uint64_t stream_id,
+                                        StreamClosedFlag flag)
+    {
+        const auto handler_it = conn_ctx.request_handlers.find(request_id);
+        if (handler_it == conn_ctx.request_handlers.end()) {
+            SPDLOG_LOGGER_DEBUG(logger_,
+                                "Stream closed for unknown request_id conn_id: {} request_id: {}",
+                                connection_handle,
+                                request_id);
+            conn_ctx.recv_req_id.erase(request_id);
+            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            return;
+        }
+
+        const bool is_reset = flag == StreamClosedFlag::kReset;
+
+        SPDLOG_LOGGER_INFO(logger_,
+                           "Closing request handler conn_id: {} request_id: {} stream_id: {} reset: {}",
+                           connection_handle,
+                           request_id,
+                           stream_id,
+                           is_reset);
+
+        if (auto sub_handler = handler_it->second.Get<SubscribeTrackHandler>()) {
+            sub_handler->SetStatus(is_reset ? SubscribeTrackHandler::Status::kDoneByReset
+                                            : SubscribeTrackHandler::Status::kDoneByFin);
+            RemoveSubscribeTrack(conn_ctx, *sub_handler, false, false);
+            conn_ctx.request_handlers.erase(handler_it);
+            if (sub_handler->GetReceivedTrackAlias().has_value()) {
+                conn_ctx.sub_by_recv_track_alias.erase(sub_handler->GetReceivedTrackAlias().value());
+            }
+            conn_ctx.recv_req_id.erase(request_id);
+            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            return;
+        }
+
+        if (auto pub_handler = handler_it->second.Get<PublishTrackHandler>()) {
+            ClosePublishTrackLocal(conn_ctx, connection_handle, *pub_handler, stream_id, is_reset);
+            conn_ctx.request_handlers.erase(handler_it);
+            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            return;
+        }
+
+        if (auto ns_handler = handler_it->second.Get<SubscribeNamespaceHandler>()) {
+            ns_handler->SetStatus(SubscribeNamespaceHandler::Status::kNotSubscribed);
+            conn_ctx.request_handlers.erase(handler_it);
+            conn_ctx.recv_req_id.erase(request_id);
+            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            return;
+        }
+
+        if (auto pub_ns_handler = handler_it->second.Get<PublishNamespaceHandler>()) {
+            pub_ns_handler->SetStatus(PublishNamespaceHandler::Status::kNotPublished);
+            conn_ctx.request_handlers.erase(handler_it);
+            conn_ctx.recv_req_id.erase(request_id);
+            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            return;
+        }
+
+        if (auto fetch_handler = handler_it->second.Get<FetchTrackHandler>()) {
+            fetch_handler->SetStatus(is_reset ? FetchTrackHandler::Status::kDoneByReset
+                                              : FetchTrackHandler::Status::kDoneByFin);
+            conn_ctx.request_handlers.erase(handler_it);
+            conn_ctx.recv_req_id.erase(request_id);
+            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            return;
+        }
+
+        conn_ctx.request_handlers.erase(handler_it);
+        conn_ctx.recv_req_id.erase(request_id);
+        conn_ctx.ctrl_msg_buffer.erase(stream_id);
     }
 
     void Transport::UnpublishTrack(TransportConnId conn_id, const std::shared_ptr<PublishTrackHandler>& track_handler)
@@ -1833,24 +1941,36 @@ namespace quicr {
     }
 
     void Transport::OnStreamClosed(const ConnectionHandle& connection_handle,
-                                   [[maybe_unused]] std::uint64_t stream_id,
+                                   std::uint64_t stream_id,
                                    std::shared_ptr<StreamRxContext> rx_ctx,
                                    std::optional<uint64_t> request_id,
                                    StreamClosedFlag flag)
     {
         SPDLOG_LOGGER_DEBUG(logger_, "Stream {} closed", stream_id);
 
-        if (rx_ctx == nullptr) { // If not RX, it's for TX/publisher
-            if (request_id.has_value()) {
-                const auto& conn_ctx = connections_[connection_handle];
-                const auto& handler_it = conn_ctx.request_handlers.find(*request_id);
-                if (handler_it != conn_ctx.request_handlers.end()) {
+        if (request_id.has_value()) {
+            const bool is_bidir = (stream_id & 2) == 0;
+
+            try {
+                std::lock_guard<std::mutex> _(state_mutex_);
+                auto conn_it = connections_.find(connection_handle);
+                if (conn_it == connections_.end()) {
+                    return;
+                }
+
+                if (is_bidir) {
+                    CloseRequestHandler(conn_it->second, connection_handle, *request_id, stream_id, flag);
+                    return;
+                }
+
+                const auto handler_it = conn_it->second.request_handlers.find(*request_id);
+                if (handler_it != conn_it->second.request_handlers.end()) {
                     if (auto pub_handler = handler_it->second.Get<PublishTrackHandler>()) {
-                        SPDLOG_LOGGER_DEBUG(
-                          logger_, "Stream {} closed, calling publish handler stream close", stream_id);
                         pub_handler->StreamClosed(stream_id, flag == StreamClosedFlag::kReset);
                     }
                 }
+            } catch (const std::exception& e) {
+                SPDLOG_LOGGER_ERROR(logger_, "Caught exception on stream closed: {}", e.what());
             }
             return;
         }
@@ -1880,6 +2000,10 @@ namespace quicr {
                         break;
                 }
 
+                return;
+            }
+
+            if (rx_ctx == nullptr) {
                 return;
             }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -317,7 +317,7 @@ namespace quicr {
                                 DataContextId data_ctx_id,
                                 std::shared_ptr<const std::vector<uint8_t>> data)
     {
-        if (!conn_ctx.ctrl_data_ctx_id.has_value()) {
+        if (!conn_ctx.tx_ctrl_data_ctx_id.has_value()) {
             CloseConnection(conn_ctx.connection_handle,
                             messages::TerminationReason::kProtocolViolation,
                             "Control bidir data context not created");
@@ -370,7 +370,7 @@ namespace quicr {
 
         auto& conn_ctx = connections_.begin()->second;
 
-        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), ControlMessageType::kClientSetup, setup_parameters);
+        SendCtrlMsg(conn_ctx, conn_ctx.tx_ctrl_data_ctx_id.value(), ControlMessageType::kClientSetup, setup_parameters);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending ClientSetup (error={})", e.what());
         throw e;
@@ -382,7 +382,7 @@ namespace quicr {
 
         SPDLOG_LOGGER_DEBUG(logger_, "Sending SERVER_SETUP to conn_id: {}", conn_ctx.connection_handle);
 
-        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), ControlMessageType::kServerSetup, setup_parameters);
+        SendCtrlMsg(conn_ctx, conn_ctx.tx_ctrl_data_ctx_id.value(), ControlMessageType::kServerSetup, setup_parameters);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending ServerSetup (error={})", e.what());
         throw e;
@@ -509,7 +509,7 @@ namespace quicr {
           logger_, "Sending TRACK_STATUS to conn_id: {} request_id: {}", conn_ctx.connection_handle, request_id);
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    conn_ctx.tx_ctrl_data_ctx_id.value(),
                     ControlMessageType::kTrackStatus,
                     UintVar(request_id),
                     tfn.name_space,
@@ -850,7 +850,7 @@ namespace quicr {
                         .AddOptional(ParameterType::kGroupOrder, group_order);
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    conn_ctx.tx_ctrl_data_ctx_id.value(),
                     ControlMessageType::kFetch,
                     UintVar(request_id),
                     messages::FetchType::kStandalone,
@@ -882,7 +882,7 @@ namespace quicr {
                         .AddOptional(ParameterType::kGroupOrder, group_order);
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    conn_ctx.tx_ctrl_data_ctx_id.value(),
                     ControlMessageType::kFetch,
                     UintVar(request_id),
                     absolute ? FetchType::kAbsoluteJoiningFetch : FetchType::kRelativeJoiningFetch,
@@ -896,7 +896,8 @@ namespace quicr {
 
     void Transport::SendFetchCancel(ConnectionContext& conn_ctx, uint64_t request_id)
     try {
-        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), ControlMessageType::kFetchCancel, UintVar(request_id));
+        SendCtrlMsg(
+          conn_ctx, conn_ctx.tx_ctrl_data_ctx_id.value(), ControlMessageType::kFetchCancel, UintVar(request_id));
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending FetchCancel (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -919,7 +920,7 @@ namespace quicr {
                             .Add(ExtensionType::kDynamicGroups, true);
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    conn_ctx.tx_ctrl_data_ctx_id.value(),
                     ControlMessageType::kFetchOk,
                     UintVar(request_id),
                     end_of_track,
@@ -1669,9 +1670,9 @@ namespace quicr {
                     SPDLOG_LOGGER_INFO(logger_,
                                        "Connection established, creating bi-dir stream and sending CLIENT_SETUP");
 
-                    conn_ctx.ctrl_data_ctx_id = quic_transport_->CreateDataContext(conn_id, true, 0, true);
-                    conn_ctx.ctrl_stream_id =
-                      quic_transport_->CreateStream(conn_id, conn_ctx.ctrl_data_ctx_id.value(), 0);
+                    conn_ctx.tx_ctrl_data_ctx_id = quic_transport_->CreateDataContext(conn_id, true, 0, false);
+                    conn_ctx.tx_ctrl_stream_id =
+                      quic_transport_->CreateStream(conn_id, conn_ctx.tx_ctrl_data_ctx_id.value(), 0);
 
                     SendClientSetup();
 
@@ -1748,6 +1749,11 @@ namespace quicr {
         conn_ctx->second.next_request_id = 1; // Server is odd, starting at 1
 
         conn_ctx->second.connection_handle = conn_id;
+
+        conn_ctx->second.tx_ctrl_data_ctx_id = quic_transport_->CreateDataContext(conn_id, true, 0, false);
+        conn_ctx->second.tx_ctrl_stream_id =
+          quic_transport_->CreateStream(conn_id, conn_ctx->second.tx_ctrl_data_ctx_id.value(), 0);
+
         NewConnectionAccepted(conn_id, { remote.host_or_ip, remote.port });
     }
 
@@ -1779,11 +1785,49 @@ namespace quicr {
             }
 
             auto& data = *data_opt.value();
+            auto cursor_it = data.begin();
+            uint64_t msg_type{ 0 };
+            bool is_controL_stream = is_bidir || conn_ctx.rx_ctrl_stream_id.value_or(0) == stream_id;
+
+            // Get message type if new stream
+            if (rx_ctx->is_new) {
+                auto type_sz = UintVar::Size(data.front());
+                if (data.size() < type_sz) {
+                    SPDLOG_LOGGER_WARN(logger_,
+                                       "New stream {} bidir: {} does not have enough bytes to process start of stream "
+                                       "header len: {} < {}",
+                                       stream_id,
+                                       is_bidir,
+                                       data.size(),
+                                       type_sz);
+                    i = kReadLoopMaxPerStream;
+                    continue; // Not enough bytes to process control message. Try again once more.
+                }
+
+                SPDLOG_LOGGER_DEBUG(logger_,
+                                    "New stream conn_id: {} stream_id: {} bidir: {} data size: {}",
+                                    conn_id,
+                                    stream_id,
+                                    is_bidir,
+                                    data.size());
+
+                msg_type = uint64_t(quicr::UintVar({ data.begin(), data.begin() + type_sz }));
+                cursor_it = std::next(data.begin(), type_sz);
+
+                if (static_cast<ControlMessageType>(msg_type) == ControlMessageType::kClientSetup ||
+                    static_cast<ControlMessageType>(msg_type) == ControlMessageType::kServerSetup) {
+                    is_controL_stream = true;
+
+                    if (!is_bidir) {
+                        conn_ctx.rx_ctrl_stream_id = stream_id;
+                    }
+                }
+            }
 
             // CONTROL STREAM
-            if (is_bidir) {
+            if (is_controL_stream) {
                 auto& ctrl_msg_buffer = conn_ctx.ctrl_msg_buffer[stream_id];
-                ctrl_msg_buffer.data.insert(ctrl_msg_buffer.data.end(), data.begin(), data.end());
+                ctrl_msg_buffer.data.insert(ctrl_msg_buffer.data.end(), cursor_it, data.end());
 
                 rx_ctx->data_queue.PopFront();
                 SPDLOG_LOGGER_DEBUG(logger_,
@@ -1792,36 +1836,8 @@ namespace quicr {
                                     stream_id,
                                     ctrl_msg_buffer.data.size());
 
-                // Set the default/primary control stream and data context id
-                if (not conn_ctx.ctrl_data_ctx_id) {
-                    if (not data_ctx_id) {
-                        CloseConnection(conn_id,
-                                        messages::TerminationReason::kInternalError,
-                                        "Received bidir is missing data context");
-                        return;
-                    }
-
-                    conn_ctx.ctrl_data_ctx_id = data_ctx_id;
-
-                    if (!conn_ctx.ctrl_stream_id.has_value()) { // First bidir is the primary control stream
-                        conn_ctx.ctrl_stream_id = stream_id;
-                    }
-                }
-
                 while (ctrl_msg_buffer.data.size() > 0) {
                     if (not ctrl_msg_buffer.msg_type.has_value()) {
-                        // Decode message type
-                        auto uv_sz = UintVar::Size(ctrl_msg_buffer.data.front());
-                        if (ctrl_msg_buffer.data.size() < uv_sz) {
-                            i = kReadLoopMaxPerStream - 4;
-                            break; // Not enough bytes to process control message. Try again once more.
-                        }
-
-                        auto msg_type = uint64_t(
-                          quicr::UintVar({ ctrl_msg_buffer.data.begin(), ctrl_msg_buffer.data.begin() + uv_sz }));
-
-                        ctrl_msg_buffer.data.erase(ctrl_msg_buffer.data.begin(), ctrl_msg_buffer.data.begin() + uv_sz);
-
                         ctrl_msg_buffer.msg_type = static_cast<ControlMessageType>(msg_type);
                     }
 
@@ -1842,7 +1858,7 @@ namespace quicr {
                     }
 
                     if (ProcessCtrlMessage(conn_ctx,
-                                           data_ctx_id.value(),
+                                           data_ctx_id.value_or(conn_ctx.tx_ctrl_data_ctx_id.value()),
                                            ctrl_msg_buffer.msg_type.value(),
                                            { ctrl_msg_buffer.data.begin() + sizeof(payload_len),
                                              ctrl_msg_buffer.data.begin() + sizeof(payload_len) + payload_len })) {
@@ -1867,24 +1883,6 @@ namespace quicr {
                  * Process data subgroup header - assume that the start of stream will always have enough bytes
                  * for track alias
                  */
-                auto type_sz = UintVar::Size(data.front());
-                if (data.size() < type_sz) {
-                    SPDLOG_LOGGER_WARN(
-                      logger_,
-                      "New stream {} does not have enough bytes to process start of stream header len: {} < {}",
-                      stream_id,
-                      data.size(),
-                      type_sz);
-                    i = kReadLoopMaxPerStream;
-                    continue; // Not enough bytes to process control message. Try again once more.
-                }
-
-                SPDLOG_LOGGER_DEBUG(
-                  logger_, "New stream conn_id: {} stream_id: {} data size: {}", conn_id, stream_id, data.size());
-
-                auto msg_type = uint64_t(quicr::UintVar({ data.begin(), data.begin() + type_sz }));
-                auto cursor_it = std::next(data.begin(), type_sz);
-
                 SPDLOG_LOGGER_TRACE(logger_, "Received stream message type: 0x{:02x} ({})", msg_type, msg_type);
 
                 bool parsed_header = false;
@@ -2009,7 +2007,7 @@ namespace quicr {
 
                 switch (flag) {
                     case StreamClosedFlag::kFin:
-                        if (conn_ctx.ctrl_stream_id.has_value() && conn_ctx.ctrl_stream_id == stream_id) {
+                        if (conn_ctx.tx_ctrl_stream_id.has_value() && conn_ctx.tx_ctrl_stream_id == stream_id) {
                             CloseConnection(
                               connection_handle, TerminationReason::kProtocolViolation, "Primary control stream FIN");
                         } else {
@@ -2018,7 +2016,7 @@ namespace quicr {
 
                         break;
                     case StreamClosedFlag::kReset:
-                        if (conn_ctx.ctrl_stream_id.has_value() && conn_ctx.ctrl_stream_id == stream_id) {
+                        if (conn_ctx.tx_ctrl_stream_id.has_value() && conn_ctx.tx_ctrl_stream_id == stream_id) {
                             CloseConnection(
                               connection_handle, TerminationReason::kProtocolViolation, "Primary control stream RESET");
                         } else {
@@ -2720,7 +2718,7 @@ namespace quicr {
             return recv_it->second.data_ctx_id;
         }
 
-        return conn_ctx.ctrl_data_ctx_id.value();
+        return conn_ctx.tx_ctrl_data_ctx_id.value();
     }
 
     // -- Client Callbacks --

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -278,11 +278,15 @@ namespace quicr {
 
         switch (subscribe_response.reason_code) {
             case RequestResponse::ReasonCode::kOk: {
-                SendRequestOk(conn_it->second, request_id, subscribe_response.largest_location);
+                SendRequestOk(conn_it->second,
+                              ResponseDataContext(conn_it->second, request_id),
+                              request_id,
+                              subscribe_response.largest_location);
                 break;
             }
             case RequestResponse::ReasonCode::kDoesNotExist:
                 SendRequestError(conn_it->second,
+                                 ResponseDataContext(conn_it->second, request_id),
                                  request_id,
                                  ErrorCode::kDoesNotExist,
                                  0ms, // TODO: Figure out retry interval
@@ -291,6 +295,7 @@ namespace quicr {
                 break;
             case RequestResponse::ReasonCode::kUnauthorized:
                 SendRequestError(conn_it->second,
+                                 ResponseDataContext(conn_it->second, request_id),
                                  request_id,
                                  ErrorCode::kUnauthorized,
                                  0ms, // TODO: Figure out retry interval
@@ -298,7 +303,12 @@ namespace quicr {
                                                                              : "Unauthorized");
                 break;
             default:
-                SendRequestError(conn_it->second, request_id, ErrorCode::kInternalError, 0ms, "Internal error");
+                SendRequestError(conn_it->second,
+                                 ResponseDataContext(conn_it->second, request_id),
+                                 request_id,
+                                 ErrorCode::kInternalError,
+                                 0ms,
+                                 "Internal error");
                 break;
         }
     }
@@ -379,6 +389,7 @@ namespace quicr {
     }
 
     void Transport::SendRequestOk(ConnectionContext& conn_ctx,
+                                  DataContextId data_ctx_id,
                                   messages::RequestID request_id,
                                   std::optional<Location> largest_location)
     try {
@@ -387,14 +398,14 @@ namespace quicr {
         SPDLOG_LOGGER_DEBUG(
           logger_, "Sending REQUEST_OK to conn_id: {} request_id: {}", conn_ctx.connection_handle, request_id);
 
-        SendCtrlMsg(
-          conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), ControlMessageType::kRequestOk, UintVar(request_id), params);
+        SendCtrlMsg(conn_ctx, data_ctx_id, ControlMessageType::kRequestOk, UintVar(request_id), params);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending REQUEST_OK (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
     void Transport::SendRequestUpdate(const ConnectionContext& conn_ctx,
+                                      DataContextId data_ctx_id,
                                       messages::RequestID request_id,
                                       messages::RequestID existing_request_id,
                                       quicr::TrackHash th,
@@ -420,7 +431,7 @@ namespace quicr {
           end_group_id.has_value());
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    data_ctx_id,
                     ControlMessageType::kRequestUpdate,
                     UintVar(request_id),
                     UintVar(existing_request_id),
@@ -431,6 +442,7 @@ namespace quicr {
     }
 
     void Transport::SendRequestError(ConnectionContext& conn_ctx,
+                                     DataContextId data_ctx_id,
                                      uint64_t request_id,
                                      ErrorCode error,
                                      std::chrono::milliseconds retry_interval,
@@ -444,7 +456,7 @@ namespace quicr {
                             reason);
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    data_ctx_id,
                     ControlMessageType::kRequestError,
                     UintVar(request_id),
                     error,
@@ -456,6 +468,7 @@ namespace quicr {
     }
 
     void Transport::SendPublishNamespace(ConnectionContext& conn_ctx,
+                                         DataContextId data_ctx_id,
                                          RequestID request_id,
                                          const TrackNamespace& track_namespace)
     try {
@@ -466,7 +479,7 @@ namespace quicr {
                             TrackHash({ track_namespace, {} }).track_namespace_hash);
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    data_ctx_id,
                     ControlMessageType::kPublishNamespace,
                     UintVar(request_id),
                     track_namespace,
@@ -476,12 +489,13 @@ namespace quicr {
         // TODO: add error handling in libquicr in calling function
     }
 
-    void Transport::SendPublishNamespaceDone(ConnectionContext& conn_ctx, messages::RequestID request_id)
+    void Transport::SendPublishNamespaceDone(ConnectionContext& conn_ctx,
+                                             DataContextId data_ctx_id,
+                                             messages::RequestID request_id)
     try {
         SPDLOG_LOGGER_DEBUG(logger_, "Sending PUBLISH_NAMESPACE_DONE to conn_id: {}", conn_ctx.connection_handle);
 
-        SendCtrlMsg(
-          conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), ControlMessageType::kPublishNamespaceDone, UintVar(request_id));
+        SendCtrlMsg(conn_ctx, data_ctx_id, ControlMessageType::kPublishNamespaceDone, UintVar(request_id));
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending PUBLISH_NAMESPACE_DONE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -506,6 +520,7 @@ namespace quicr {
     }
 
     void Transport::SendSubscribe(ConnectionContext& conn_ctx,
+                                  DataContextId data_ctx_id,
                                   uint64_t request_id,
                                   const FullTrackName& tfn,
                                   TrackHash th, // TODO: This is only for a debug message, should be removed
@@ -541,7 +556,7 @@ namespace quicr {
                             th.track_name_hash);
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    data_ctx_id,
                     ControlMessageType::kSubscribe,
                     UintVar(request_id),
                     tfn.name_space,
@@ -553,6 +568,7 @@ namespace quicr {
     }
 
     void Transport::SendPublish(ConnectionContext& conn_ctx,
+                                DataContextId data_ctx_id,
                                 messages::RequestID request_id,
                                 const FullTrackName& tfn,
                                 uint64_t track_alias,
@@ -586,7 +602,7 @@ namespace quicr {
                             track_alias);
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    data_ctx_id,
                     ControlMessageType::kPublish,
                     UintVar(request_id),
                     tfn.name_space,
@@ -600,6 +616,7 @@ namespace quicr {
     }
 
     void Transport::SendPublishOk(ConnectionContext& conn_ctx,
+                                  DataContextId data_ctx_id,
                                   messages::RequestID request_id,
                                   bool forward,
                                   std::uint8_t priority,
@@ -627,8 +644,7 @@ namespace quicr {
         SPDLOG_LOGGER_DEBUG(
           logger_, "Sending PUBLISH_OK to conn_id: {} request_id: {} ", conn_ctx.connection_handle, request_id);
 
-        SendCtrlMsg(
-          conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), ControlMessageType::kPublishOk, UintVar(request_id), params);
+        SendCtrlMsg(conn_ctx, data_ctx_id, ControlMessageType::kPublishOk, UintVar(request_id), params);
 
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Publish Ok (error={})", e.what());
@@ -636,6 +652,7 @@ namespace quicr {
     }
 
     void Transport::SendSubscribeOk(ConnectionContext& conn_ctx,
+                                    DataContextId data_ctx_id,
                                     uint64_t request_id,
                                     uint64_t track_alias,
                                     uint64_t expires,
@@ -657,7 +674,7 @@ namespace quicr {
           logger_, "Sending SUBSCRIBE OK to conn_id: {} request_id: {}", conn_ctx.connection_handle, request_id);
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    data_ctx_id,
                     ControlMessageType::kSubscribeOk,
                     UintVar(request_id),
                     UintVar(track_alias),
@@ -669,6 +686,7 @@ namespace quicr {
     }
 
     void Transport::SendPublishDone(ConnectionContext& conn_ctx,
+                                    DataContextId data_ctx_id,
                                     uint64_t request_id,
                                     messages::PublishDoneStatusCode status,
                                     const std::string& reason)
@@ -680,7 +698,7 @@ namespace quicr {
                             static_cast<uint64_t>(status));
 
         SendCtrlMsg(conn_ctx,
-                    conn_ctx.ctrl_data_ctx_id.value(),
+                    data_ctx_id,
                     ControlMessageType::kPublishDone,
                     UintVar(request_id),
                     status,
@@ -691,12 +709,14 @@ namespace quicr {
         // TODO: add error handling in libquicr in calling function
     }
 
-    void Transport::SendUnsubscribe(ConnectionContext& conn_ctx, uint64_t request_id)
+    void Transport::SendUnsubscribe(ConnectionContext& conn_ctx,
+                                      DataContextId data_ctx_id,
+                                      uint64_t request_id)
     try {
         SPDLOG_LOGGER_DEBUG(
           logger_, "Sending UNSUBSCRIBE to conn_id: {} request_id: {}", conn_ctx.connection_handle, request_id);
 
-        SendCtrlMsg(conn_ctx, conn_ctx.ctrl_data_ctx_id.value(), ControlMessageType::kUnsubscribe, UintVar(request_id));
+        SendCtrlMsg(conn_ctx, data_ctx_id, ControlMessageType::kUnsubscribe, UintVar(request_id));
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Unsubscribe (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -758,10 +778,16 @@ namespace quicr {
                                 handler->GetRequestId().value(),
                                 th.track_namespace_hash);
 
-            handler->data_ctx_id_ = quic_transport_->CreateDataContext(conn_handle, true, 0, true);
+            handler->SetDataContextId(quic_transport_->CreateDataContext(
+              conn_handle, true, 0, true, handler->GetRequestId()));
             quic_transport_->CreateStream(conn_handle, handler->GetDataContextId().value(), 0);
 
-            SendCtrlMsg(conn_it->second, handler->GetDataContextId().value(), type, UintVar(handler->GetRequestId().value()), prefix, params);
+            SendCtrlMsg(conn_it->second,
+                        handler->GetDataContextId().value(),
+                        type,
+                        UintVar(handler->GetRequestId().value()),
+                        prefix,
+                        params);
         } catch (const std::exception& e) {
             SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending {} (error={})", log_name, e.what());
             // TODO: add error handling in libquicr in calling function
@@ -789,7 +815,10 @@ namespace quicr {
                             conn_handle,
                             th.track_namespace_hash);
 
-        SendCtrlMsg(conn_it->second, handler->data_ctx_id_, ControlMessageType::kNamespaceDone, prefix);
+        SendCtrlMsg(conn_it->second,
+                    handler->GetDataContextId().value(),
+                    ControlMessageType::kNamespaceDone,
+                    prefix);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending UNSUBSCRIBE_NAMESPACE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -947,6 +976,11 @@ namespace quicr {
                 throw std::runtime_error("Missing request id for publisher initiated subscribe");
             }
 
+            const auto req_it = conn_it->second.recv_req_id.find(*track_handler->GetRequestId());
+            if (req_it != conn_it->second.recv_req_id.end() && req_it->second.data_ctx_id != 0) {
+                track_handler->SetDataContextId(req_it->second.data_ctx_id);
+            }
+
             conn_it->second.sub_by_recv_track_alias[*track_handler->GetReceivedTrackAlias()] = track_handler;
         }
 
@@ -961,7 +995,12 @@ namespace quicr {
         conn_it->second.request_handlers[*track_handler->GetRequestId()] = track_handler;
 
         if (!track_handler->IsPublisherInitiated()) {
+            track_handler->SetDataContextId(quic_transport_->CreateDataContext(
+              conn_id, true, 0, true, track_handler->GetRequestId()));
+            quic_transport_->CreateStream(conn_id, track_handler->GetDataContextId().value(), 0);
+
             SendSubscribe(conn_it->second,
+                          track_handler->GetDataContextId().value(),
                           *track_handler->GetRequestId(),
                           tfn,
                           th,
@@ -1023,7 +1062,13 @@ namespace quicr {
         }
 
         auto priority = track_handler->GetPriority();
+        if (!track_handler->GetDataContextId().has_value()) {
+            SPDLOG_LOGGER_ERROR(logger_, "Subscribe track update missing data context conn_id: {}", conn_id);
+            return;
+        }
+
         SendRequestUpdate(conn_it->second,
+                          track_handler->GetDataContextId().value(),
                           conn_it->second.GetNextRequestId(),
                           track_handler->GetRequestId().value(),
                           th,
@@ -1046,7 +1091,11 @@ namespace quicr {
             case SubscribeTrackHandler::Status::kOk:
                 try {
                     if (not handler.IsPublisherInitiated() && not conn_ctx.closed) {
-                        SendUnsubscribe(conn_ctx, handler.GetRequestId().value());
+                        if (handler.GetDataContextId().has_value()) {
+                            SendUnsubscribe(conn_ctx,
+                                            handler.GetDataContextId().value(),
+                                            handler.GetRequestId().value());
+                        }
                     }
                 } catch (const std::exception& e) {
                     SPDLOG_LOGGER_ERROR(logger_, "Failed to send unsubscribe: {}", e.what());
@@ -1107,7 +1156,8 @@ namespace quicr {
             if (pub_n_it != pub_ns_it->second.end()) {
                 // Send subscribe done if track has subscriber and is sending
                 if (pub_n_it->second->GetStatus() == PublishTrackHandler::Status::kOk &&
-                    pub_n_it->second->GetRequestId().has_value()) {
+                    pub_n_it->second->GetRequestId().has_value() &&
+                    pub_n_it->second->GetDataContextId().has_value()) {
                     SPDLOG_LOGGER_INFO(
                       logger_,
                       "Unpublish track namespace hash: {} track_name_hash: {} track_alias: {}, sending "
@@ -1116,6 +1166,7 @@ namespace quicr {
                       th.track_name_hash,
                       th.track_fullname_hash);
                     SendPublishDone(conn_it->second,
+                                    *pub_n_it->second->GetDataContextId(),
                                     *pub_n_it->second->GetRequestId(),
                                     PublishDoneStatusCode::kSubscribtionEnded,
                                     "Unpublish track");
@@ -1167,7 +1218,13 @@ namespace quicr {
         conn_it->second.recv_req_id[*track_handler->GetRequestId()] = { track_handler->GetFullTrackName(), th };
 
         track_handler->SetStatus(PublishTrackHandler::Status::kPendingPublishOk);
+
+        track_handler->SetDataContextId(quic_transport_->CreateDataContext(
+          conn_id, true, 0, true, track_handler->GetRequestId()));
+        quic_transport_->CreateStream(conn_id, track_handler->GetDataContextId().value(), 0);
+
         SendPublish(conn_it->second,
+                    track_handler->GetDataContextId().value(),
                     *track_handler->GetRequestId(),
                     tfn,
                     track_handler->GetTrackAlias().value(),
@@ -1224,9 +1281,16 @@ namespace quicr {
 
             ns_handler->SetStatus(PublishNamespaceHandler::Status::kPendingResponse);
 
+            ns_handler->SetDataContextId(quic_transport_->CreateDataContext(
+              conn_id, true, 0, true, ns_handler->GetRequestId()));
+            quic_transport_->CreateStream(conn_id, ns_handler->GetDataContextId().value(), 0);
+
             lock.lock();
 
-            SendPublishNamespace(conn_it->second, *ns_handler->GetRequestId(), ns_handler->GetPrefix());
+            SendPublishNamespace(conn_it->second,
+                                 ns_handler->GetDataContextId().value(),
+                                 *ns_handler->GetRequestId(),
+                                 ns_handler->GetPrefix());
             conn_it->second.request_handlers[*ns_handler->GetRequestId()] = ns_handler;
 
         } else {
@@ -1256,7 +1320,17 @@ namespace quicr {
             return;
         }
 
-        SendPublishNamespaceDone(conn_it->second, track_handler->GetRequestId().value());
+        if (!track_handler->GetDataContextId().has_value()) {
+            SPDLOG_LOGGER_ERROR(logger_,
+                                "PublishNamespaceDone missing data context conn_id: {} prefix_hash: {}",
+                                conn_id,
+                                prefix_hash);
+            return;
+        }
+
+        SendPublishNamespaceDone(conn_it->second,
+                                 track_handler->GetDataContextId().value(),
+                                 track_handler->GetRequestId().value());
         conn_it->second.request_handlers.erase(track_handler->GetRequestId().value());
     }
 
@@ -1294,6 +1368,7 @@ namespace quicr {
                 }
 
                 SendPublishOk(conn_it->second,
+                              ResponseDataContext(conn_it->second, request_id),
                               request_id,
                               attributes.forward,
                               attributes.priority,
@@ -1317,7 +1392,12 @@ namespace quicr {
                 break;
         }
 
-        SendRequestError(conn_it->second, request_id, error_code, 0ms, reason);
+        SendRequestError(conn_it->second,
+                         ResponseDataContext(conn_it->second, request_id),
+                         request_id,
+                         error_code,
+                         0ms,
+                         reason);
     }
 
     void Transport::StandaloneFetchReceived(
@@ -2175,6 +2255,7 @@ namespace quicr {
             switch (subscribe_response.reason_code) {
                 case RequestResponse::ReasonCode::kOk:
                     SendSubscribeOk(conn_it->second,
+                                    ResponseDataContext(conn_it->second, request_id),
                                     request_id,
                                     track_alias,
                                     kSubscribeExpires,
@@ -2182,8 +2263,12 @@ namespace quicr {
                                     subscribe_response.publisher_default_group_order);
                     break;
                 default:
-                    SendRequestError(
-                      conn_it->second, request_id, messages::ErrorCode::kInternalError, 0ms, "Internal error");
+                    SendRequestError(conn_it->second,
+                                     ResponseDataContext(conn_it->second, request_id),
+                                     request_id,
+                                     messages::ErrorCode::kInternalError,
+                                     0ms,
+                                     "Internal error");
                     break;
             }
             return;
@@ -2205,8 +2290,8 @@ namespace quicr {
                 req_it->second.largest_location = subscribe_response.largest_location;
 
                 if (!subscribe_response.is_publisher_initiated) {
-                    // Send the ok.
                     SendSubscribeOk(conn_it->second,
+                                    ResponseDataContext(conn_it->second, request_id),
                                     request_id,
                                     track_alias,
                                     kSubscribeExpires,
@@ -2217,8 +2302,12 @@ namespace quicr {
             }
             default:
                 if (!subscribe_response.is_publisher_initiated) {
-                    SendRequestError(
-                      conn_it->second, request_id, messages::ErrorCode::kInternalError, 0ms, "Internal error");
+                    SendRequestError(conn_it->second,
+                                     ResponseDataContext(conn_it->second, request_id),
+                                     request_id,
+                                     messages::ErrorCode::kInternalError,
+                                     0ms,
+                                     "Internal error");
                 }
                 break;
         }
@@ -2238,11 +2327,16 @@ namespace quicr {
         auto th = TrackHash({ prefix, {} });
 
         if (response.reason_code != SubscribeNamespaceResponse::ReasonCode::kOk) {
-            SendRequestError(conn_it->second, request_id, messages::ErrorCode::kInternalError, 0ms, "Internal error");
+            SendRequestError(conn_it->second,
+                             data_ctx_id,
+                             request_id,
+                             messages::ErrorCode::kInternalError,
+                             0ms,
+                             "Internal error");
             return;
         }
 
-        SendRequestOk(conn_it->second, request_id);
+        SendRequestOk(conn_it->second, data_ctx_id, request_id);
 
         // Fan out PUBLISH_NAMESPACE for matching namespaces.
         for (const auto& name_space : response.namespaces) {
@@ -2252,13 +2346,13 @@ namespace quicr {
                 continue;
             }
 
-            auto request_id = conn_it->second.GetNextRequestId();
-            SendPublishNamespace(conn_it->second, request_id, name_space);
+            auto pub_ns_request_id = conn_it->second.GetNextRequestId();
+            SendPublishNamespace(conn_it->second, data_ctx_id, pub_ns_request_id, name_space);
         }
     }
 
     void Transport::ResolveSubscribeTracks(ConnectionHandle connection_handle,
-                                           DataContextId,
+                                           DataContextId data_ctx_id,
                                            uint64_t request_id,
                                            const TrackNamespace& prefix,
                                            const SubscribeNamespaceResponse& response)
@@ -2269,11 +2363,16 @@ namespace quicr {
         }
 
         if (response.reason_code != SubscribeNamespaceResponse::ReasonCode::kOk) {
-            SendRequestError(conn_it->second, request_id, messages::ErrorCode::kInternalError, 0ms, "Internal error");
+            SendRequestError(conn_it->second,
+                             data_ctx_id,
+                             request_id,
+                             messages::ErrorCode::kInternalError,
+                             0ms,
+                             "Internal error");
             return;
         }
 
-        SendRequestOk(conn_it->second, request_id);
+        SendRequestOk(conn_it->second, data_ctx_id, request_id);
 
         // Fan out PUBLISH_NAMESPACE for matching namespaces.
         for (const auto& name_space : response.namespaces) {
@@ -2283,8 +2382,8 @@ namespace quicr {
                 continue;
             }
 
-            auto request_id = conn_it->second.GetNextRequestId();
-            SendPublishNamespace(conn_it->second, request_id, name_space);
+            auto pub_ns_request_id = conn_it->second.GetNextRequestId();
+            SendPublishNamespace(conn_it->second, data_ctx_id, pub_ns_request_id, name_space);
         }
     }
 
@@ -2318,7 +2417,10 @@ namespace quicr {
                 break;
         }
 
+        const auto data_ctx_id = ResponseDataContext(conn_it->second, request_id);
+
         SendRequestError(conn_it->second,
+                         data_ctx_id,
                          request_id,
                          error_code,
                          0ms,
@@ -2339,9 +2441,16 @@ namespace quicr {
                     continue;
                 }
 
+                const auto sub_data_ctx_id = FindSubscribeNamespaceDataContext(it->second, track_namespace);
+                if (!sub_data_ctx_id.has_value()) {
+                    SPDLOG_LOGGER_WARN(logger_,
+                                       "No subscribe namespace data context for fan-out conn_id: {}",
+                                       sub_conn_handle);
+                    continue;
+                }
+
                 auto next_request_id = it->second.GetNextRequestId();
-                SendPublishNamespace(it->second, next_request_id, track_namespace);
-                // it->second.tracks_by_request_id[request_id] = next_request_id;
+                SendPublishNamespace(it->second, *sub_data_ctx_id, next_request_id, track_namespace);
             }
         };
 
@@ -2357,7 +2466,14 @@ namespace quicr {
 
         switch (response.reason_code) {
             case PublishNamespaceResponse::ReasonCode::kOk: {
-                SendRequestOk(conn_it->second, request_id);
+                DataContextId response_data_ctx_id = ResponseDataContext(conn_it->second, request_id);
+                const auto pub_ns_it = conn_it->second.request_handlers.find(request_id);
+                if (pub_ns_it != conn_it->second.request_handlers.end() &&
+                    pub_ns_it->second.handler->GetDataContextId().has_value()) {
+                    response_data_ctx_id = *pub_ns_it->second.handler->GetDataContextId();
+                }
+
+                SendRequestOk(conn_it->second, response_data_ctx_id, request_id);
 
                 fanout_subscribe_namespace_requestors();
                 break;
@@ -2380,7 +2496,9 @@ namespace quicr {
 
             auto req_it = it->second.request_handlers.find(request_id);
             if (req_it != it->second.request_handlers.end()) {
-                SendPublishNamespaceDone(it->second, request_id);
+                if (const auto data_ctx_id = req_it->second.handler->GetDataContextId()) {
+                    SendPublishNamespaceDone(it->second, *data_ctx_id, request_id);
+                }
                 it->second.request_handlers.erase(req_it);
             }
         }
@@ -2399,7 +2517,13 @@ namespace quicr {
         auto track_it = conn_it->second.request_handlers.find(existing_request_id);
         if (track_it == conn_it->second.request_handlers.end()) {
             if (client_mode_) {
+                const auto recv_it = conn_it->second.recv_req_id.find(existing_request_id);
+                if (recv_it == conn_it->second.recv_req_id.end()) {
+                    return;
+                }
+
                 SendRequestError(conn_it->second,
+                                 recv_it->second.data_ctx_id,
                                  request_id,
                                  messages::ErrorCode::kDoesNotExist,
                                  0ms,
@@ -2413,7 +2537,48 @@ namespace quicr {
 
         track_it->second.handler->RequestUpdate(request_id, params);
 
-        SendRequestOk(conn_it->second, request_id);
+        if (!track_it->second.handler->GetDataContextId().has_value()) {
+            SPDLOG_LOGGER_WARN(logger_,
+                               "ResolveRequestUpdate missing handler data context conn_id: {} existing_id: {}",
+                               connection_handle,
+                               existing_request_id);
+            return;
+        }
+
+        SendRequestOk(conn_it->second, *track_it->second.handler->GetDataContextId(), request_id);
+    }
+
+    std::optional<DataContextId> Transport::FindSubscribeNamespaceDataContext(
+      const ConnectionContext& conn_ctx,
+      const TrackNamespace& track_namespace) const
+    {
+        for (const auto& [_, handler] : conn_ctx.request_handlers) {
+            if (auto h = handler.Get<SubscribeNamespaceHandler>()) {
+                if (!h->GetDataContextId().has_value()) {
+                    continue;
+                }
+
+                const auto match = h->GetPrefix().IsPrefixOf(track_namespace);
+                if (match == std::partial_ordering::unordered || match == std::partial_ordering::less) {
+                    continue;
+                }
+
+                return h->GetDataContextId();
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    DataContextId Transport::ResponseDataContext(const ConnectionContext& conn_ctx,
+                                                 messages::RequestID request_id) const
+    {
+        const auto recv_it = conn_ctx.recv_req_id.find(request_id);
+        if (recv_it != conn_ctx.recv_req_id.end() && recv_it->second.data_ctx_id != 0) {
+            return recv_it->second.data_ctx_id;
+        }
+
+        return conn_ctx.ctrl_data_ctx_id.value();
     }
 
     // -- Client Callbacks --
@@ -2550,11 +2715,17 @@ namespace quicr {
 
         track_handler->connection_handle_ = connection_handle;
 
+        const auto req_it = conn_it->second.recv_req_id.find(request_id);
+        if (req_it != conn_it->second.recv_req_id.end() && req_it->second.data_ctx_id != 0) {
+            track_handler->SetDataContextId(req_it->second.data_ctx_id);
+        }
+
         track_handler->publish_data_ctx_id_ =
           quic_transport_->CreateDataContext(connection_handle,
                                              track_handler->default_track_mode_ == TrackMode::kDatagram ? false : true,
                                              track_handler->default_priority_,
-                                             false);
+                                             false,
+                                             request_id);
 
         // Set this transport as the one for the publisher to use.
         track_handler->SetTransport(GetSharedPtr());
@@ -2612,8 +2783,9 @@ namespace quicr {
 
         quic_transport_->DeleteDataContext(connection_handle, track_handler->publish_data_ctx_id_);
 
-        if (send_publish_done) {
+        if (send_publish_done && track_handler->GetDataContextId().has_value()) {
             SendPublishDone(conn_it->second,
+                            *track_handler->GetDataContextId(),
                             track_handler->GetRequestId().value(),
                             messages::PublishDoneStatusCode::kSubscribtionEnded,
                             "No publishers");
@@ -2677,7 +2849,9 @@ namespace quicr {
 
                 auto tfn = FullTrackName{ track_namespace, track_name };
                 auto th = TrackHash(tfn);
-                conn_ctx.recv_req_id[request_id] = { .track_full_name = tfn, .track_hash = th };
+                conn_ctx.recv_req_id[request_id] = { .track_full_name = tfn,
+                                                     .track_hash = th,
+                                                     .data_ctx_id = data_ctx_id };
 
                 if (client_mode_) {
                     auto ptd = GetPubTrackHandler(conn_ctx, th);
@@ -2690,10 +2864,16 @@ namespace quicr {
                                            th.track_name_hash,
                                            request_id);
 
-                        SendRequestError(
-                          conn_ctx, request_id, messages::ErrorCode::kDoesNotExist, 0ms, "Published track not found");
+                        SendRequestError(conn_ctx,
+                                         data_ctx_id,
+                                         request_id,
+                                         messages::ErrorCode::kDoesNotExist,
+                                         0ms,
+                                         "Published track not found");
                         return true;
                     }
+
+                    ptd->SetDataContextId(data_ctx_id);
 
                     ResolveSubscribe(conn_ctx.connection_handle,
                                      request_id,
@@ -2860,6 +3040,10 @@ namespace quicr {
                 const auto track_namespace = messages::Message::ParseField<TrackNamespace>(msg_bytes);
                 [[maybe_unused]] const auto parameters = messages::Message::ParseField<messages::Parameters>(msg_bytes);
 
+                conn_ctx.recv_req_id[request_id] = { .track_full_name = { track_namespace, {} },
+                                                     .track_hash = TrackHash({ track_namespace, {} }),
+                                                     .data_ctx_id = data_ctx_id };
+
                 if (client_mode_) {
                     PublishNamespaceReceived(track_namespace, { .request_id = request_id });
                 } else {
@@ -2949,7 +3133,14 @@ namespace quicr {
                         continue;
                     }
 
-                    SendPublishNamespaceDone(conn_it->second, request_id);
+                    for (const auto& [_, handler] : conn_it->second.request_handlers) {
+                        if (auto h = handler.Get<SubscribeNamespaceHandler>()) {
+                            if (const auto ctx = h->GetDataContextId()) {
+                                SendPublishNamespaceDone(conn_it->second, *ctx, request_id);
+                                break;
+                            }
+                        }
+                    }
                 }
 
                 return true;
@@ -3189,6 +3380,7 @@ namespace quicr {
                         const auto subscribe_state = conn_ctx.recv_req_id.find(joining_request_id);
                         if (subscribe_state == conn_ctx.recv_req_id.end()) {
                             SendRequestError(conn_ctx,
+                                             data_ctx_id,
                                              request_id,
                                              messages::ErrorCode::kDoesNotExist,
                                              0ms,
@@ -3215,8 +3407,12 @@ namespace quicr {
                         return true;
                     }
                     default: {
-                        SendRequestError(
-                          conn_ctx, request_id, messages::ErrorCode::kNotSupported, 0ms, "Unknown fetch type");
+                        SendRequestError(conn_ctx,
+                                         data_ctx_id,
+                                         request_id,
+                                         messages::ErrorCode::kNotSupported,
+                                         0ms,
+                                         "Unknown fetch type");
                         return true;
                     }
                 }
@@ -3255,7 +3451,9 @@ namespace quicr {
 
                 auto tfn = FullTrackName{ track_namespace, track_name };
                 auto th = TrackHash(tfn);
-                conn_ctx.recv_req_id[request_id] = { .track_full_name = tfn, .track_hash = th };
+                conn_ctx.recv_req_id[request_id] = { .track_full_name = tfn,
+                                                     .track_hash = th,
+                                                     .data_ctx_id = data_ctx_id };
 
                 auto delivery_timeout = parameters.Get<std::uint64_t>(messages::ParameterType::kDeliveryTimeout);
                 auto expires = parameters.Get<std::uint64_t>(messages::ParameterType::kExpires);
@@ -3386,7 +3584,7 @@ namespace quicr {
                                        request_id);
 
                     SendRequestError(
-                      conn_ctx, request_id, messages::ErrorCode::kDoesNotExist, 0ms, "Subscription not found");
+                      conn_ctx, data_ctx_id, request_id, messages::ErrorCode::kDoesNotExist, 0ms, "Subscription not found");
                     return true;
                 }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -1787,7 +1787,7 @@ namespace quicr {
             auto& data = *data_opt.value();
             auto cursor_it = data.begin();
             uint64_t msg_type{ 0 };
-            bool is_controL_stream = is_bidir || conn_ctx.rx_ctrl_stream_id.value_or(0) == stream_id;
+            bool is_control_stream = is_bidir || conn_ctx.rx_ctrl_stream_id.value_or(0) == stream_id;
 
             // Get message type if new stream
             if (rx_ctx->is_new) {
@@ -1816,7 +1816,7 @@ namespace quicr {
 
                 if (static_cast<ControlMessageType>(msg_type) == ControlMessageType::kClientSetup ||
                     static_cast<ControlMessageType>(msg_type) == ControlMessageType::kServerSetup) {
-                    is_controL_stream = true;
+                    is_control_stream = true;
 
                     if (!is_bidir) {
                         conn_ctx.rx_ctrl_stream_id = stream_id;
@@ -1825,7 +1825,7 @@ namespace quicr {
             }
 
             // CONTROL STREAM
-            if (is_controL_stream) {
+            if (is_control_stream) {
                 auto& ctrl_msg_buffer = conn_ctx.ctrl_msg_buffer[stream_id];
                 ctrl_msg_buffer.data.insert(ctrl_msg_buffer.data.end(), cursor_it, data.end());
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -728,7 +728,7 @@ namespace quicr {
             }
 
             const auto& prefix = handler->GetPrefix();
-            const auto rid = conn_it->second.GetNextRequestId();
+            handler->SetRequestId(conn_it->second.GetNextRequestId());
 
             /* Available parameters:
              * - AUTHORIZATION TOKEN (0x03)
@@ -744,7 +744,9 @@ namespace quicr {
 
             [[maybe_unused]] auto th = TrackHash({ prefix, {} });
 
-            if (auto [_, is_new] = conn_it->second.request_handlers.try_emplace(rid, handler); !is_new) {
+            if (auto [_, is_new] =
+                  conn_it->second.request_handlers.try_emplace(handler->GetRequestId().value(), handler);
+                !is_new) {
                 SPDLOG_LOGGER_WARN(logger_, "Namespace already subscribed to (alias={})", th.track_fullname_hash);
                 return;
             }
@@ -753,13 +755,13 @@ namespace quicr {
                                 "Sending {} to conn_id: {} request_id: {} prefix_hash: {}",
                                 log_name,
                                 conn_it->second.connection_handle,
-                                rid,
+                                handler->GetRequestId().value(),
                                 th.track_namespace_hash);
 
             handler->data_ctx_id_ = quic_transport_->CreateDataContext(conn_handle, true, 0, true);
-            quic_transport_->CreateStream(conn_handle, handler->data_ctx_id_, 0);
+            quic_transport_->CreateStream(conn_handle, handler->GetDataContextId().value(), 0);
 
-            SendCtrlMsg(conn_it->second, handler->data_ctx_id_, type, UintVar(rid), prefix, params);
+            SendCtrlMsg(conn_it->second, handler->GetDataContextId().value(), type, UintVar(handler->GetRequestId().value()), prefix, params);
         } catch (const std::exception& e) {
             SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending {} (error={})", log_name, e.what());
             // TODO: add error handling in libquicr in calling function

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -555,13 +555,8 @@ namespace quicr {
                             th.track_namespace_hash,
                             th.track_name_hash);
 
-        SendCtrlMsg(conn_ctx,
-                    data_ctx_id,
-                    ControlMessageType::kSubscribe,
-                    UintVar(request_id),
-                    tfn.name_space,
-                    tfn.name,
-                    params);
+        SendCtrlMsg(
+          conn_ctx, data_ctx_id, ControlMessageType::kSubscribe, UintVar(request_id), tfn.name_space, tfn.name, params);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Subscribe (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -709,9 +704,7 @@ namespace quicr {
         // TODO: add error handling in libquicr in calling function
     }
 
-    void Transport::SendUnsubscribe(ConnectionContext& conn_ctx,
-                                      DataContextId data_ctx_id,
-                                      uint64_t request_id)
+    void Transport::SendUnsubscribe(ConnectionContext& conn_ctx, DataContextId data_ctx_id, uint64_t request_id)
     try {
         SPDLOG_LOGGER_DEBUG(
           logger_, "Sending UNSUBSCRIBE to conn_id: {} request_id: {}", conn_ctx.connection_handle, request_id);
@@ -778,8 +771,8 @@ namespace quicr {
                                 handler->GetRequestId().value(),
                                 th.track_namespace_hash);
 
-            handler->SetDataContextId(quic_transport_->CreateDataContext(
-              conn_handle, true, 0, true, handler->GetRequestId()));
+            handler->SetDataContextId(
+              quic_transport_->CreateDataContext(conn_handle, true, 0, true, handler->GetRequestId()));
             quic_transport_->CreateStream(conn_handle, handler->GetDataContextId().value(), 0);
 
             SendCtrlMsg(conn_it->second,
@@ -815,10 +808,7 @@ namespace quicr {
                             conn_handle,
                             th.track_namespace_hash);
 
-        SendCtrlMsg(conn_it->second,
-                    handler->GetDataContextId().value(),
-                    ControlMessageType::kNamespaceDone,
-                    prefix);
+        SendCtrlMsg(conn_it->second, handler->GetDataContextId().value(), ControlMessageType::kNamespaceDone, prefix);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending UNSUBSCRIBE_NAMESPACE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -995,8 +985,8 @@ namespace quicr {
         conn_it->second.request_handlers[*track_handler->GetRequestId()] = track_handler;
 
         if (!track_handler->IsPublisherInitiated()) {
-            track_handler->SetDataContextId(quic_transport_->CreateDataContext(
-              conn_id, true, 0, true, track_handler->GetRequestId()));
+            track_handler->SetDataContextId(
+              quic_transport_->CreateDataContext(conn_id, true, 0, true, track_handler->GetRequestId()));
             quic_transport_->CreateStream(conn_id, track_handler->GetDataContextId().value(), 0);
 
             SendSubscribe(conn_it->second,
@@ -1093,9 +1083,8 @@ namespace quicr {
                 try {
                     if (send_unsubscribe && not handler.IsPublisherInitiated() && not conn_ctx.closed) {
                         if (handler.GetDataContextId().has_value()) {
-                            SendUnsubscribe(conn_ctx,
-                                            handler.GetDataContextId().value(),
-                                            handler.GetRequestId().value());
+                            SendUnsubscribe(
+                              conn_ctx, handler.GetDataContextId().value(), handler.GetRequestId().value());
                         }
                     }
                 } catch (const std::exception& e) {
@@ -1264,8 +1253,7 @@ namespace quicr {
             if (pub_n_it != pub_ns_it->second.end()) {
                 // Send subscribe done if track has subscriber and is sending
                 if (pub_n_it->second->GetStatus() == PublishTrackHandler::Status::kOk &&
-                    pub_n_it->second->GetRequestId().has_value() &&
-                    pub_n_it->second->GetDataContextId().has_value()) {
+                    pub_n_it->second->GetRequestId().has_value() && pub_n_it->second->GetDataContextId().has_value()) {
                     SPDLOG_LOGGER_INFO(
                       logger_,
                       "Unpublish track namespace hash: {} track_name_hash: {} track_alias: {}, sending "
@@ -1327,8 +1315,8 @@ namespace quicr {
 
         track_handler->SetStatus(PublishTrackHandler::Status::kPendingPublishOk);
 
-        track_handler->SetDataContextId(quic_transport_->CreateDataContext(
-          conn_id, true, 0, true, track_handler->GetRequestId()));
+        track_handler->SetDataContextId(
+          quic_transport_->CreateDataContext(conn_id, true, 0, true, track_handler->GetRequestId()));
         quic_transport_->CreateStream(conn_id, track_handler->GetDataContextId().value(), 0);
 
         SendPublish(conn_it->second,
@@ -1389,8 +1377,8 @@ namespace quicr {
 
             ns_handler->SetStatus(PublishNamespaceHandler::Status::kPendingResponse);
 
-            ns_handler->SetDataContextId(quic_transport_->CreateDataContext(
-              conn_id, true, 0, true, ns_handler->GetRequestId()));
+            ns_handler->SetDataContextId(
+              quic_transport_->CreateDataContext(conn_id, true, 0, true, ns_handler->GetRequestId()));
             quic_transport_->CreateStream(conn_id, ns_handler->GetDataContextId().value(), 0);
 
             lock.lock();
@@ -1429,16 +1417,13 @@ namespace quicr {
         }
 
         if (!track_handler->GetDataContextId().has_value()) {
-            SPDLOG_LOGGER_ERROR(logger_,
-                                "PublishNamespaceDone missing data context conn_id: {} prefix_hash: {}",
-                                conn_id,
-                                prefix_hash);
+            SPDLOG_LOGGER_ERROR(
+              logger_, "PublishNamespaceDone missing data context conn_id: {} prefix_hash: {}", conn_id, prefix_hash);
             return;
         }
 
-        SendPublishNamespaceDone(conn_it->second,
-                                 track_handler->GetDataContextId().value(),
-                                 track_handler->GetRequestId().value());
+        SendPublishNamespaceDone(
+          conn_it->second, track_handler->GetDataContextId().value(), track_handler->GetRequestId().value());
         conn_it->second.request_handlers.erase(track_handler->GetRequestId().value());
     }
 
@@ -1500,12 +1485,8 @@ namespace quicr {
                 break;
         }
 
-        SendRequestError(conn_it->second,
-                         ResponseDataContext(conn_it->second, request_id),
-                         request_id,
-                         error_code,
-                         0ms,
-                         reason);
+        SendRequestError(
+          conn_it->second, ResponseDataContext(conn_it->second, request_id), request_id, error_code, 0ms, reason);
     }
 
     void Transport::StandaloneFetchReceived(
@@ -2451,12 +2432,8 @@ namespace quicr {
         auto th = TrackHash({ prefix, {} });
 
         if (response.reason_code != SubscribeNamespaceResponse::ReasonCode::kOk) {
-            SendRequestError(conn_it->second,
-                             data_ctx_id,
-                             request_id,
-                             messages::ErrorCode::kInternalError,
-                             0ms,
-                             "Internal error");
+            SendRequestError(
+              conn_it->second, data_ctx_id, request_id, messages::ErrorCode::kInternalError, 0ms, "Internal error");
             return;
         }
 
@@ -2487,12 +2464,8 @@ namespace quicr {
         }
 
         if (response.reason_code != SubscribeNamespaceResponse::ReasonCode::kOk) {
-            SendRequestError(conn_it->second,
-                             data_ctx_id,
-                             request_id,
-                             messages::ErrorCode::kInternalError,
-                             0ms,
-                             "Internal error");
+            SendRequestError(
+              conn_it->second, data_ctx_id, request_id, messages::ErrorCode::kInternalError, 0ms, "Internal error");
             return;
         }
 
@@ -2567,9 +2540,8 @@ namespace quicr {
 
                 const auto sub_data_ctx_id = FindSubscribeNamespaceDataContext(it->second, track_namespace);
                 if (!sub_data_ctx_id.has_value()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "No subscribe namespace data context for fan-out conn_id: {}",
-                                       sub_conn_handle);
+                    SPDLOG_LOGGER_WARN(
+                      logger_, "No subscribe namespace data context for fan-out conn_id: {}", sub_conn_handle);
                     continue;
                 }
 
@@ -3707,8 +3679,12 @@ namespace quicr {
                                        conn_ctx.connection_handle,
                                        request_id);
 
-                    SendRequestError(
-                      conn_ctx, data_ctx_id, request_id, messages::ErrorCode::kDoesNotExist, 0ms, "Subscription not found");
+                    SendRequestError(conn_ctx,
+                                     data_ctx_id,
+                                     request_id,
+                                     messages::ErrorCode::kDoesNotExist,
+                                     0ms,
+                                     "Subscription not found");
                     return true;
                 }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -715,115 +715,117 @@ namespace quicr {
         // TODO: add error handling in libquicr in calling function
     }
 
-    void Transport::SendSubscribeNamespace(ConnectionHandle conn_handle,
-                                           std::shared_ptr<SubscribeNamespaceHandler> handler)
-    {
-        // Namespace or tracks?
-        std::string log_name;
-        ControlMessageType type;
-        switch (handler->GetMode()) {
-            case SubscribeNamespaceHandler::Mode::kNamespaces:
-                log_name = "SUBSCRIBE_NAMESPACE";
-                type = ControlMessageType::kSubscribeNamespace;
-                break;
-            case SubscribeNamespaceHandler::Mode::kTracks:
-                log_name = "SUBSCRIBE_TRACKS";
-                type = ControlMessageType::kSubscribeTracks;
-                break;
-        }
-
-        try {
-            std::lock_guard<std::mutex> _(state_mutex_);
-            auto conn_it = connections_.find(conn_handle);
-            if (conn_it == connections_.end()) {
-                SPDLOG_LOGGER_ERROR(logger_, "Subscribe track conn_id: {} does not exist.", conn_handle);
-                return;
-            }
-
-            const auto& prefix = handler->GetPrefix();
-            handler->SetRequestId(conn_it->second.GetNextRequestId());
-
-            /* Available parameters:
-             * - AUTHORIZATION TOKEN (0x03)
-             * - FORWARD (0x10)
-             */
-            const auto& filter = handler->GetFilter();
-            Parameters params;
-            if (const auto filter_type = GetFilterParameterType(filter); filter_type != ParameterType::kInvalid) {
-                params.Add(filter_type, filter);
-            }
-
-            handler->SetTransport(GetSharedPtr());
-
-            [[maybe_unused]] auto th = TrackHash({ prefix, {} });
-
-            if (auto [_, is_new] =
-                  conn_it->second.request_handlers.try_emplace(handler->GetRequestId().value(), handler);
-                !is_new) {
-                SPDLOG_LOGGER_WARN(logger_, "Namespace already subscribed to (alias={})", th.track_fullname_hash);
-                return;
-            }
-
-            SPDLOG_LOGGER_DEBUG(logger_,
-                                "Sending {} to conn_id: {} request_id: {} prefix_hash: {}",
-                                log_name,
-                                conn_it->second.connection_handle,
-                                handler->GetRequestId().value(),
-                                th.track_namespace_hash);
-
-            handler->SetDataContextId(
-              quic_transport_->CreateDataContext(conn_handle, true, 0, true, handler->GetRequestId()));
-            quic_transport_->CreateStream(conn_handle, handler->GetDataContextId().value(), 0);
-
-            SendCtrlMsg(conn_it->second,
-                        handler->GetDataContextId().value(),
-                        type,
-                        UintVar(handler->GetRequestId().value()),
-                        prefix,
-                        params);
-        } catch (const std::exception& e) {
-            SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending {} (error={})", log_name, e.what());
-            // TODO: add error handling in libquicr in calling function
-        }
-    }
-
-    void Transport::SendUnsubscribeNamespace(ConnectionHandle conn_handle,
-                                             const std::shared_ptr<SubscribeNamespaceHandler>& handler)
+    void Transport::SendSubscribeNamespace(ConnectionContext& conn_ctx,
+                                           DataContextId data_ctx_id,
+                                           messages::RequestID request_id,
+                                           const TrackNamespace& prefix,
+                                           const messages::Filter& filter,
+                                           messages::ControlMessageType type)
     try {
-        std::lock_guard<std::mutex> _(state_mutex_);
-        auto conn_it = connections_.find(conn_handle);
-        if (conn_it == connections_.end()) {
-            SPDLOG_LOGGER_ERROR(logger_, "Subscribe track conn_id: {} does not exist.", conn_handle);
-            return;
+        Parameters params;
+        if (const auto filter_type = GetFilterParameterType(filter); filter_type != ParameterType::kInvalid) {
+            params.Add(filter_type, filter);
         }
 
-        conn_it->second.request_handlers.erase(handler->GetRequestId().value());
-
-        const auto& prefix = handler->GetPrefix();
+        const char* log_name =
+          type == ControlMessageType::kSubscribeNamespace ? "SUBSCRIBE_NAMESPACE" : "SUBSCRIBE_TRACKS";
 
         [[maybe_unused]] auto th = TrackHash({ prefix, {} });
 
         SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending UNSUBSCRIBE_NAMESPACE to conn_id: {} prefix_hash: {}",
-                            conn_handle,
+                            "Sending {} to conn_id: {} request_id: {} prefix_hash: {}",
+                            log_name,
+                            conn_ctx.connection_handle,
+                            request_id,
                             th.track_namespace_hash);
 
-        SendCtrlMsg(conn_it->second, handler->GetDataContextId().value(), ControlMessageType::kNamespaceDone, prefix);
+        SendCtrlMsg(conn_ctx, data_ctx_id, type, UintVar(request_id), prefix, params);
+    } catch (const std::exception& e) {
+        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending subscribe namespace (error={})", e.what());
+        // TODO: add error handling in libquicr in calling function
+    }
+
+    void Transport::SendUnsubscribeNamespace(ConnectionContext& conn_ctx,
+                                             DataContextId data_ctx_id,
+                                             const TrackNamespace& prefix)
+    try {
+        [[maybe_unused]] auto th = TrackHash({ prefix, {} });
+
+        SPDLOG_LOGGER_DEBUG(logger_,
+                            "Sending UNSUBSCRIBE_NAMESPACE to conn_id: {} prefix_hash: {}",
+                            conn_ctx.connection_handle,
+                            th.track_namespace_hash);
+
+        SendCtrlMsg(conn_ctx, data_ctx_id, ControlMessageType::kNamespaceDone, prefix);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending UNSUBSCRIBE_NAMESPACE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
-    void Transport::SubscribeNamespace(ConnectionHandle connection_handle,
-                                       std::shared_ptr<SubscribeNamespaceHandler> handler)
+    void Transport::SubscribeNamespace(ConnectionHandle conn_id, std::shared_ptr<SubscribeNamespaceHandler> handler)
     {
-        SendSubscribeNamespace(connection_handle, std::move(handler));
+        const auto& prefix = handler->GetPrefix();
+        handler->connection_handle_ = conn_id;
+
+        [[maybe_unused]] auto th = TrackHash({ prefix, {} });
+
+        SPDLOG_LOGGER_INFO(logger_,
+                           "Subscribe namespace conn_id: {} prefix_hash: {} mode: {}",
+                           conn_id,
+                           th.track_namespace_hash,
+                           handler->GetMode() == SubscribeNamespaceHandler::Mode::kNamespaces ? "namespaces"
+                                                                                              : "tracks");
+
+        std::lock_guard<std::mutex> lock(state_mutex_);
+
+        auto conn_it = connections_.find(conn_id);
+        if (conn_it == connections_.end()) {
+            SPDLOG_LOGGER_ERROR(logger_, "Subscribe namespace conn_id: {} does not exist.", conn_id);
+            return;
+        }
+
+        handler->SetRequestId(conn_it->second.GetNextRequestId());
+        handler->SetTransport(GetSharedPtr());
+
+        if (auto [_, is_new] = conn_it->second.request_handlers.try_emplace(handler->GetRequestId().value(), handler);
+            !is_new) {
+            SPDLOG_LOGGER_WARN(logger_, "Namespace already subscribed to (prefix_hash={})", th.track_namespace_hash);
+            return;
+        }
+
+        const auto message_type = handler->GetMode() == SubscribeNamespaceHandler::Mode::kNamespaces
+                                    ? ControlMessageType::kSubscribeNamespace
+                                    : ControlMessageType::kSubscribeTracks;
+
+        handler->SetDataContextId(quic_transport_->CreateDataContext(conn_id, true, 0, true, handler->GetRequestId()));
+        quic_transport_->CreateStream(conn_id, handler->GetDataContextId().value(), 0);
+
+        SendSubscribeNamespace(conn_it->second,
+                               handler->GetDataContextId().value(),
+                               handler->GetRequestId().value(),
+                               prefix,
+                               handler->GetFilter(),
+                               message_type);
     }
 
-    void Transport::UnsubscribeNamespace(ConnectionHandle connection_handle,
+    void Transport::UnsubscribeNamespace(ConnectionHandle conn_id,
                                          const std::shared_ptr<SubscribeNamespaceHandler>& handler)
     {
-        SendUnsubscribeNamespace(connection_handle, handler);
+        const auto& prefix = handler->GetPrefix();
+        [[maybe_unused]] auto th = TrackHash({ prefix, {} });
+
+        SPDLOG_LOGGER_INFO(
+          logger_, "Unsubscribe namespace conn_id: {} prefix_hash: {}", conn_id, th.track_namespace_hash);
+
+        std::lock_guard<std::mutex> lock(state_mutex_);
+
+        auto conn_it = connections_.find(conn_id);
+        if (conn_it == connections_.end()) {
+            SPDLOG_LOGGER_ERROR(logger_, "Unsubscribe namespace conn_id: {} does not exist.", conn_id);
+            return;
+        }
+
+        RemoveSubscribeNamespace(conn_it->second, *handler);
     }
 
     void Transport::SendFetch(ConnectionContext& conn_ctx,
@@ -981,10 +983,15 @@ namespace quicr {
 
         track_handler->SetTransport(GetSharedPtr());
 
-        // Set the track handler for tracking by request ID
-        conn_it->second.request_handlers[*track_handler->GetRequestId()] = track_handler;
-
         if (!track_handler->IsPublisherInitiated()) {
+            if (auto [_, is_new] =
+                  conn_it->second.request_handlers.try_emplace(*track_handler->GetRequestId(), track_handler);
+                !is_new) {
+                SPDLOG_LOGGER_WARN(
+                  logger_, "Track already subscribed conn_id: {} track_alias: {}", conn_id, th.track_fullname_hash);
+                return;
+            }
+
             track_handler->SetDataContextId(
               quic_transport_->CreateDataContext(conn_id, true, 0, true, track_handler->GetRequestId()));
             quic_transport_->CreateStream(conn_id, track_handler->GetDataContextId().value(), 0);
@@ -1022,14 +1029,28 @@ namespace quicr {
                                  info.joining_start,
                                  info.absolute);
             }
+        } else {
+            conn_it->second.request_handlers[*track_handler->GetRequestId()] = track_handler;
         }
     }
 
     void Transport::UnsubscribeTrack(quicr::TransportConnId conn_id,
                                      const std::shared_ptr<SubscribeTrackHandler>& track_handler)
     {
-        auto& conn_ctx = connections_[conn_id];
-        RemoveSubscribeTrack(conn_ctx, *track_handler);
+        const auto& tfn = track_handler->GetFullTrackName();
+        auto th = TrackHash(tfn);
+
+        SPDLOG_LOGGER_INFO(logger_, "Unsubscribe track conn_id: {} track_alias: {}", conn_id, th.track_fullname_hash);
+
+        std::lock_guard<std::mutex> lock(state_mutex_);
+
+        auto conn_it = connections_.find(conn_id);
+        if (conn_it == connections_.end()) {
+            SPDLOG_LOGGER_ERROR(logger_, "Unsubscribe track conn_id: {} does not exist.", conn_id);
+            return;
+        }
+
+        RemoveSubscribeTrack(conn_it->second, *track_handler);
     }
 
     void Transport::UpdateTrackSubscription(TransportConnId conn_id,
@@ -1099,8 +1120,6 @@ namespace quicr {
         }
 
         if (remove_handler) {
-            std::lock_guard<std::mutex> _(state_mutex_);
-
             if (handler.GetRequestId().has_value()) {
                 conn_ctx.request_handlers.erase(*handler.GetRequestId());
             }
@@ -1108,6 +1127,33 @@ namespace quicr {
             if (handler.GetReceivedTrackAlias().has_value()) {
                 conn_ctx.sub_by_recv_track_alias.erase(handler.GetReceivedTrackAlias().value());
             }
+        }
+    }
+
+    void Transport::RemoveSubscribeNamespace(ConnectionContext& conn_ctx,
+                                             SubscribeNamespaceHandler& handler,
+                                             bool remove_handler,
+                                             bool send_unsubscribe)
+    {
+        switch (handler.GetStatus()) {
+            case SubscribeNamespaceHandler::Status::kOk:
+                try {
+                    if (send_unsubscribe && not conn_ctx.closed && handler.GetDataContextId().has_value()) {
+                        SendUnsubscribeNamespace(conn_ctx, handler.GetDataContextId().value(), handler.GetPrefix());
+                    }
+                } catch (const std::exception& e) {
+                    SPDLOG_LOGGER_ERROR(logger_, "Failed to send unsubscribe namespace: {}", e.what());
+                }
+
+                handler.SetStatus(SubscribeNamespaceHandler::Status::kNotSubscribed);
+                break;
+
+            default:
+                break;
+        }
+
+        if (remove_handler && handler.GetRequestId().has_value()) {
+            conn_ctx.request_handlers.erase(*handler.GetRequestId());
         }
     }
 
@@ -1189,7 +1235,7 @@ namespace quicr {
         }
 
         if (auto ns_handler = handler_it->second.Get<SubscribeNamespaceHandler>()) {
-            ns_handler->SetStatus(SubscribeNamespaceHandler::Status::kNotSubscribed);
+            RemoveSubscribeNamespace(conn_ctx, *ns_handler, false, false);
             conn_ctx.request_handlers.erase(handler_it);
             conn_ctx.recv_req_id.erase(request_id);
             conn_ctx.ctrl_msg_buffer.erase(stream_id);

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1096,7 +1096,7 @@ PicoQuicTransport::Enqueue(const TransportConnId& conn_id,
 
         decltype(streams.begin()) stream_it;
 
-        if (data_ctx_it->second.is_bidir) {
+        if (data_ctx_it->second.is_bidir || (stream_id == 0 && priority == 0)) {
             if (streams.empty()) {
                 return TransportError::kInvalidStreamId;
             }

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -214,6 +214,8 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
                     }
 
                     if (data_ctx != nullptr) {
+                        transport->OnStreamClosed(
+                          conn_id, stream_id, nullptr, data_ctx->request_id, StreamClosedFlag::kFin);
                         transport->DeleteDataContext(conn_id, data_ctx->data_ctx_id, false);
                     }
                 }

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -456,6 +456,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
                 picoquic_cnx_t* close_cnx = picoquic_get_first_cnx(quic);
 
                 if (close_cnx == NULL) {
+                    transport->SetStatus(TransportStatus::kShutdown);
                     return PICOQUIC_NO_ERROR_TERMINATE_PACKET_LOOP;
                 }
 

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1,6 +1,8 @@
 #include "quicr/config.h"
 #include "quicr/defer.h"
 #include "quicr/fetch_track_handler.h"
+#include "quicr/publish_namespace_handler.h"
+#include "quicr/subscribe_namespace_handler.h"
 #include "quicr/subscribe_track_handler.h"
 #include "test_client.h"
 #include "test_server.h"
@@ -88,6 +90,8 @@ class CallbackPublishTrackHandler final : public PublishTrackHandler
             on_status_(status);
         }
     }
+
+    uint64_t GetPublishDataContextId() const { return publish_data_ctx_id_; }
 
   private:
     const StatusCallback on_status_;
@@ -1390,5 +1394,139 @@ TEST_CASE("Integration - Dynamic groups support roundtrip")
     SUBCASE("WebTransport - Publisher initiated")
     {
         test_dynamic_groups_publisher_initiated("https");
+    }
+}
+
+TEST_CASE("Integration - Dedicated bidirectional control data contexts")
+{
+    auto server = MakeTestServer(std::nullopt, 4);
+
+    auto test_dedicated_control_data_contexts = [&](const std::string& protocol_scheme) {
+        auto client = MakeTestClient(true, std::nullopt, protocol_scheme);
+
+        TrackNamespace prefix(std::vector<std::string>{ "ctrl", "stream" });
+
+        std::promise<TestServer::SubscribeNamespaceDetails> ns_server_promise;
+        std::future<TestServer::SubscribeNamespaceDetails> ns_server_future = ns_server_promise.get_future();
+        server->SetSubscribeNamespacePromise(std::move(ns_server_promise));
+
+        auto ns_handler = SubscribeNamespaceHandler::Create(prefix, SubscribeNamespaceHandler::Mode::kTracks);
+        CHECK_NOTHROW(client->SubscribeNamespace(ns_handler));
+
+        REQUIRE(ns_server_future.wait_for(kDefaultTimeout) == std::future_status::ready);
+        const auto ns_server_details = ns_server_future.get();
+        CHECK(ns_server_details.data_ctx_id != 0);
+
+        const bool ns_ready =
+          WaitFor([&ns_handler]() { return ns_handler->GetStatus() == SubscribeNamespaceHandler::Status::kOk; });
+        REQUIRE(ns_ready);
+        REQUIRE(ns_handler->GetDataContextId().has_value());
+        CHECK(ns_handler->GetDataContextId().value() != 0);
+
+        const auto ns_data_ctx = ns_handler->GetDataContextId().value();
+
+        FullTrackName ftn;
+        ftn.name_space = prefix;
+        ftn.name = { 1, 2, 3 };
+
+        const auto sub_handler = SubscribeTrackHandler::Create(ftn, 0, std::nullopt);
+        CHECK_NOTHROW(client->SubscribeTrack(sub_handler));
+
+        const bool sub_ready =
+          WaitFor([&sub_handler]() { return sub_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; });
+        REQUIRE(sub_ready);
+        REQUIRE(sub_handler->GetDataContextId().has_value());
+        CHECK(sub_handler->GetDataContextId().value() != ns_data_ctx);
+
+        const auto sub_data_ctx = sub_handler->GetDataContextId().value();
+
+        auto publisher = MakeTestClient(true, std::nullopt, protocol_scheme);
+        const auto pub_handler = std::make_shared<CallbackPublishTrackHandler>(ftn, 1, 5000, [](const auto&) {});
+        CHECK_NOTHROW(publisher->PublishTrack(pub_handler));
+        const bool pub_ready = WaitFor([&pub_handler]() { return pub_handler->CanPublish(); });
+        REQUIRE(pub_ready);
+        REQUIRE(pub_handler->GetDataContextId().has_value());
+        CHECK(pub_handler->GetPublishDataContextId() != 0);
+        // Control and object data contexts are distinct on the same connection.
+        CHECK(pub_handler->GetDataContextId().value() != pub_handler->GetPublishDataContextId());
+
+        TrackNamespace pub_ns(std::vector<std::string>{ "ctrl", "publish" });
+        std::promise<TestServer::PublishNamespaceDetails> pub_ns_server_promise;
+        std::future<TestServer::PublishNamespaceDetails> pub_ns_server_future = pub_ns_server_promise.get_future();
+        server->SetPublishNamespacePromise(std::move(pub_ns_server_promise));
+
+        const auto pub_ns_handler = PublishNamespaceHandler::Create(pub_ns);
+        CHECK_NOTHROW(publisher->PublishNamespace(pub_ns_handler));
+        REQUIRE(pub_ns_server_future.wait_for(kDefaultTimeout) == std::future_status::ready);
+        (void)pub_ns_server_future.get();
+
+        const bool pub_ns_ready =
+          WaitFor([&pub_ns_handler]() { return pub_ns_handler->GetStatus() == PublishNamespaceHandler::Status::kOk; });
+        REQUIRE(pub_ns_ready);
+        REQUIRE(pub_ns_handler->GetDataContextId().has_value());
+        // Data context IDs are unique per connection; compare handlers on the publisher only.
+        CHECK(pub_ns_handler->GetDataContextId().value() != pub_handler->GetDataContextId().value());
+    };
+
+    SUBCASE("Raw QUIC")
+    {
+        test_dedicated_control_data_contexts("moq");
+    }
+
+    SUBCASE("WebTransport")
+    {
+        test_dedicated_control_data_contexts("https");
+    }
+}
+
+TEST_CASE("Integration - Request updates use handler data context")
+{
+    auto server = MakeTestServer(std::nullopt, 4);
+
+    auto test_request_update_data_context = [&](const std::string& protocol_scheme) {
+        auto publisher = MakeTestClient(true, std::nullopt, protocol_scheme);
+        auto subscriber = MakeTestClient(true, std::nullopt, protocol_scheme);
+
+        FullTrackName ftn;
+        ftn.name_space = TrackNamespace(std::vector<std::string>{ "ctrl", "update" });
+        ftn.name = { 4, 5, 6 };
+
+        auto new_group_was_requested = std::make_shared<std::atomic_bool>(false);
+        const auto pub_handler = std::make_shared<CallbackPublishTrackHandler>(
+          ftn, 1, 5000, [new_group_was_requested](const PublishTrackHandler::Status status) {
+              if (status == PublishTrackHandler::Status::kNewGroupRequested) {
+                  new_group_was_requested->store(true);
+              }
+          });
+        CHECK_NOTHROW(publisher->PublishTrack(pub_handler));
+        const bool pub_ready = WaitFor([&pub_handler]() { return pub_handler->CanPublish(); });
+        REQUIRE(pub_ready);
+
+        const auto sub_handler = SubscribeTrackHandler::Create(ftn, 0, std::nullopt);
+        CHECK_NOTHROW(subscriber->SubscribeTrack(sub_handler));
+
+        const bool sub_ready =
+          WaitFor([&sub_handler]() { return sub_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; });
+        REQUIRE(sub_ready);
+        REQUIRE(sub_handler->GetDataContextId().has_value());
+
+        const auto data_ctx_before = sub_handler->GetDataContextId().value();
+
+        CHECK_NOTHROW(sub_handler->RequestNewGroup());
+
+        const bool received = WaitFor([new_group_was_requested]() { return new_group_was_requested->load(); });
+        CHECK(received);
+        REQUIRE(sub_handler->GetDataContextId().has_value());
+        CHECK(sub_handler->GetDataContextId().value() == data_ctx_before);
+    };
+
+    SUBCASE("Raw QUIC")
+    {
+        test_request_update_data_context("moq");
+    }
+
+    SUBCASE("WebTransport")
+    {
+        test_request_update_data_context("https");
     }
 }

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -157,7 +157,7 @@ TestServer::SubscribeTracksReceived(const ConnectionHandle connection_handle,
                                     const messages::SubscribeNamespaceAttributes& attributes)
 {
     if (subscribe_namespace_promise_.has_value()) {
-        subscribe_namespace_promise_->set_value({ connection_handle, prefix_namespace, attributes });
+        subscribe_namespace_promise_->set_value({ connection_handle, data_ctx_id, prefix_namespace, attributes });
     }
 
     // Deliberately not prefix matching to allow testing bad case. Tests should only add tracks

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -121,6 +121,7 @@ namespace quicr_test {
         struct SubscribeNamespaceDetails
         {
             quicr::ConnectionHandle connection_handle;
+            quicr::DataContextId data_ctx_id{ 0 };
             quicr::TrackNamespace prefix_namespace;
             quicr::messages::SubscribeNamespaceAttributes attributes;
         };


### PR DESCRIPTION
Refactors code to use the new style of per message request bidirectional streams and for messages that are request based.  Messages that are one-way, such as SETUP use unidirectional control stream. 