### PR TITLE
Statically type params / encode

### DIFF
--- a/include/quicr/detail/control_messages.h
+++ b/include/quicr/detail/control_messages.h
@@ -9,6 +9,7 @@
 #include "quicr/detail/control_messages/message_reader.h"
 #include "quicr/detail/control_messages/namespace.h"
 #include "quicr/detail/control_messages/namespace_done.h"
+#include "quicr/detail/control_messages/parameters.h"
 #include "quicr/detail/control_messages/publish.h"
 #include "quicr/detail/control_messages/publish_blocked.h"
 #include "quicr/detail/control_messages/publish_done.h"

--- a/include/quicr/detail/control_messages/fetch.h
+++ b/include/quicr/detail/control_messages/fetch.h
@@ -4,12 +4,34 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 #include "quicr/detail/ctrl_message_types.h"
 #include "quicr/track_name.h"
 
 #include <variant>
 
 namespace quicr::messages::control {
+
+    namespace detail {
+        inline Parameters EncodeFetchParameters(const std::vector<Token>& auth_tokens,
+                                                std::optional<std::uint64_t> fill_timeout,
+                                                std::uint8_t subscriber_priority,
+                                                GroupOrder group_order)
+        {
+            auto params = Parameters{};
+            for (const auto& token : auth_tokens) {
+                params.Add(ParameterType::kAuthorizationToken, token);
+            }
+            params.AddOptional(ParameterType::kFillTimeout, fill_timeout);
+            if (subscriber_priority != 128) {
+                params.Add(ParameterType::kSubscriberPriority, subscriber_priority);
+            }
+            if (group_order != GroupOrder::kAscending) {
+                params.Add(ParameterType::kGroupOrder, group_order);
+            }
+            return params;
+        }
+    } // namespace detail
 
     struct StandaloneFetch
     {
@@ -21,26 +43,50 @@ namespace quicr::messages::control {
         const TrackName track_name;
         const Location start;
         const Location end;
-        const Parameters parameters;
+        const std::vector<Token> auth_tokens;
+        const std::optional<std::uint64_t> fill_timeout;
+        const std::uint8_t subscriber_priority;
+        const GroupOrder group_order;
 
-        explicit StandaloneFetch(BytesSpan payload)
-          : StandaloneFetch(MessageReader{ payload })
+        static StandaloneFetch Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto request_id = reader.Read<RequestID>();
+            auto fetch_type = ReadFetchType(reader);
+            auto track_namespace = reader.Read<TrackNamespace>();
+            auto track_name = reader.Read<TrackName>();
+            auto start = reader.Read<Location>();
+            auto end = reader.Read<Location>();
+
+            const auto params = reader.Read<Parameters>();
+            reader.ExpectDone();
+            auto fetch_params = ResolveFetchParameters(params);
+
+            return StandaloneFetch{
+                .request_id = request_id,
+                .fetch_type = fetch_type,
+                .track_namespace = std::move(track_namespace),
+                .track_name = std::move(track_name),
+                .start = start,
+                .end = end,
+                .auth_tokens = std::move(fetch_params.auth_tokens),
+                .fill_timeout = fetch_params.fill_timeout,
+                .subscriber_priority = fetch_params.subscriber_priority,
+                .group_order = fetch_params.group_order,
+            };
+        }
+
+        [[nodiscard]] Bytes Encode() const
+        {
+            const auto params =
+              detail::EncodeFetchParameters(auth_tokens, fill_timeout, subscriber_priority, group_order);
+            Bytes out;
+            out << request_id << static_cast<std::uint64_t>(fetch_type) << track_namespace << track_name << start << end
+                << params;
+            return out;
         }
 
       private:
-        explicit StandaloneFetch(MessageReader reader)
-          : request_id(reader.Read<RequestID>())
-          , fetch_type(ReadFetchType(reader))
-          , track_namespace(reader.Read<TrackNamespace>())
-          , track_name(reader.Read<TrackName>())
-          , start(reader.Read<Location>())
-          , end(reader.Read<Location>())
-          , parameters(reader.Read<Parameters>())
-        {
-            reader.ExpectDone();
-        }
-
         static FetchType ReadFetchType(MessageReader& reader)
         {
             const auto fetch_type = static_cast<FetchType>(reader.Read<std::uint64_t>());
@@ -61,24 +107,47 @@ namespace quicr::messages::control {
         const FetchType fetch_type;
         const RequestID joining_request_id;
         const std::uint64_t joining_start;
-        const Parameters parameters;
+        const std::vector<Token> auth_tokens;
+        const std::optional<std::uint64_t> fill_timeout;
+        const std::uint8_t subscriber_priority;
+        const GroupOrder group_order;
 
-        explicit JoiningFetch(BytesSpan payload)
-          : JoiningFetch(MessageReader{ payload })
+        static JoiningFetch Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto request_id = reader.Read<RequestID>();
+            auto fetch_type = ReadJoiningFetchType(reader);
+            auto joining_request_id = reader.Read<RequestID>();
+            auto joining_start = reader.Read<std::uint64_t>();
+
+            const auto params = reader.Read<Parameters>();
+            reader.ExpectDone();
+            auto fetch_params = ResolveFetchParameters(params);
+
+            return JoiningFetch{
+                .request_id = request_id,
+                .fetch_type = fetch_type,
+                .joining_request_id = joining_request_id,
+                .joining_start = joining_start,
+                .auth_tokens = std::move(fetch_params.auth_tokens),
+                .fill_timeout = fetch_params.fill_timeout,
+                .subscriber_priority = fetch_params.subscriber_priority,
+                .group_order = fetch_params.group_order,
+            };
+        }
+
+        [[nodiscard]] Bytes Encode() const
+        {
+            const auto params =
+              detail::EncodeFetchParameters(auth_tokens, fill_timeout, subscriber_priority, group_order);
+
+            Bytes out;
+            out << request_id << static_cast<std::uint64_t>(fetch_type) << joining_request_id << joining_start
+                << params;
+            return out;
         }
 
       private:
-        explicit JoiningFetch(MessageReader reader)
-          : request_id(reader.Read<RequestID>())
-          , fetch_type(ReadJoiningFetchType(reader))
-          , joining_request_id(reader.Read<RequestID>())
-          , joining_start(reader.Read<std::uint64_t>())
-          , parameters(reader.Read<Parameters>())
-        {
-            reader.ExpectDone();
-        }
-
         static FetchType ReadJoiningFetchType(MessageReader& reader)
         {
             const auto fetch_type = static_cast<FetchType>(reader.Read<std::uint64_t>());
@@ -94,19 +163,18 @@ namespace quicr::messages::control {
     };
 
     using Fetch = std::variant<StandaloneFetch, JoiningFetch>;
-    Fetch ReadFetch(BytesSpan payload)
+    inline Fetch ReadFetch(BytesSpan payload)
     {
         auto reader = MessageReader{ payload };
-        // TODO: We don't need to re-read these after we read them here.
         [[maybe_unused]] const auto request_id = reader.Read<RequestID>();
         const auto fetch_type = static_cast<FetchType>(reader.Read<std::uint64_t>());
 
         switch (fetch_type) {
             case FetchType::kStandalone:
-                return StandaloneFetch{ payload };
+                return StandaloneFetch::Decode(payload);
             case FetchType::kRelativeJoiningFetch:
             case FetchType::kAbsoluteJoiningFetch:
-                return JoiningFetch{ payload };
+                return JoiningFetch::Decode(payload);
         }
 
         throw ProtocolViolationException("Invalid FETCH type");

--- a/include/quicr/detail/control_messages/fetch_ok.h
+++ b/include/quicr/detail/control_messages/fetch_ok.h
@@ -16,19 +16,29 @@ namespace quicr::messages::control {
         const Parameters parameters;
         const TrackExtensions track_properties;
 
-        explicit FetchOk(BytesSpan payload)
-          : FetchOk(MessageReader{ payload })
+        static FetchOk Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto end_of_track = reader.Read<std::uint8_t>();
+            auto end_location = reader.Read<Location>();
+
+            auto parameters = reader.Read<Parameters>();
+            auto track_properties = reader.Read<TrackExtensions>();
+            reader.ExpectDone();
+
+            return FetchOk{
+                .end_of_track = end_of_track,
+                .end_location = end_location,
+                .parameters = std::move(parameters),
+                .track_properties = std::move(track_properties),
+            };
         }
 
-      private:
-        explicit FetchOk(MessageReader reader)
-          : end_of_track(reader.Read<std::uint8_t>())
-          , end_location(reader.Read<Location>())
-          , parameters(reader.Read<Parameters>())
-          , track_properties(reader.Read<TrackExtensions>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            Bytes out;
+            out << end_of_track << end_location << parameters << track_properties;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/goaway.h
+++ b/include/quicr/detail/control_messages/goaway.h
@@ -7,6 +7,7 @@
 
 namespace quicr::messages::control {
 
+    // A GOAWAY sent on a request stream: no Request ID (§10.4).
     struct RequestGoaway
     {
         static constexpr std::uint64_t kType = 0x10;
@@ -14,20 +15,28 @@ namespace quicr::messages::control {
         const Bytes new_session_uri;
         const std::uint64_t timeout;
 
-        explicit RequestGoaway(BytesSpan payload)
-          : RequestGoaway(MessageReader{ payload })
+        static RequestGoaway Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto new_session_uri = reader.Read<Bytes>();
+            auto timeout = reader.Read<std::uint64_t>();
+            reader.ExpectDone();
+
+            return RequestGoaway{
+                .new_session_uri = std::move(new_session_uri),
+                .timeout = timeout,
+            };
         }
 
-      private:
-        explicit RequestGoaway(MessageReader reader)
-          : new_session_uri(reader.Read<Bytes>())
-          , timeout(reader.Read<std::uint64_t>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            Bytes out;
+            out << new_session_uri << timeout;
+            return out;
         }
     };
 
+    // A GOAWAY sent on the control stream: carries the trailing Request ID (§10.4).
     struct ControlGoaway
     {
         static constexpr std::uint64_t kType = 0x10;
@@ -36,18 +45,26 @@ namespace quicr::messages::control {
         const std::uint64_t timeout;
         const RequestID request_id;
 
-        explicit ControlGoaway(BytesSpan payload)
-          : ControlGoaway(MessageReader{ payload })
+        static ControlGoaway Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto new_session_uri = reader.Read<Bytes>();
+            auto timeout = reader.Read<std::uint64_t>();
+            auto request_id = reader.Read<RequestID>();
+            reader.ExpectDone();
+
+            return ControlGoaway{
+                .new_session_uri = std::move(new_session_uri),
+                .timeout = timeout,
+                .request_id = request_id,
+            };
         }
 
-      private:
-        explicit ControlGoaway(MessageReader reader)
-          : new_session_uri(reader.Read<Bytes>())
-          , timeout(reader.Read<std::uint64_t>())
-          , request_id(reader.Read<RequestID>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            Bytes out;
+            out << new_session_uri << timeout << request_id;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/namespace.h
+++ b/include/quicr/detail/control_messages/namespace.h
@@ -13,16 +13,20 @@ namespace quicr::messages::control {
 
         const TrackNamespace track_namespace_suffix;
 
-        explicit Namespace(BytesSpan payload)
-          : Namespace(MessageReader{ payload })
+        static Namespace Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto track_namespace_suffix = reader.Read<TrackNamespace>();
+            reader.ExpectDone();
+
+            return Namespace{ .track_namespace_suffix = std::move(track_namespace_suffix) };
         }
 
-      private:
-        explicit Namespace(MessageReader reader)
-          : track_namespace_suffix(reader.Read<TrackNamespace>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            Bytes out;
+            out << track_namespace_suffix;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/namespace_done.h
+++ b/include/quicr/detail/control_messages/namespace_done.h
@@ -13,16 +13,20 @@ namespace quicr::messages::control {
 
         const TrackNamespace track_namespace_suffix;
 
-        explicit NamespaceDone(BytesSpan payload)
-          : NamespaceDone(MessageReader{ payload })
+        static NamespaceDone Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto track_namespace_suffix = reader.Read<TrackNamespace>();
+            reader.ExpectDone();
+
+            return NamespaceDone{ .track_namespace_suffix = std::move(track_namespace_suffix) };
         }
 
-      private:
-        explicit NamespaceDone(MessageReader reader)
-          : track_namespace_suffix(reader.Read<TrackNamespace>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            Bytes out;
+            out << track_namespace_suffix;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/parameters.h
+++ b/include/quicr/detail/control_messages/parameters.h
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 Cisco Systems
+// SPDX-License-Identifier: BSD-2-Clause
+
+#pragma once
+
+#include "quicr/detail/ctrl_message_types.h"
+
+#include <algorithm>
+#include <initializer_list>
+#include <vector>
+
+namespace quicr::messages::control {
+
+    /// Enforce the §10.2 receipt rules: every present type must be in `allowed`,
+    /// and no type may repeat except AUTHORIZATION_TOKEN.
+    inline void ValidateParameters(const Parameters& params, std::initializer_list<ParameterType> allowed)
+    {
+        std::vector<ParameterType> seen;
+        for (const auto& kvp : params) {
+            if (std::find(allowed.begin(), allowed.end(), kvp.type) == allowed.end()) {
+                throw ProtocolViolationException("Parameter not valid for this message type");
+            }
+
+            if (kvp.type != ParameterType::kAuthorizationToken) {
+                if (std::find(seen.begin(), seen.end(), kvp.type) != seen.end()) {
+                    throw ProtocolViolationException("Unexpected duplicate parameter");
+                }
+                seen.push_back(kvp.type);
+            }
+        }
+    }
+
+    /// Collect every AUTHORIZATION_TOKEN parameter as a parsed Token.
+    inline std::vector<Token> CollectAuthTokens(const Parameters& params)
+    {
+        std::vector<Token> tokens;
+        for (const auto& kvp : params) {
+            if (kvp.type != ParameterType::kAuthorizationToken) {
+                continue;
+            }
+            Token token{};
+            BytesSpan span{ kvp.value };
+            span >> token;
+            tokens.push_back(std::move(token));
+        }
+        return tokens;
+    }
+
+    /// Resolve the FORWARD parameter (0x10). Default 1 (true). Throws on a value outside {0,1}.
+    inline bool ResolveForward(const Parameters& params, bool default_value)
+    {
+        if (!params.Contains(ParameterType::kForward)) {
+            return default_value;
+        }
+        const auto value = params.Get<std::uint8_t>(ParameterType::kForward);
+        if (value > 1) {
+            throw ProtocolViolationException("FORWARD parameter must be 0 or 1");
+        }
+        return value == 1;
+    }
+
+    /// Resolve the GROUP_ORDER parameter (0x22). Throws on a value outside {1,2}.
+    inline std::optional<GroupOrder> ResolveGroupOrder(const Parameters& params)
+    {
+        if (!params.Contains(ParameterType::kGroupOrder)) {
+            return std::nullopt;
+        }
+        const auto value = params.Get<std::uint8_t>(ParameterType::kGroupOrder);
+        if (value != static_cast<std::uint8_t>(GroupOrder::kAscending) &&
+            value != static_cast<std::uint8_t>(GroupOrder::kDescending)) {
+            throw ProtocolViolationException("GROUP_ORDER parameter must be Ascending or Descending");
+        }
+        return static_cast<GroupOrder>(value);
+    }
+
+    /// Resolve the EXPIRES parameter (0x08). Absent or 0 both mean "no expiry" (nullopt).
+    inline std::optional<std::uint64_t> ResolveExpires(const Parameters& params)
+    {
+        const auto expires = params.GetOptional<std::uint64_t>(ParameterType::kExpires);
+        return (expires.has_value() && expires.value() != 0) ? expires : std::nullopt;
+    }
+
+    /// The §10.2 parameters common to both standalone and joining FETCH messages.
+    struct FetchParameters
+    {
+        std::vector<Token> auth_tokens;
+        std::optional<std::uint64_t> fill_timeout;
+        std::uint8_t subscriber_priority;
+        GroupOrder group_order;
+    };
+
+    /// Validate and resolve the parameters carried by a FETCH message, applying the
+    /// §10.2 defaults (subscriber priority 128, group order Ascending).
+    inline FetchParameters ResolveFetchParameters(const Parameters& params)
+    {
+        ValidateParameters(params,
+                           { ParameterType::kAuthorizationToken,
+                             ParameterType::kFillTimeout,
+                             ParameterType::kSubscriberPriority,
+                             ParameterType::kGroupOrder });
+
+        return FetchParameters{
+            .auth_tokens = CollectAuthTokens(params),
+            .fill_timeout = params.GetOptional<std::uint64_t>(ParameterType::kFillTimeout),
+            .subscriber_priority = params.GetOptional<std::uint8_t>(ParameterType::kSubscriberPriority).value_or(128),
+            .group_order = ResolveGroupOrder(params).value_or(GroupOrder::kAscending),
+        };
+    }
+
+    /// The SUBSCRIPTION_FILTER variants; at most one may appear in a message.
+    inline constexpr FilterType kFilterTypes[] = {
+        FilterType::kLocationFilter, FilterType::kSubgroupFilter, FilterType::kObjectFilter,
+        FilterType::kPriorityFilter, FilterType::kPropertyFilter, FilterType::kTrackFilter,
+    };
+
+    /// True if any SUBSCRIPTION_FILTER variant is present.
+    inline bool ContainsAnyFilter(const Parameters& params)
+    {
+        return std::any_of(std::begin(kFilterTypes), std::end(kFilterTypes), [&](const auto filter_type) {
+            return params.Contains(ToParameterFilterType(filter_type));
+        });
+    }
+
+    /// Resolve whichever SUBSCRIPTION_FILTER parameter is present, else monostate (unfiltered).
+    inline Filter ResolveFilter(const Parameters& params)
+    {
+        for (const auto filter_type : kFilterTypes) {
+            if (params.Contains(ToParameterFilterType(filter_type))) {
+                return params.GetFilter(filter_type);
+            }
+        }
+        return std::monostate{};
+    }
+
+} // namespace quicr::messages::control

--- a/include/quicr/detail/control_messages/publish.h
+++ b/include/quicr/detail/control_messages/publish.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 
 namespace quicr::messages::control {
 
@@ -15,24 +16,60 @@ namespace quicr::messages::control {
         const TrackNamespace track_namespace;
         const TrackName track_name;
         const TrackAlias track_alias;
-        const Parameters parameters;
+        const std::vector<Token> auth_tokens;
+        const std::optional<std::uint64_t> expires;
+        const std::optional<Location> largest_object;
+        const bool forward;
         const TrackExtensions track_properties;
 
-        explicit Publish(BytesSpan payload)
-          : Publish(MessageReader{ payload })
+        static Publish Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto request_id = reader.Read<RequestID>();
+            auto track_namespace = reader.Read<TrackNamespace>();
+            auto track_name = reader.Read<TrackName>();
+            auto track_alias = reader.Read<TrackAlias>();
+
+            const auto params = reader.Read<Parameters>();
+            auto track_properties = reader.Read<TrackExtensions>();
+            reader.ExpectDone();
+
+            ValidateParameters(params,
+                               { ParameterType::kAuthorizationToken,
+                                 ParameterType::kExpires,
+                                 ParameterType::kLargestObject,
+                                 ParameterType::kForward });
+
+            return Publish{
+                .request_id = request_id,
+                .track_namespace = std::move(track_namespace),
+                .track_name = std::move(track_name),
+                .track_alias = track_alias,
+                .auth_tokens = CollectAuthTokens(params),
+                .expires = ResolveExpires(params),
+                .largest_object = params.GetOptional<Location>(ParameterType::kLargestObject),
+                .forward = ResolveForward(params, true),
+                .track_properties = std::move(track_properties),
+            };
         }
 
-      private:
-        explicit Publish(MessageReader reader)
-          : request_id(reader.Read<RequestID>())
-          , track_namespace(reader.Read<TrackNamespace>())
-          , track_name(reader.Read<TrackName>())
-          , track_alias(reader.Read<TrackAlias>())
-          , parameters(reader.Read<Parameters>())
-          , track_properties(reader.Read<TrackExtensions>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            auto params = Parameters{};
+            for (const auto& token : auth_tokens) {
+                params.Add(ParameterType::kAuthorizationToken, token);
+            }
+            if (expires.has_value() && expires.value() != 0) {
+                params.Add(ParameterType::kExpires, expires.value());
+            }
+            params.AddOptional(ParameterType::kLargestObject, largest_object);
+            if (!forward) {
+                params.Add(ParameterType::kForward, std::uint8_t{ 0 });
+            }
+
+            Bytes out;
+            out << request_id << track_namespace << track_name << track_alias << params << track_properties;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/publish_blocked.h
+++ b/include/quicr/detail/control_messages/publish_blocked.h
@@ -14,17 +14,24 @@ namespace quicr::messages::control {
         const TrackNamespace track_namespace_suffix;
         const TrackName track_name;
 
-        explicit PublishBlocked(BytesSpan payload)
-          : PublishBlocked(MessageReader{ payload })
+        static PublishBlocked Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto track_namespace_suffix = reader.Read<TrackNamespace>();
+            auto track_name = reader.Read<TrackName>();
+            reader.ExpectDone();
+
+            return PublishBlocked{
+                .track_namespace_suffix = std::move(track_namespace_suffix),
+                .track_name = std::move(track_name),
+            };
         }
 
-      private:
-        explicit PublishBlocked(MessageReader reader)
-          : track_namespace_suffix(reader.Read<TrackNamespace>())
-          , track_name(reader.Read<TrackName>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            Bytes out;
+            out << track_namespace_suffix << track_name;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/publish_done.h
+++ b/include/quicr/detail/control_messages/publish_done.h
@@ -15,18 +15,26 @@ namespace quicr::messages::control {
         const std::uint64_t stream_count;
         const ReasonPhrase error_reason;
 
-        explicit PublishDone(BytesSpan payload)
-          : PublishDone(MessageReader{ payload })
+        static PublishDone Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto status_code = static_cast<PublishDoneStatus>(reader.Read<std::uint64_t>());
+            auto stream_count = reader.Read<std::uint64_t>();
+            auto error_reason = reader.Read<ReasonPhrase>();
+            reader.ExpectDone();
+
+            return PublishDone{
+                .status_code = status_code,
+                .stream_count = stream_count,
+                .error_reason = std::move(error_reason),
+            };
         }
 
-      private:
-        explicit PublishDone(MessageReader reader)
-          : status_code(static_cast<PublishDoneStatus>(reader.Read<std::uint64_t>()))
-          , stream_count(reader.Read<std::uint64_t>())
-          , error_reason(reader.Read<ReasonPhrase>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            Bytes out;
+            out << static_cast<std::uint64_t>(status_code) << stream_count << error_reason;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/publish_namespace.h
+++ b/include/quicr/detail/control_messages/publish_namespace.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 
 namespace quicr::messages::control {
 
@@ -13,20 +14,36 @@ namespace quicr::messages::control {
 
         const RequestID request_id;
         const TrackNamespace track_namespace;
-        const Parameters parameters;
+        const std::vector<Token> auth_tokens;
 
-        explicit PublishNamespace(BytesSpan payload)
-          : PublishNamespace(MessageReader{ payload })
+        static PublishNamespace Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto request_id = reader.Read<RequestID>();
+            auto track_namespace = reader.Read<TrackNamespace>();
+
+            const auto params = reader.Read<Parameters>();
+            reader.ExpectDone();
+
+            ValidateParameters(params, { ParameterType::kAuthorizationToken });
+
+            return PublishNamespace{
+                .request_id = request_id,
+                .track_namespace = std::move(track_namespace),
+                .auth_tokens = CollectAuthTokens(params),
+            };
         }
 
-      private:
-        explicit PublishNamespace(MessageReader reader)
-          : request_id(reader.Read<RequestID>())
-          , track_namespace(reader.Read<TrackNamespace>())
-          , parameters(reader.Read<Parameters>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            auto params = Parameters{};
+            for (const auto& token : auth_tokens) {
+                params.Add(ParameterType::kAuthorizationToken, token);
+            }
+
+            Bytes out;
+            out << request_id << track_namespace << params;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/request_error.h
+++ b/include/quicr/detail/control_messages/request_error.h
@@ -22,23 +22,37 @@ namespace quicr::messages::control {
         const ErrorCode error_code;
         const std::uint64_t retry_interval;
         const ReasonPhrase error_reason;
+        // Present iff error_code is the redirect code (§10.6.1); the two travel together on the wire.
         const std::optional<Redirect> redirect;
 
-        explicit RequestError(BytesSpan payload)
-          : RequestError(MessageReader{ payload })
+        static RequestError Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto error_code = static_cast<ErrorCode>(reader.Read<std::uint64_t>());
+            auto retry_interval = reader.Read<std::uint64_t>();
+            auto error_reason = reader.Read<ReasonPhrase>();
+            auto redirect = ReadRedirect(reader, error_code);
+            reader.ExpectDone();
+
+            return RequestError{
+                .error_code = error_code,
+                .retry_interval = retry_interval,
+                .error_reason = std::move(error_reason),
+                .redirect = std::move(redirect),
+            };
+        }
+
+        [[nodiscard]] Bytes Encode() const
+        {
+            Bytes out;
+            out << static_cast<std::uint64_t>(error_code) << retry_interval << error_reason;
+            if (static_cast<std::uint64_t>(error_code) == kRedirectErrorCode && redirect.has_value()) {
+                out << redirect->connect_uri << redirect->track_namespace << redirect->track_name;
+            }
+            return out;
         }
 
       private:
-        explicit RequestError(MessageReader reader)
-          : error_code(static_cast<ErrorCode>(reader.Read<std::uint64_t>()))
-          , retry_interval(reader.Read<std::uint64_t>())
-          , error_reason(reader.Read<ReasonPhrase>())
-          , redirect(ReadRedirect(reader, error_code))
-        {
-            reader.ExpectDone();
-        }
-
         static std::optional<Redirect> ReadRedirect(MessageReader& reader, ErrorCode error_code)
         {
             if (static_cast<std::uint64_t>(error_code) != kRedirectErrorCode) {

--- a/include/quicr/detail/control_messages/request_ok.h
+++ b/include/quicr/detail/control_messages/request_ok.h
@@ -4,35 +4,200 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 
 namespace quicr::messages::control {
 
-    struct RequestOk
+    // Every REQUEST_OK is a parameter block optionally followed by Track Properties (§10.5).
+    // Only TRACK_STATUS_OK carries properties; the rest MUST be empty, so their Decode reads the
+    // parameters and then expects the message to be done -- trailing property bytes are a violation.
+    inline Parameters ReadOkParameters(MessageReader& reader)
+    {
+        auto parameters = reader.Read<Parameters>();
+        reader.ExpectDone();
+        return parameters;
+    }
+
+    struct PublishOk
     {
         static constexpr std::uint64_t kType = 0x7;
 
-        const Parameters parameters;
-        const TrackExtensions track_properties;
+        const std::optional<std::uint64_t> object_delivery_timeout;
+        const std::optional<std::uint64_t> subgroup_delivery_timeout;
+        const std::uint8_t subscriber_priority;      // Absent on the wire means 128 (§10.2.7).
+        const std::optional<GroupOrder> group_order; // Absent means the Track's preference (§10.2.8).
+        const Filter subscription_filter;            // monostate means unfiltered (§10.2.9).
+        const std::optional<std::uint64_t> expires;  // Absent or 0 both mean "no expiry" (§10.2.10).
+        const bool forward;                          // Absent on the wire means true (§10.2.12).
+        const std::optional<std::uint64_t> new_group_request;
 
-        explicit RequestOk(BytesSpan payload)
-          : RequestOk(MessageReader{ payload })
+        static PublishOk Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            const auto params = ReadOkParameters(reader);
+
+            ValidateParameters(params,
+                               { ParameterType::kDeliveryTimeout,
+                                 ParameterType::kSubgroupDeliveryTimeout,
+                                 ParameterType::kSubscriberPriority,
+                                 ParameterType::kGroupOrder,
+                                 ParameterType::kLocationFilter,
+                                 ParameterType::kSubgroupFilter,
+                                 ParameterType::kObjectFilter,
+                                 ParameterType::kPriorityFilter,
+                                 ParameterType::kPropertyFilter,
+                                 ParameterType::kTrackFilter,
+                                 ParameterType::kExpires,
+                                 ParameterType::kForward,
+                                 ParameterType::kNewGroupRequest });
+
+            return PublishOk{
+                .object_delivery_timeout = params.GetOptional<std::uint64_t>(ParameterType::kDeliveryTimeout),
+                .subgroup_delivery_timeout = params.GetOptional<std::uint64_t>(ParameterType::kSubgroupDeliveryTimeout),
+                .subscriber_priority =
+                  params.GetOptional<std::uint8_t>(ParameterType::kSubscriberPriority).value_or(128),
+                .group_order = ResolveGroupOrder(params),
+                .subscription_filter = ResolveFilter(params),
+                .expires = ResolveExpires(params),
+                .forward = ResolveForward(params, true),
+                .new_group_request = params.GetOptional<std::uint64_t>(ParameterType::kNewGroupRequest),
+            };
         }
 
-      private:
-        explicit RequestOk(MessageReader reader)
-          : parameters(reader.Read<Parameters>())
-          , track_properties(reader.Read<TrackExtensions>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            auto params = Parameters{};
+            params.AddOptional(ParameterType::kDeliveryTimeout, object_delivery_timeout);
+            params.AddOptional(ParameterType::kSubgroupDeliveryTimeout, subgroup_delivery_timeout);
+            if (subscriber_priority != 128) {
+                params.Add(ParameterType::kSubscriberPriority, subscriber_priority);
+            }
+            params.AddOptional(ParameterType::kGroupOrder, group_order);
+            if (const auto filter_type = GetFilterParameterType(subscription_filter);
+                filter_type != ParameterType::kInvalid) {
+                params.Add(filter_type, subscription_filter);
+            }
+            if (expires.has_value() && expires.value() != 0) {
+                params.Add(ParameterType::kExpires, expires.value());
+            }
+            if (!forward) {
+                params.Add(ParameterType::kForward, std::uint8_t{ 0 });
+            }
+            params.AddOptional(ParameterType::kNewGroupRequest, new_group_request);
+
+            Bytes out;
+            out << params;
+            return out;
         }
     };
 
-    using PublishOk = RequestOk;
-    using PublishNamespaceOk = RequestOk;
-    using RequestUpdateOk = RequestOk;
-    using SubscribeNamespaceOk = RequestOk;
-    using SubscribeTracksOk = RequestOk;
-    using TrackStatusOk = RequestOk;
+    struct RequestUpdateOk
+    {
+        static constexpr std::uint64_t kType = 0x7;
+
+        const std::optional<std::uint64_t> expires; // Absent or 0 both mean "no expiry" (§10.2.10).
+        const std::optional<Location> largest_object;
+
+        static RequestUpdateOk Decode(BytesSpan payload)
+        {
+            MessageReader reader{ payload };
+            const auto params = ReadOkParameters(reader);
+
+            ValidateParameters(params, { ParameterType::kExpires, ParameterType::kLargestObject });
+
+            return RequestUpdateOk{
+                .expires = ResolveExpires(params),
+                .largest_object = params.GetOptional<Location>(ParameterType::kLargestObject),
+            };
+        }
+
+        [[nodiscard]] Bytes Encode() const
+        {
+            auto params = Parameters{};
+            if (expires.has_value() && expires.value() != 0) {
+                params.Add(ParameterType::kExpires, expires.value());
+            }
+            params.AddOptional(ParameterType::kLargestObject, largest_object);
+
+            Bytes out;
+            out << params;
+            return out;
+        }
+    };
+
+    // The only REQUEST_OK that carries Track Properties (§10.5): they follow the parameter block
+    // and consume the remaining bytes of the message.
+    struct TrackStatusOk
+    {
+        static constexpr std::uint64_t kType = 0x7;
+
+        const std::optional<Location> largest_object;
+        const TrackExtensions track_properties;
+
+        static TrackStatusOk Decode(BytesSpan payload)
+        {
+            MessageReader reader{ payload };
+            const auto params = reader.Read<Parameters>();
+            auto track_properties = reader.Read<TrackExtensions>();
+            reader.ExpectDone();
+
+            ValidateParameters(params, { ParameterType::kLargestObject });
+
+            return TrackStatusOk{
+                .largest_object = params.GetOptional<Location>(ParameterType::kLargestObject),
+                .track_properties = std::move(track_properties),
+            };
+        }
+
+        [[nodiscard]] Bytes Encode() const
+        {
+            auto params = Parameters{};
+            params.AddOptional(ParameterType::kLargestObject, largest_object);
+
+            Bytes out;
+            out << params << track_properties;
+            return out;
+        }
+    };
+
+    // No-parameter, no-properties OK messages: any parameter or trailing property byte is a violation.
+    struct EmptyOk
+    {
+        static EmptyOk Decode(BytesSpan payload)
+        {
+            MessageReader reader{ payload };
+            const auto params = ReadOkParameters(reader);
+            ValidateParameters(params, std::initializer_list<ParameterType>{});
+            return EmptyOk{};
+        }
+
+        [[nodiscard]] Bytes Encode() const
+        {
+            Bytes out;
+            out << Parameters{};
+            return out;
+        }
+    };
+
+    struct PublishNamespaceOk : EmptyOk
+    {
+        static constexpr std::uint64_t kType = 0x7;
+        static PublishNamespaceOk Decode(BytesSpan payload) { return PublishNamespaceOk{ EmptyOk::Decode(payload) }; }
+    };
+
+    struct SubscribeNamespaceOk : EmptyOk
+    {
+        static constexpr std::uint64_t kType = 0x7;
+        static SubscribeNamespaceOk Decode(BytesSpan payload)
+        {
+            return SubscribeNamespaceOk{ EmptyOk::Decode(payload) };
+        }
+    };
+
+    struct SubscribeTracksOk : EmptyOk
+    {
+        static constexpr std::uint64_t kType = 0x7;
+        static SubscribeTracksOk Decode(BytesSpan payload) { return SubscribeTracksOk{ EmptyOk::Decode(payload) }; }
+    };
 
 } // namespace quicr::messages::control

--- a/include/quicr/detail/control_messages/request_update.h
+++ b/include/quicr/detail/control_messages/request_update.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 
 namespace quicr::messages::control {
 
@@ -12,19 +13,74 @@ namespace quicr::messages::control {
         static constexpr std::uint64_t kType = 0x2;
 
         const RequestID request_id;
-        const Parameters parameters;
+        const std::vector<Token> auth_tokens;
+        const std::optional<std::uint64_t> object_delivery_timeout;
+        const std::optional<std::uint64_t> subgroup_delivery_timeout;
+        const std::optional<std::uint8_t> subscriber_priority;
+        const std::optional<Filter> subscription_filter; // Absent means unchanged (§10.2.9).
+        const std::optional<bool> forward;               // Absent means unchanged (§10.2.12).
+        const std::optional<std::uint64_t> new_group_request;
+        const std::optional<TrackNamespace> track_namespace_prefix;
 
-        explicit RequestUpdate(BytesSpan payload)
-          : RequestUpdate(MessageReader{ payload })
+        static RequestUpdate Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto request_id = reader.Read<RequestID>();
+            const auto params = reader.Read<Parameters>();
+            reader.ExpectDone();
+
+            ValidateParameters(params,
+                               { ParameterType::kAuthorizationToken,
+                                 ParameterType::kDeliveryTimeout,
+                                 ParameterType::kSubgroupDeliveryTimeout,
+                                 ParameterType::kSubscriberPriority,
+                                 ParameterType::kLocationFilter,
+                                 ParameterType::kSubgroupFilter,
+                                 ParameterType::kObjectFilter,
+                                 ParameterType::kPriorityFilter,
+                                 ParameterType::kPropertyFilter,
+                                 ParameterType::kTrackFilter,
+                                 ParameterType::kForward,
+                                 ParameterType::kNewGroupRequest,
+                                 ParameterType::kTrackNamespacePrefix });
+
+            return RequestUpdate{
+                .request_id = request_id,
+                .auth_tokens = CollectAuthTokens(params),
+                .object_delivery_timeout = params.GetOptional<std::uint64_t>(ParameterType::kDeliveryTimeout),
+                .subgroup_delivery_timeout = params.GetOptional<std::uint64_t>(ParameterType::kSubgroupDeliveryTimeout),
+                .subscriber_priority = params.GetOptional<std::uint8_t>(ParameterType::kSubscriberPriority),
+                .subscription_filter =
+                  ContainsAnyFilter(params) ? std::optional<Filter>{ ResolveFilter(params) } : std::nullopt,
+                .forward = params.Contains(ParameterType::kForward)
+                             ? std::optional<bool>{ ResolveForward(params, true) }
+                             : std::nullopt,
+                .new_group_request = params.GetOptional<std::uint64_t>(ParameterType::kNewGroupRequest),
+                .track_namespace_prefix = params.GetOptional<TrackNamespace>(ParameterType::kTrackNamespacePrefix),
+            };
         }
 
-      private:
-        explicit RequestUpdate(MessageReader reader)
-          : request_id(reader.Read<RequestID>())
-          , parameters(reader.Read<Parameters>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            auto params = Parameters{};
+            for (const auto& token : auth_tokens) {
+                params.Add(ParameterType::kAuthorizationToken, token);
+            }
+            params.AddOptional(ParameterType::kDeliveryTimeout, object_delivery_timeout);
+            params.AddOptional(ParameterType::kSubgroupDeliveryTimeout, subgroup_delivery_timeout);
+            params.AddOptional(ParameterType::kSubscriberPriority, subscriber_priority);
+            if (subscription_filter.has_value()) {
+                params.Add(GetFilterParameterType(subscription_filter.value()), subscription_filter.value());
+            }
+            if (forward.has_value()) {
+                params.Add(ParameterType::kForward, static_cast<std::uint8_t>(forward.value()));
+            }
+            params.AddOptional(ParameterType::kNewGroupRequest, new_group_request);
+            params.AddOptional(ParameterType::kTrackNamespacePrefix, track_namespace_prefix);
+
+            Bytes out;
+            out << request_id << params;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/setup.h
+++ b/include/quicr/detail/control_messages/setup.h
@@ -13,16 +13,20 @@ namespace quicr::messages::control {
 
         const KeyValuePairs setup_options;
 
-        explicit Setup(BytesSpan payload)
-          : Setup(MessageReader{ payload })
+        static Setup Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto setup_options = reader.Read<KeyValuePairs>();
+            reader.ExpectDone();
+
+            return Setup{ .setup_options = std::move(setup_options) };
         }
 
-      private:
-        explicit Setup(MessageReader reader)
-          : setup_options(reader.Read<KeyValuePairs>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            Bytes out;
+            out << setup_options;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/subscribe.h
+++ b/include/quicr/detail/control_messages/subscribe.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 
 namespace quicr::messages::control {
 
@@ -14,21 +15,88 @@ namespace quicr::messages::control {
         const RequestID request_id;
         const TrackNamespace track_namespace;
         const TrackName track_name;
-        const Parameters parameters;
+        const std::vector<Token> auth_tokens;
+        const std::optional<std::uint64_t> object_delivery_timeout;
+        const std::optional<std::uint64_t> subgroup_delivery_timeout;
+        const std::uint64_t rendezvous_timeout;      // Absent on the wire means 0 (§10.2.6).
+        const std::uint8_t subscriber_priority;      // Absent on the wire means 128 (§10.2.7).
+        const std::optional<GroupOrder> group_order; // Absent means the Track's preference (§10.2.8).
+        const Filter subscription_filter;            // monostate means unfiltered (§10.2.9).
+        const bool forward;                          // Absent on the wire means true (§10.2.12).
+        const std::optional<std::uint64_t> new_group_request;
 
-        explicit Subscribe(BytesSpan payload)
-          : Subscribe(MessageReader{ payload })
+        /// Parse and validate a SUBSCRIBE off the wire, applying the §10.2 receive-side defaults.
+        static Subscribe Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto request_id = reader.Read<RequestID>();
+            auto track_namespace = reader.Read<TrackNamespace>();
+            auto track_name = reader.Read<TrackName>();
+
+            const auto params = reader.Read<Parameters>();
+            reader.ExpectDone();
+
+            ValidateParameters(params,
+                               { ParameterType::kAuthorizationToken,
+                                 ParameterType::kDeliveryTimeout,
+                                 ParameterType::kSubgroupDeliveryTimeout,
+                                 ParameterType::kRendezvousTimeout,
+                                 ParameterType::kSubscriberPriority,
+                                 ParameterType::kGroupOrder,
+                                 ParameterType::kLocationFilter,
+                                 ParameterType::kSubgroupFilter,
+                                 ParameterType::kObjectFilter,
+                                 ParameterType::kPriorityFilter,
+                                 ParameterType::kPropertyFilter,
+                                 ParameterType::kTrackFilter,
+                                 ParameterType::kForward,
+                                 ParameterType::kNewGroupRequest });
+
+            return Subscribe{
+                .request_id = request_id,
+                .track_namespace = std::move(track_namespace),
+                .track_name = std::move(track_name),
+                .auth_tokens = CollectAuthTokens(params),
+                .object_delivery_timeout = params.GetOptional<std::uint64_t>(ParameterType::kDeliveryTimeout),
+                .subgroup_delivery_timeout = params.GetOptional<std::uint64_t>(ParameterType::kSubgroupDeliveryTimeout),
+                .rendezvous_timeout = params.GetOptional<std::uint64_t>(ParameterType::kRendezvousTimeout).value_or(0),
+                .subscriber_priority =
+                  params.GetOptional<std::uint8_t>(ParameterType::kSubscriberPriority).value_or(128),
+                .group_order = ResolveGroupOrder(params),
+                .subscription_filter = ResolveFilter(params),
+                .forward = ResolveForward(params, true),
+                .new_group_request = params.GetOptional<std::uint64_t>(ParameterType::kNewGroupRequest),
+            };
         }
 
-      private:
-        explicit Subscribe(MessageReader reader)
-          : request_id(reader.Read<RequestID>())
-          , track_namespace(reader.Read<TrackNamespace>())
-          , track_name(reader.Read<TrackName>())
-          , parameters(reader.Read<Parameters>())
+        /// Serialise to the wire, omitting any parameter whose value equals its §10.2 default.
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            auto params = Parameters{};
+            for (const auto& token : auth_tokens) {
+                params.Add(ParameterType::kAuthorizationToken, token);
+            }
+            params.AddOptional(ParameterType::kDeliveryTimeout, object_delivery_timeout);
+            params.AddOptional(ParameterType::kSubgroupDeliveryTimeout, subgroup_delivery_timeout);
+            if (rendezvous_timeout != 0) {
+                params.Add(ParameterType::kRendezvousTimeout, rendezvous_timeout);
+            }
+            if (subscriber_priority != 128) {
+                params.Add(ParameterType::kSubscriberPriority, subscriber_priority);
+            }
+            params.AddOptional(ParameterType::kGroupOrder, group_order);
+            if (!forward) {
+                params.Add(ParameterType::kForward, std::uint8_t{ 0 });
+            }
+            params.AddOptional(ParameterType::kNewGroupRequest, new_group_request);
+            if (const auto filter_type = GetFilterParameterType(subscription_filter);
+                filter_type != ParameterType::kInvalid) {
+                params.Add(filter_type, subscription_filter);
+            }
+
+            Bytes out;
+            out << request_id << track_namespace << track_name << params;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/subscribe_namespace.h
+++ b/include/quicr/detail/control_messages/subscribe_namespace.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 
 namespace quicr::messages::control {
 
@@ -13,20 +14,36 @@ namespace quicr::messages::control {
 
         const RequestID request_id;
         const TrackNamespace track_namespace_prefix;
-        const Parameters parameters;
+        const std::vector<Token> auth_tokens;
 
-        explicit SubscribeNamespace(BytesSpan payload)
-          : SubscribeNamespace(MessageReader{ payload })
+        static SubscribeNamespace Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto request_id = reader.Read<RequestID>();
+            auto track_namespace_prefix = reader.Read<TrackNamespace>();
+
+            const auto params = reader.Read<Parameters>();
+            reader.ExpectDone();
+
+            ValidateParameters(params, { ParameterType::kAuthorizationToken });
+
+            return SubscribeNamespace{
+                .request_id = request_id,
+                .track_namespace_prefix = std::move(track_namespace_prefix),
+                .auth_tokens = CollectAuthTokens(params),
+            };
         }
 
-      private:
-        explicit SubscribeNamespace(MessageReader reader)
-          : request_id(reader.Read<RequestID>())
-          , track_namespace_prefix(reader.Read<TrackNamespace>())
-          , parameters(reader.Read<Parameters>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            auto params = Parameters{};
+            for (const auto& token : auth_tokens) {
+                params.Add(ParameterType::kAuthorizationToken, token);
+            }
+
+            Bytes out;
+            out << request_id << track_namespace_prefix << params;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/subscribe_ok.h
+++ b/include/quicr/detail/control_messages/subscribe_ok.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 
 namespace quicr::messages::control {
 
@@ -12,21 +13,40 @@ namespace quicr::messages::control {
         static constexpr std::uint64_t kType = 0x4;
 
         const TrackAlias track_alias;
-        const Parameters parameters;
+        const std::optional<std::uint64_t> expires; // Absent or 0 both mean "no expiry" (§10.2.10).
+        const std::optional<Location> largest_object;
         const TrackExtensions track_properties;
 
-        explicit SubscribeOk(BytesSpan payload)
-          : SubscribeOk(MessageReader{ payload })
+        static SubscribeOk Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto track_alias = reader.Read<TrackAlias>();
+
+            const auto params = reader.Read<Parameters>();
+            auto track_properties = reader.Read<TrackExtensions>();
+            reader.ExpectDone();
+
+            ValidateParameters(params, { ParameterType::kExpires, ParameterType::kLargestObject });
+
+            return SubscribeOk{
+                .track_alias = track_alias,
+                .expires = ResolveExpires(params),
+                .largest_object = params.GetOptional<Location>(ParameterType::kLargestObject),
+                .track_properties = std::move(track_properties),
+            };
         }
 
-      private:
-        explicit SubscribeOk(MessageReader reader)
-          : track_alias(reader.Read<TrackAlias>())
-          , parameters(reader.Read<Parameters>())
-          , track_properties(reader.Read<TrackExtensions>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            auto params = Parameters{};
+            if (expires.has_value() && expires.value() != 0) {
+                params.Add(ParameterType::kExpires, expires.value());
+            }
+            params.AddOptional(ParameterType::kLargestObject, largest_object);
+
+            Bytes out;
+            out << track_alias << params << track_properties;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/subscribe_tracks.h
+++ b/include/quicr/detail/control_messages/subscribe_tracks.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 
 namespace quicr::messages::control {
 
@@ -13,20 +14,41 @@ namespace quicr::messages::control {
 
         const RequestID request_id;
         const TrackNamespace track_namespace_prefix;
-        const Parameters parameters;
+        const std::vector<Token> auth_tokens;
+        const bool forward; // Absent on the wire means true (§10.2.12).
 
-        explicit SubscribeTracks(BytesSpan payload)
-          : SubscribeTracks(MessageReader{ payload })
+        static SubscribeTracks Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto request_id = reader.Read<RequestID>();
+            auto track_namespace_prefix = reader.Read<TrackNamespace>();
+
+            const auto params = reader.Read<Parameters>();
+            reader.ExpectDone();
+
+            ValidateParameters(params, { ParameterType::kAuthorizationToken, ParameterType::kForward });
+
+            return SubscribeTracks{
+                .request_id = request_id,
+                .track_namespace_prefix = std::move(track_namespace_prefix),
+                .auth_tokens = CollectAuthTokens(params),
+                .forward = ResolveForward(params, true),
+            };
         }
 
-      private:
-        explicit SubscribeTracks(MessageReader reader)
-          : request_id(reader.Read<RequestID>())
-          , track_namespace_prefix(reader.Read<TrackNamespace>())
-          , parameters(reader.Read<Parameters>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            auto params = Parameters{};
+            for (const auto& token : auth_tokens) {
+                params.Add(ParameterType::kAuthorizationToken, token);
+            }
+            if (!forward) {
+                params.Add(ParameterType::kForward, std::uint8_t{ 0 });
+            }
+
+            Bytes out;
+            out << request_id << track_namespace_prefix << params;
+            return out;
         }
     };
 

--- a/include/quicr/detail/control_messages/track_status.h
+++ b/include/quicr/detail/control_messages/track_status.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "quicr/detail/control_messages/message_reader.h"
+#include "quicr/detail/control_messages/parameters.h"
 
 namespace quicr::messages::control {
 
@@ -14,21 +15,38 @@ namespace quicr::messages::control {
         const RequestID request_id;
         const TrackNamespace track_namespace;
         const TrackName track_name;
-        const Parameters parameters;
+        const std::vector<Token> auth_tokens;
 
-        explicit TrackStatus(BytesSpan payload)
-          : TrackStatus(MessageReader{ payload })
+        static TrackStatus Decode(BytesSpan payload)
         {
+            MessageReader reader{ payload };
+            auto request_id = reader.Read<RequestID>();
+            auto track_namespace = reader.Read<TrackNamespace>();
+            auto track_name = reader.Read<TrackName>();
+
+            const auto params = reader.Read<Parameters>();
+            reader.ExpectDone();
+
+            ValidateParameters(params, { ParameterType::kAuthorizationToken });
+
+            return TrackStatus{
+                .request_id = request_id,
+                .track_namespace = std::move(track_namespace),
+                .track_name = std::move(track_name),
+                .auth_tokens = CollectAuthTokens(params),
+            };
         }
 
-      private:
-        explicit TrackStatus(MessageReader reader)
-          : request_id(reader.Read<RequestID>())
-          , track_namespace(reader.Read<TrackNamespace>())
-          , track_name(reader.Read<TrackName>())
-          , parameters(reader.Read<Parameters>())
+        [[nodiscard]] Bytes Encode() const
         {
-            reader.ExpectDone();
+            auto params = Parameters{};
+            for (const auto& token : auth_tokens) {
+                params.Add(ParameterType::kAuthorizationToken, token);
+            }
+
+            Bytes out;
+            out << request_id << track_namespace << track_name << params;
+            return out;
         }
     };
 

--- a/include/quicr/detail/ctrl_message_types.h
+++ b/include/quicr/detail/ctrl_message_types.h
@@ -278,18 +278,22 @@ namespace quicr::messages {
     {
         kDeliveryTimeout = 0x02,
         kAuthorizationToken = 0x03,
+        kRendezvousTimeout = 0x04,
+        kSubgroupDeliveryTimeout = 0x06,
         kExpires = 0x08,
         kLargestObject = 0x09,
+        kFillTimeout = 0x0A,
         kForward = 0x10,
         kSubscriberPriority = 0x20,
         kLocationFilter = 0x21,
+        kGroupOrder = 0x22,
         kSubgroupFilter = 0x25,
         kObjectFilter = 0x26,
         kPriorityFilter = 0x27,
         kPropertyFilter = 0x28,
         kTrackFilter = 0x29,
-        kGroupOrder = 0x22,
         kNewGroupRequest = 0x32,
+        kTrackNamespacePrefix = 0x34,
 
         /*===================================================================*/
         // Internal Use
@@ -300,6 +304,84 @@ namespace quicr::messages {
 
     using Parameter = KeyValuePair<ParameterType>;
     using SetupParameter = KeyValuePair<SetupOptionType>;
+
+    struct Token
+    {
+        enum class AliasType : std::uint64_t
+        {
+            kDelete = 0x0,
+            kRegister = 0x1,
+            kUseAlias = 0x2,
+            kUseValue = 0x3,
+        };
+
+        AliasType alias_type{ AliasType::kUseValue };
+        std::optional<std::uint64_t> token_alias;
+        std::optional<std::uint64_t> token_type;
+        Bytes token_value;
+
+        bool operator==(const Token&) const = default;
+    };
+
+    inline Bytes& operator<<(Bytes& buffer, const Token& token)
+    {
+        buffer << UintVar(static_cast<std::uint64_t>(token.alias_type));
+        switch (token.alias_type) {
+            case Token::AliasType::kDelete:
+            case Token::AliasType::kUseAlias:
+                buffer << UintVar(token.token_alias.value());
+                break;
+            case Token::AliasType::kRegister:
+                buffer << UintVar(token.token_alias.value());
+                buffer << UintVar(token.token_type.value());
+                AppendBytes(buffer, token.token_value);
+                break;
+            case Token::AliasType::kUseValue:
+                buffer << UintVar(token.token_type.value());
+                AppendBytes(buffer, token.token_value);
+                break;
+        }
+        return buffer;
+    }
+
+    inline BytesSpan operator>>(BytesSpan buffer, Token& token)
+    {
+        std::uint64_t alias_type = 0;
+        buffer = buffer >> alias_type;
+        token.alias_type = static_cast<Token::AliasType>(alias_type);
+
+        switch (token.alias_type) {
+            case Token::AliasType::kDelete:
+            case Token::AliasType::kUseAlias: {
+                std::uint64_t alias = 0;
+                buffer = buffer >> alias;
+                token.token_alias = alias;
+                break;
+            }
+            case Token::AliasType::kRegister: {
+                std::uint64_t alias = 0;
+                std::uint64_t type = 0;
+                buffer = buffer >> alias;
+                buffer = buffer >> type;
+                token.token_alias = alias;
+                token.token_type = type;
+                token.token_value.assign(buffer.begin(), buffer.end());
+                buffer = buffer.subspan(buffer.size());
+                break;
+            }
+            case Token::AliasType::kUseValue: {
+                std::uint64_t type = 0;
+                buffer = buffer >> type;
+                token.token_type = type;
+                token.token_value.assign(buffer.begin(), buffer.end());
+                buffer = buffer.subspan(buffer.size());
+                break;
+            }
+            default:
+                throw ProtocolViolationException("Invalid AUTHORIZATION_TOKEN alias type");
+        }
+        return buffer;
+    }
 
     enum struct GroupOrder : uint8_t
     {

--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -24,6 +24,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <concepts>
 #include <map>
 #include <span>
 #include <string>
@@ -1121,6 +1122,19 @@ namespace quicr {
 
             (msg.Append(args), ...);
 
+            SendCtrlMsg(conn_ctx, data_ctx_id, msg.ToBytes());
+        }
+
+        template<typename Msg>
+            requires requires(const Msg& m) {
+                { Msg::kType } -> std::convertible_to<std::uint64_t>;
+                { m.Encode() } -> std::same_as<Bytes>;
+            }
+        void SendCtrlMsg(const ConnectionContext& conn_ctx, DataContextId data_ctx_id, const Msg& message)
+        {
+            messages::Message msg = messages::Message{}.PrependType(Msg::kType).ReserveLength();
+            const auto payload = message.Encode();
+            msg.Append(std::span<const std::uint8_t>{ payload });
             SendCtrlMsg(conn_ctx, data_ctx_id, msg.ToBytes());
         }
 

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -360,7 +360,6 @@ namespace quicr {
         } else {
             setup_options.Add(SetupOptionType::kEndpointId, server_config_.endpoint_id);
         }
-
         SendCtrlMsg(conn_ctx, conn_ctx.tx_ctrl_data_ctx_id.value(), ControlMessageType::kSetup, setup_options);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Setup (error={})", e.what());
@@ -3374,7 +3373,7 @@ namespace quicr {
                 return true;
             }
             case messages::ControlMessageType::kSetup: {
-                const auto setup = messages::control::Setup{ msg_bytes };
+                const auto setup = messages::control::Setup::Decode(msg_bytes);
 
                 std::string endpoint_id = "Unknown Endpoint ID";
                 if (auto endpoint =

--- a/test/moq_ctrl_messages.cpp
+++ b/test/moq_ctrl_messages.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include "quicr/detail/control_messages.h"
 #include "quicr/detail/message.h"
 #include "quicr/detail/messages.h"
 
@@ -20,6 +21,65 @@ static Bytes
 FromASCII(const std::string& ascii)
 {
     return std::vector<uint8_t>(ascii.begin(), ascii.end());
+}
+
+TEST_CASE("Token round-trips for each alias type")
+{
+    using namespace quicr::messages;
+
+    SUBCASE("USE_VALUE carries type and value")
+    {
+        const Token in{ .alias_type = Token::AliasType::kUseValue,
+                        .token_alias = std::nullopt,
+                        .token_type = 7,
+                        .token_value = FromASCII("secret") };
+        Bytes buffer;
+        buffer << in;
+        BytesSpan span{ buffer };
+        Token out{};
+        span = span >> out;
+        CHECK(span.empty());
+        CHECK(out == in);
+    }
+
+    SUBCASE("REGISTER carries alias, type and value")
+    {
+        const Token in{ .alias_type = Token::AliasType::kRegister,
+                        .token_alias = 3,
+                        .token_type = 7,
+                        .token_value = FromASCII("secret") };
+        Bytes buffer;
+        buffer << in;
+        BytesSpan span{ buffer };
+        Token out{};
+        span = span >> out;
+        CHECK(span.empty());
+        CHECK(out == in);
+    }
+
+    SUBCASE("DELETE carries only an alias")
+    {
+        const Token in{ .alias_type = Token::AliasType::kDelete, .token_alias = 3 };
+        Bytes buffer;
+        buffer << in;
+        BytesSpan span{ buffer };
+        Token out{};
+        span = span >> out;
+        CHECK(span.empty());
+        CHECK(out == in);
+    }
+
+    SUBCASE("USE_ALIAS carries only an alias")
+    {
+        const Token in{ .alias_type = Token::AliasType::kUseAlias, .token_alias = 5 };
+        Bytes buffer;
+        buffer << in;
+        BytesSpan span{ buffer };
+        Token out{};
+        span = span >> out;
+        CHECK(span.empty());
+        CHECK(out == in);
+    }
 }
 
 const TrackNamespace kTrackNamespaceConf{ FromASCII("conf.example.com"), FromASCII("conf"), FromASCII("1") };
@@ -560,4 +620,773 @@ TEST_CASE("Parameters - Filters")
 
     auto recv_filter = recv_params.GetFilter(FilterType::kTrackFilter);
     CHECK_EQ(recv_filter, filter);
+}
+
+TEST_CASE("ValidateParameters enforces the allow-list")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    SUBCASE("a parameter outside the allow-list throws")
+    {
+        const Parameters params{ { ParameterType::kForward, Bytes{ 0x1 } } };
+        CHECK_THROWS_AS(ValidateParameters(params, { ParameterType::kExpires }), ProtocolViolationException);
+    }
+
+    SUBCASE("an unexpected duplicate throws")
+    {
+        const Parameters params{ { ParameterType::kForward, Bytes{ 0x1 } }, { ParameterType::kForward, Bytes{ 0x1 } } };
+        CHECK_THROWS_AS(ValidateParameters(params, { ParameterType::kForward }), ProtocolViolationException);
+    }
+
+    SUBCASE("a repeated AUTHORIZATION_TOKEN is allowed")
+    {
+        const Parameters params{ { ParameterType::kAuthorizationToken, Bytes{ 0x3, 0x1 } },
+                                 { ParameterType::kAuthorizationToken, Bytes{ 0x3, 0x2 } } };
+        CHECK_NOTHROW(ValidateParameters(params, { ParameterType::kAuthorizationToken }));
+    }
+}
+
+TEST_CASE("Subscribe resolves parameters and defaults")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    auto make_payload = [](const Parameters& params) {
+        Bytes payload;
+        payload << RequestID{ 1 };
+        payload << kTrackNamespaceConf;
+        payload << kTrackNameAliceVideo;
+        payload << params;
+        return payload;
+    };
+
+    SUBCASE("defaults apply when parameters omitted")
+    {
+        const auto payload = make_payload(Parameters{});
+        const auto msg = Subscribe::Decode(BytesSpan{ payload });
+        CHECK(msg.rendezvous_timeout == 0);
+        CHECK(msg.subscriber_priority == 128);
+        CHECK(msg.forward == true);
+        CHECK_FALSE(msg.group_order.has_value());
+        CHECK_FALSE(msg.object_delivery_timeout.has_value());
+        CHECK_FALSE(msg.new_group_request.has_value());
+        CHECK(msg.auth_tokens.empty());
+    }
+
+    SUBCASE("present scalar parameters are resolved")
+    {
+        Parameters params;
+        params.Add(ParameterType::kRendezvousTimeout, std::uint64_t{ 50 });
+        params.Add(ParameterType::kNewGroupRequest, std::uint64_t{ 9 });
+        const auto payload = make_payload(params);
+        const auto msg = Subscribe::Decode(BytesSpan{ payload });
+        CHECK(msg.rendezvous_timeout == 50);
+        REQUIRE(msg.new_group_request.has_value());
+        CHECK(msg.new_group_request.value() == 9);
+    }
+
+    SUBCASE("a FETCH-only parameter is rejected")
+    {
+        Parameters params;
+        params.Add(ParameterType::kFillTimeout, std::uint64_t{ 10 });
+        const auto payload = make_payload(params);
+        CHECK_THROWS_AS(Subscribe::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    }
+}
+
+TEST_CASE("Subscribe round-trips through Encode and Decode")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    auto check_round_trip = [](const Subscribe& sent) {
+        const auto bytes = sent.Encode();
+        const auto received = Subscribe::Decode(BytesSpan{ bytes });
+        CHECK(received.request_id == sent.request_id);
+        CHECK(received.track_namespace == sent.track_namespace);
+        CHECK(received.track_name == sent.track_name);
+        CHECK(received.object_delivery_timeout == sent.object_delivery_timeout);
+        CHECK(received.subgroup_delivery_timeout == sent.subgroup_delivery_timeout);
+        CHECK(received.rendezvous_timeout == sent.rendezvous_timeout);
+        CHECK(received.subscriber_priority == sent.subscriber_priority);
+        CHECK(received.group_order == sent.group_order);
+        CHECK(received.subscription_filter == sent.subscription_filter);
+        CHECK(received.forward == sent.forward);
+        CHECK(received.new_group_request == sent.new_group_request);
+    };
+
+    SUBCASE("all-default fields survive omit-on-default")
+    {
+        check_round_trip(Subscribe{
+          .request_id = RequestID{ 7 },
+          .track_namespace = kTrackNamespaceConf,
+          .track_name = kTrackNameAliceVideo,
+          .rendezvous_timeout = 0,
+          .subscriber_priority = 128,
+          .subscription_filter = std::monostate{},
+          .forward = true,
+        });
+    }
+
+    SUBCASE("non-default fields are carried explicitly")
+    {
+        check_round_trip(Subscribe{
+          .request_id = RequestID{ 7 },
+          .track_namespace = kTrackNamespaceConf,
+          .track_name = kTrackNameAliceVideo,
+          .object_delivery_timeout = std::uint64_t{ 100 },
+          .subgroup_delivery_timeout = std::uint64_t{ 200 },
+          .rendezvous_timeout = 50,
+          .subscriber_priority = 64,
+          .group_order = GroupOrder::kDescending,
+          .subscription_filter = TrackFilter{ .property_type = 1, .max_tracks_selected = 2, .timeout = 3 },
+          .forward = false,
+          .new_group_request = std::uint64_t{ 9 },
+        });
+    }
+}
+
+TEST_CASE("SubscribeTracks resolves FORWARD and auth tokens")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    auto make_payload = [](const Parameters& params) {
+        Bytes payload;
+        payload << RequestID{ 1 };
+        payload << kTrackNamespaceConf;
+        payload << params;
+        return payload;
+    };
+
+    SUBCASE("FORWARD defaults to true")
+    {
+        const auto payload = make_payload(Parameters{});
+        const auto msg = SubscribeTracks::Decode(BytesSpan{ payload });
+        CHECK(msg.forward == true);
+        CHECK(msg.auth_tokens.empty());
+    }
+
+    SUBCASE("a non-token, non-forward parameter is rejected")
+    {
+        Parameters params;
+        params.Add(ParameterType::kExpires, std::uint64_t{ 1 });
+        const auto payload = make_payload(params);
+        CHECK_THROWS_AS(SubscribeTracks::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    }
+}
+
+TEST_CASE("Publish resolves parameters and defaults")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    auto make_payload = [](const Parameters& params) {
+        Bytes payload;
+        payload << RequestID{ 1 };
+        payload << kTrackNamespaceConf;
+        payload << kTrackNameAliceVideo;
+        payload << TrackAlias{ 0xA11CE };
+        payload << params;
+        payload << TrackExtensions{}; // track_properties, empty
+        return payload;
+    };
+
+    SUBCASE("defaults apply when omitted")
+    {
+        const auto payload = make_payload(Parameters{});
+        const auto msg = Publish::Decode(BytesSpan{ payload });
+        CHECK(msg.forward == true);
+        CHECK_FALSE(msg.expires.has_value());
+        CHECK_FALSE(msg.largest_object.has_value());
+        CHECK(msg.auth_tokens.empty());
+    }
+
+    SUBCASE("EXPIRES of 0 resolves to no expiry")
+    {
+        Parameters params;
+        params.Add(ParameterType::kExpires, std::uint64_t{ 0 });
+        const auto payload = make_payload(params);
+        const auto msg = Publish::Decode(BytesSpan{ payload });
+        CHECK_FALSE(msg.expires.has_value());
+    }
+
+    SUBCASE("non-zero EXPIRES is resolved")
+    {
+        Parameters params;
+        params.Add(ParameterType::kExpires, std::uint64_t{ 5000 });
+        const auto payload = make_payload(params);
+        const auto msg = Publish::Decode(BytesSpan{ payload });
+        REQUIRE(msg.expires.has_value());
+        CHECK(msg.expires.value() == 5000);
+    }
+
+    SUBCASE("LARGEST_OBJECT is resolved")
+    {
+        Parameters params;
+        Location loc{ .group = 10, .object = 20 };
+        params.Add(ParameterType::kLargestObject, loc);
+        const auto payload = make_payload(params);
+        const auto msg = Publish::Decode(BytesSpan{ payload });
+        REQUIRE(msg.largest_object.has_value());
+        CHECK(msg.largest_object.value().group == 10);
+        CHECK(msg.largest_object.value().object == 20);
+    }
+
+    SUBCASE("FORWARD is resolved")
+    {
+        Parameters params;
+        params.Add(ParameterType::kForward, std::uint8_t{ 0 });
+        const auto payload = make_payload(params);
+        const auto msg = Publish::Decode(BytesSpan{ payload });
+        CHECK(msg.forward == false);
+    }
+
+    SUBCASE("a SUBSCRIBE-only parameter is rejected")
+    {
+        Parameters params;
+        params.Add(ParameterType::kRendezvousTimeout, std::uint64_t{ 10 });
+        const auto payload = make_payload(params);
+        CHECK_THROWS_AS(Publish::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    }
+}
+
+TEST_CASE("StandaloneFetch resolves parameters and defaults")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    auto make_payload = [](const Parameters& params) {
+        Bytes payload;
+        payload << RequestID{ 1 };
+        payload << FetchType::kStandalone;
+        payload << kTrackNamespaceConf;
+        payload << kTrackNameAliceVideo;
+        payload << Location{ 0, 0 };
+        payload << Location{ 1, 0 };
+        payload << params;
+        return payload;
+    };
+
+    SUBCASE("defaults apply when omitted")
+    {
+        const auto payload = make_payload(Parameters{});
+        const auto msg = StandaloneFetch::Decode(BytesSpan{ payload });
+        CHECK(msg.subscriber_priority == 128);
+        CHECK(msg.group_order == GroupOrder::kAscending);
+        CHECK_FALSE(msg.fill_timeout.has_value());
+        CHECK(msg.auth_tokens.empty());
+    }
+
+    SUBCASE("FILL_TIMEOUT is resolved")
+    {
+        Parameters params;
+        params.Add(ParameterType::kFillTimeout, std::uint64_t{ 250 });
+        const auto payload = make_payload(params);
+        const auto msg = StandaloneFetch::Decode(BytesSpan{ payload });
+        REQUIRE(msg.fill_timeout.has_value());
+        CHECK(msg.fill_timeout.value() == 250);
+    }
+
+    SUBCASE("SUBSCRIBER_PRIORITY is resolved")
+    {
+        Parameters params;
+        params.Add(ParameterType::kSubscriberPriority, std::uint8_t{ 64 });
+        const auto payload = make_payload(params);
+        const auto msg = StandaloneFetch::Decode(BytesSpan{ payload });
+        CHECK(msg.subscriber_priority == 64);
+    }
+
+    SUBCASE("GROUP_ORDER is resolved")
+    {
+        Parameters params;
+        params.Add(ParameterType::kGroupOrder, std::uint8_t{ static_cast<std::uint8_t>(GroupOrder::kDescending) });
+        const auto payload = make_payload(params);
+        const auto msg = StandaloneFetch::Decode(BytesSpan{ payload });
+        CHECK(msg.group_order == GroupOrder::kDescending);
+    }
+
+    SUBCASE("AUTH_TOKEN is collected")
+    {
+        Parameters params;
+        Token token{ .alias_type = Token::AliasType::kUseValue, .token_type = 7, .token_value = FromASCII("secret") };
+        params.Add(ParameterType::kAuthorizationToken, token);
+        const auto payload = make_payload(params);
+        const auto msg = StandaloneFetch::Decode(BytesSpan{ payload });
+        REQUIRE(msg.auth_tokens.size() == 1);
+        CHECK(msg.auth_tokens[0] == token);
+    }
+}
+
+TEST_CASE("JoiningFetch resolves parameters and defaults")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    auto make_payload = [](const Parameters& params) {
+        Bytes payload;
+        payload << RequestID{ 1 };
+        payload << FetchType::kRelativeJoiningFetch;
+        payload << RequestID{ 2 };
+        payload << std::uint64_t{ 5 };
+        payload << params;
+        return payload;
+    };
+
+    SUBCASE("defaults apply when omitted")
+    {
+        const auto payload = make_payload(Parameters{});
+        const auto msg = JoiningFetch::Decode(BytesSpan{ payload });
+        CHECK(msg.subscriber_priority == 128);
+        CHECK(msg.group_order == GroupOrder::kAscending);
+        CHECK_FALSE(msg.fill_timeout.has_value());
+        CHECK(msg.auth_tokens.empty());
+    }
+
+    SUBCASE("present parameters are resolved")
+    {
+        Parameters params;
+        params.Add(ParameterType::kFillTimeout, std::uint64_t{ 250 });
+        params.Add(ParameterType::kGroupOrder, std::uint8_t{ static_cast<std::uint8_t>(GroupOrder::kDescending) });
+        const auto payload = make_payload(params);
+        const auto msg = JoiningFetch::Decode(BytesSpan{ payload });
+        REQUIRE(msg.fill_timeout.has_value());
+        CHECK(msg.fill_timeout.value() == 250);
+        CHECK(msg.group_order == GroupOrder::kDescending);
+    }
+}
+
+TEST_CASE("RequestUpdate leaves omitted parameters unset")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    auto make_payload = [](const Parameters& params) {
+        Bytes payload;
+        payload << RequestID{ 1 };
+        payload << params;
+        return payload;
+    };
+
+    SUBCASE("all parameters optional when omitted")
+    {
+        const auto payload = make_payload(Parameters{});
+        const auto msg = RequestUpdate::Decode(BytesSpan{ payload });
+        CHECK_FALSE(msg.subscriber_priority.has_value());
+        CHECK_FALSE(msg.forward.has_value());
+        CHECK_FALSE(msg.new_group_request.has_value());
+        CHECK_FALSE(msg.track_namespace_prefix.has_value());
+        CHECK(msg.auth_tokens.empty());
+    }
+
+    SUBCASE("present FORWARD resolves to a set optional")
+    {
+        Parameters params;
+        params.Add(ParameterType::kForward, std::uint8_t{ 0 });
+        const auto payload = make_payload(params);
+        const auto msg = RequestUpdate::Decode(BytesSpan{ payload });
+        REQUIRE(msg.forward.has_value());
+        CHECK(msg.forward.value() == false);
+    }
+
+    SUBCASE("present scalar parameters resolve to set optionals")
+    {
+        Parameters params;
+        params.Add(ParameterType::kDeliveryTimeout, std::uint64_t{ 1500 });
+        params.Add(ParameterType::kSubscriberPriority, std::uint8_t{ 64 });
+        const auto payload = make_payload(params);
+        const auto msg = RequestUpdate::Decode(BytesSpan{ payload });
+        REQUIRE(msg.object_delivery_timeout.has_value());
+        CHECK(msg.object_delivery_timeout.value() == 1500);
+        REQUIRE(msg.subscriber_priority.has_value());
+        CHECK(msg.subscriber_priority.value() == 64);
+    }
+}
+
+TEST_CASE("SubscribeOk resolves EXPIRES and LARGEST_OBJECT")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    auto make_payload = [](const Parameters& params) {
+        Bytes payload;
+        payload << TrackAlias{ 0xA11CE };
+        payload << params;
+        payload << TrackExtensions{};
+        return payload;
+    };
+
+    SUBCASE("omitted parameters are unset")
+    {
+        const auto payload = make_payload(Parameters{});
+        const auto msg = SubscribeOk::Decode(BytesSpan{ payload });
+        CHECK_FALSE(msg.expires.has_value());
+        CHECK_FALSE(msg.largest_object.has_value());
+    }
+
+    SUBCASE("non-zero EXPIRES is resolved")
+    {
+        Parameters params;
+        params.Add(ParameterType::kExpires, std::uint64_t{ 1234 });
+        const auto payload = make_payload(params);
+        const auto msg = SubscribeOk::Decode(BytesSpan{ payload });
+        REQUIRE(msg.expires.has_value());
+        CHECK(msg.expires.value() == 1234);
+    }
+
+    SUBCASE("EXPIRES of 0 resolves to no expiry")
+    {
+        Parameters params;
+        params.Add(ParameterType::kExpires, std::uint64_t{ 0 });
+        const auto payload = make_payload(params);
+        const auto msg = SubscribeOk::Decode(BytesSpan{ payload });
+        CHECK_FALSE(msg.expires.has_value());
+    }
+
+    SUBCASE("LARGEST_OBJECT is resolved")
+    {
+        Parameters params;
+        Location loc{ .group = 99, .object = 123 };
+        params.Add(ParameterType::kLargestObject, loc);
+        const auto payload = make_payload(params);
+        const auto msg = SubscribeOk::Decode(BytesSpan{ payload });
+        REQUIRE(msg.largest_object.has_value());
+        CHECK(msg.largest_object.value().group == 99);
+        CHECK(msg.largest_object.value().object == 123);
+    }
+
+    SUBCASE("invalid parameter is rejected")
+    {
+        Parameters params;
+        params.Add(ParameterType::kForward, std::uint8_t{ 1 });
+        const auto payload = make_payload(params);
+        CHECK_THROWS_AS(SubscribeOk::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    }
+}
+
+TEST_CASE("Auth-token-only messages collect tokens and reject others")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    Parameters with_token;
+    Token token{ .alias_type = Token::AliasType::kUseValue, .token_type = 7, .token_value = FromASCII("sec") };
+    with_token.Add(ParameterType::kAuthorizationToken, token);
+
+    SUBCASE("TrackStatus collects the token")
+    {
+        Bytes payload;
+        payload << RequestID{ 1 } << kTrackNamespaceConf << kTrackNameAliceVideo << with_token;
+        const auto msg = TrackStatus::Decode(BytesSpan{ payload });
+        REQUIRE(msg.auth_tokens.size() == 1);
+        CHECK(msg.auth_tokens[0] == token);
+    }
+
+    SUBCASE("PublishNamespace rejects a non-token parameter")
+    {
+        Parameters bad;
+        bad.Add(ParameterType::kForward, std::uint8_t{ 1 });
+        Bytes payload;
+        payload << RequestID{ 1 } << kTrackNamespaceConf << bad;
+        CHECK_THROWS_AS(PublishNamespace::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    }
+
+    SUBCASE("SubscribeNamespace collects the token")
+    {
+        Bytes payload;
+        payload << RequestID{ 1 } << kTrackNamespaceConf << with_token;
+        const auto msg = SubscribeNamespace::Decode(BytesSpan{ payload });
+        REQUIRE(msg.auth_tokens.size() == 1);
+        CHECK(msg.auth_tokens[0] == token);
+    }
+}
+
+TEST_CASE("OK messages have distinct parameter allow-lists")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    auto make_payload = [](const Parameters& params) {
+        Bytes payload;
+        payload << params;
+        payload << TrackExtensions{};
+        return payload;
+    };
+
+    SUBCASE("PublishOk resolves its defaults")
+    {
+        const auto payload = make_payload(Parameters{});
+        const auto msg = PublishOk::Decode(BytesSpan{ payload });
+        CHECK(msg.subscriber_priority == 128);
+        CHECK(msg.forward == true);
+        CHECK_FALSE(msg.expires.has_value());
+    }
+
+    SUBCASE("TrackStatusOk rejects EXPIRES")
+    {
+        Parameters params;
+        params.Add(ParameterType::kExpires, std::uint64_t{ 1 });
+        const auto payload = make_payload(params);
+        CHECK_THROWS_AS(TrackStatusOk::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    }
+
+    SUBCASE("PublishNamespaceOk accepts no parameters")
+    {
+        Parameters params;
+        params.Add(ParameterType::kForward, std::uint8_t{ 1 });
+        const auto payload = make_payload(params);
+        CHECK_THROWS_AS(PublishNamespaceOk::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    }
+
+    SUBCASE("RequestUpdateOk resolves EXPIRES and LARGEST_OBJECT")
+    {
+        Parameters params;
+        params.Add(ParameterType::kExpires, std::uint64_t{ 42 });
+        const auto payload = make_payload(params);
+        const auto msg = RequestUpdateOk::Decode(BytesSpan{ payload });
+        REQUIRE(msg.expires.has_value());
+        CHECK(msg.expires.value() == 42);
+        CHECK_FALSE(msg.largest_object.has_value());
+    }
+}
+
+TEST_CASE("REQUEST_OK messages that MUST be empty reject Track Properties (§10.5)")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    // A REQUEST_OK with empty parameters followed by a non-empty Track Properties block.
+    Bytes payload;
+    payload << Parameters{};
+    payload << TrackExtensions{}.Add(ExtensionType::kDeliveryTimeout, std::uint64_t{ 0 });
+
+    // Only TRACK_STATUS_OK is permitted to carry properties; every other REQUEST_OK must reject them.
+    CHECK_NOTHROW(TrackStatusOk::Decode(BytesSpan{ payload }));
+    CHECK_THROWS_AS(PublishOk::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    CHECK_THROWS_AS(RequestUpdateOk::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    CHECK_THROWS_AS(PublishNamespaceOk::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    CHECK_THROWS_AS(SubscribeNamespaceOk::Decode(BytesSpan{ payload }), ProtocolViolationException);
+    CHECK_THROWS_AS(SubscribeTracksOk::Decode(BytesSpan{ payload }), ProtocolViolationException);
+}
+
+TEST_CASE("AUTHORIZATION_TOKEN may repeat in a single message")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    const Token first{ .alias_type = Token::AliasType::kUseValue, .token_type = 7, .token_value = FromASCII("a") };
+    const Token second{ .alias_type = Token::AliasType::kUseValue, .token_type = 7, .token_value = FromASCII("b") };
+
+    Parameters params;
+    params.Add(ParameterType::kAuthorizationToken, first);
+    params.Add(ParameterType::kAuthorizationToken, second);
+
+    Bytes payload;
+    payload << RequestID{ 1 } << kTrackNamespaceConf << params;
+    const auto msg = SubscribeNamespace::Decode(BytesSpan{ payload });
+    REQUIRE(msg.auth_tokens.size() == 2);
+    CHECK(msg.auth_tokens[0] == first);
+    CHECK(msg.auth_tokens[1] == second);
+}
+
+TEST_CASE("Control messages round-trip through Encode and Decode")
+{
+    using namespace quicr::messages;
+    using namespace quicr::messages::control;
+
+    const Token token{ .alias_type = Token::AliasType::kUseValue, .token_type = 7, .token_value = FromASCII("secret") };
+    const Filter filter = TrackFilter{ .property_type = 1, .max_tracks_selected = 2, .timeout = 3 };
+
+    // Decoding then re-encoding must reproduce the exact bytes Encode produced: this exercises
+    // both directions including omit-on-default, since the source bytes are already canonical.
+    auto is_idempotent = [](const auto& sent) {
+        const auto bytes = sent.Encode();
+        const auto round_tripped = std::remove_cvref_t<decltype(sent)>::Decode(BytesSpan{ bytes }).Encode();
+        return bytes == round_tripped;
+    };
+
+    SUBCASE("Publish")
+    {
+        CHECK(is_idempotent(Publish{
+          .request_id = RequestID{ 7 },
+          .track_namespace = kTrackNamespaceConf,
+          .track_name = kTrackNameAliceVideo,
+          .track_alias = TrackAlias{ 0xA11CE },
+          .auth_tokens = { token },
+          .expires = std::uint64_t{ 1234 },
+          .largest_object = Location{ .group = 9, .object = 4 },
+          .forward = false,
+          .track_properties = TrackExtensions{},
+        }));
+    }
+
+    SUBCASE("StandaloneFetch")
+    {
+        CHECK(is_idempotent(StandaloneFetch{
+          .request_id = RequestID{ 7 },
+          .fetch_type = FetchType::kStandalone,
+          .track_namespace = kTrackNamespaceConf,
+          .track_name = kTrackNameAliceVideo,
+          .start = Location{ .group = 0, .object = 0 },
+          .end = Location{ .group = 1, .object = 0 },
+          .auth_tokens = { token },
+          .fill_timeout = std::uint64_t{ 250 },
+          .subscriber_priority = 64,
+          .group_order = GroupOrder::kDescending,
+        }));
+    }
+
+    SUBCASE("JoiningFetch")
+    {
+        CHECK(is_idempotent(JoiningFetch{
+          .request_id = RequestID{ 7 },
+          .fetch_type = FetchType::kRelativeJoiningFetch,
+          .joining_request_id = RequestID{ 2 },
+          .joining_start = 5,
+          .auth_tokens = { token },
+          .fill_timeout = std::uint64_t{ 250 },
+          .subscriber_priority = 64,
+          .group_order = GroupOrder::kDescending,
+        }));
+    }
+
+    SUBCASE("RequestUpdate carries the three-state FORWARD and filter")
+    {
+        CHECK(is_idempotent(RequestUpdate{
+          .request_id = RequestID{ 7 },
+          .auth_tokens = { token },
+          .object_delivery_timeout = std::uint64_t{ 1500 },
+          .subscriber_priority = std::uint8_t{ 64 },
+          .subscription_filter = filter,
+          .forward = false,
+          .new_group_request = std::uint64_t{ 9 },
+        }));
+
+        // FORWARD omitted means "unchanged" and must stay absent through a round-trip.
+        const auto decoded = RequestUpdate::Decode(BytesSpan{ RequestUpdate{ .request_id = RequestID{ 7 } }.Encode() });
+        CHECK_FALSE(decoded.forward.has_value());
+        CHECK_FALSE(decoded.subscription_filter.has_value());
+    }
+
+    SUBCASE("SubscribeOk")
+    {
+        CHECK(is_idempotent(SubscribeOk{
+          .track_alias = TrackAlias{ 0xA11CE },
+          .expires = std::uint64_t{ 1234 },
+          .largest_object = Location{ .group = 99, .object = 123 },
+          .track_properties = TrackExtensions{},
+        }));
+    }
+
+    SUBCASE("PublishOk")
+    {
+        CHECK(is_idempotent(PublishOk{
+          .object_delivery_timeout = std::uint64_t{ 100 },
+          .subscriber_priority = 64,
+          .group_order = GroupOrder::kDescending,
+          .subscription_filter = filter,
+          .expires = std::uint64_t{ 1234 },
+          .forward = false,
+          .new_group_request = std::uint64_t{ 9 },
+        }));
+    }
+
+    SUBCASE("RequestUpdateOk")
+    {
+        CHECK(is_idempotent(RequestUpdateOk{
+          .expires = std::uint64_t{ 42 },
+          .largest_object = Location{ .group = 1, .object = 2 },
+        }));
+    }
+
+    SUBCASE("TrackStatusOk carries Track Properties")
+    {
+        CHECK(is_idempotent(TrackStatusOk{
+          .largest_object = Location{ .group = 1, .object = 2 },
+          .track_properties = TrackExtensions{},
+        }));
+    }
+
+    SUBCASE("auth-token-only messages")
+    {
+        CHECK(is_idempotent(PublishNamespace{
+          .request_id = RequestID{ 7 }, .track_namespace = kTrackNamespaceConf, .auth_tokens = { token } }));
+        CHECK(is_idempotent(SubscribeNamespace{
+          .request_id = RequestID{ 7 }, .track_namespace_prefix = kTrackNamespaceConf, .auth_tokens = { token } }));
+        CHECK(is_idempotent(TrackStatus{ .request_id = RequestID{ 7 },
+                                         .track_namespace = kTrackNamespaceConf,
+                                         .track_name = kTrackNameAliceVideo,
+                                         .auth_tokens = { token } }));
+        CHECK(is_idempotent(SubscribeTracks{ .request_id = RequestID{ 7 },
+                                             .track_namespace_prefix = kTrackNamespaceConf,
+                                             .auth_tokens = { token },
+                                             .forward = false }));
+    }
+
+    SUBCASE("empty OK messages")
+    {
+        CHECK(is_idempotent(PublishNamespaceOk{}));
+        CHECK(is_idempotent(SubscribeNamespaceOk{}));
+        CHECK(is_idempotent(SubscribeTracksOk{}));
+    }
+
+    SUBCASE("Setup")
+    {
+        KeyValuePairs setup_options;
+        setup_options.Add(SetupOptionType::kEndpointId, std::string{ "alice" });
+        CHECK(is_idempotent(Setup{ .setup_options = std::move(setup_options) }));
+    }
+
+    SUBCASE("GOAWAY variants")
+    {
+        CHECK(is_idempotent(RequestGoaway{ .new_session_uri = FromASCII("moq://relay"), .timeout = 5000 }));
+        CHECK(is_idempotent(
+          ControlGoaway{ .new_session_uri = FromASCII("moq://relay"), .timeout = 5000, .request_id = RequestID{ 3 } }));
+    }
+
+    SUBCASE("FetchOk")
+    {
+        CHECK(is_idempotent(FetchOk{
+          .end_of_track = 1,
+          .end_location = Location{ .group = 9, .object = 4 },
+          .parameters = Parameters{},
+          .track_properties = TrackExtensions{},
+        }));
+    }
+
+    SUBCASE("PublishDone")
+    {
+        CHECK(is_idempotent(PublishDone{
+          .status_code = PublishDoneStatus::kTrackEnded,
+          .stream_count = 12,
+          .error_reason = FromASCII("done"),
+        }));
+    }
+
+    SUBCASE("PublishBlocked, Namespace, NamespaceDone")
+    {
+        CHECK(is_idempotent(
+          PublishBlocked{ .track_namespace_suffix = kTrackNamespaceConf, .track_name = kTrackNameAliceVideo }));
+        CHECK(is_idempotent(Namespace{ .track_namespace_suffix = kTrackNamespaceConf }));
+        CHECK(is_idempotent(NamespaceDone{ .track_namespace_suffix = kTrackNamespaceConf }));
+    }
+
+    SUBCASE("RequestError without and with a redirect")
+    {
+        CHECK(is_idempotent(RequestError{
+          .error_code = ErrorCode::kDoesNotExist,
+          .retry_interval = 0,
+          .error_reason = FromASCII("nope"),
+          .redirect = std::nullopt,
+        }));
+        CHECK(is_idempotent(RequestError{
+          .error_code = static_cast<ErrorCode>(RequestError::kRedirectErrorCode),
+          .retry_interval = 0,
+          .error_reason = FromASCII("over there"),
+          .redirect = Redirect{ .connect_uri = FromASCII("moq://other"),
+                                .track_namespace = kTrackNamespaceConf,
+                                .track_name = kTrackNameAliceVideo },
+        }));
+    }
 }


### PR DESCRIPTION
- Add all message parameters as first-class citizens
- Encode functions to wire format
- Update SendCtrlMessage to support sending a typed messages