### PR TITLE
Initial REQUEST_OK rework

### DIFF
--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -1133,10 +1133,30 @@ namespace quicr {
         // Requests
         /*===================================================================*/
 
+        void SendTrackStatusOk(ConnectionContext& conn_ctx,
+                               DataContextId data_ctx_id,
+                               const std::optional<messages::Location>& largest_object,
+                               const messages::TrackExtensions& track_properties);
+
+        void SendSubscribeNamespaceOk(ConnectionContext& conn_ctx, DataContextId data_ctx_id);
+        void SendSubscribeTracksOk(ConnectionContext& conn_ctx, DataContextId data_ctx_id)
+        {
+            SendSubscribeNamespaceOk(conn_ctx, data_ctx_id);
+        }
+        void SendPublishNamespaceOk(ConnectionContext& conn_ctx, DataContextId data_ctx_id)
+        {
+            SendSubscribeNamespaceOk(conn_ctx, data_ctx_id);
+        }
+        void SendRequestUpdateOk(ConnectionContext& conn_ctx,
+                                 DataContextId data_ctx_id,
+                                 std::optional<std::uint64_t> expires,
+                                 const std::optional<messages::Location>& largest_object);
+
+        // Prefer the above typed overloads.
         void SendRequestOk(ConnectionContext& conn_ctx,
                            DataContextId data_ctx_id,
-                           messages::RequestID request_id,
-                           std::optional<messages::Location> largest_location = std::nullopt);
+                           const messages::Parameters& params,
+                           const messages::TrackExtensions& track_properties = {});
 
         void SendRequestUpdate(const ConnectionContext& conn_ctx,
                                DataContextId data_ctx_id,

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -2703,7 +2703,8 @@ namespace quicr {
 
         track_it->second.handler->RequestUpdate(request_id, params);
 
-        if (!track_it->second.handler->GetDataContextId().has_value()) {
+        const auto data_ctx_id = track_it->second.handler->GetDataContextId();
+        if (!data_ctx_id.has_value()) {
             SPDLOG_LOGGER_WARN(logger_,
                                "ResolveRequestUpdate missing handler data context conn_id: {} existing_id: {}",
                                connection_handle,
@@ -2712,8 +2713,7 @@ namespace quicr {
         }
 
         // TODO: Type the params in resolve, fill in here.
-        SendRequestUpdateOk(
-          conn_it->second, ResponseDataContext(conn_it->second, request_id), std::nullopt, std::nullopt);
+        SendRequestUpdateOk(conn_it->second, *data_ctx_id, std::nullopt, std::nullopt);
     }
 
     std::optional<DataContextId> Session::FindSubscribeNamespaceDataContext(const ConnectionContext& conn_ctx,
@@ -3126,7 +3126,16 @@ namespace quicr {
                 return true;
             }
             case messages::ControlMessageType::kRequestOk: {
-                const auto request_id = conn_ctx.request_id_by_data_ctx.at(data_ctx_id);
+                // What request is this for?
+                const auto req_it = conn_ctx.request_id_by_data_ctx.find(data_ctx_id);
+                if (req_it == conn_ctx.request_id_by_data_ctx.end()) {
+                    SPDLOG_LOGGER_WARN(logger_,
+                                       "Received REQUEST_OK for unknown request conn_id: {} data_ctx_ic: {}, ignored",
+                                       conn_ctx.connection_handle,
+                                       data_ctx_id);
+                }
+                const auto request_id = req_it->second;
+
                 const auto parameters = messages::Message::ParseField<messages::Parameters>(msg_bytes);
                 const auto track_properties = Message::ParseField<messages::TrackExtensions>(msg_bytes);
                 // TODO: If track properties exist on anything other than TRACK_STATUS_OK, protocol violation. We can't
@@ -3616,6 +3625,7 @@ namespace quicr {
                 conn_ctx.recv_req_id[request_id] = { .track_full_name = publish.track_full_name,
                                                      .track_hash = th,
                                                      .data_ctx_id = data_ctx_id };
+                conn_ctx.request_id_by_data_ctx[data_ctx_id] = request_id;
 
                 if (client_mode_) {
                     std::weak_ptr<SubscribeNamespaceHandler> sub_ns_handler;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -282,10 +282,11 @@ namespace quicr {
 
         switch (subscribe_response.reason_code) {
             case RequestResponse::ReasonCode::kOk: {
-                SendRequestOk(conn_it->second,
-                              ResponseDataContext(conn_it->second, request_id),
-                              request_id,
-                              subscribe_response.largest_location);
+                // TODO: TrackProperties should be in the subscribe_response.
+                SendTrackStatusOk(conn_it->second,
+                                  ResponseDataContext(conn_it->second, request_id),
+                                  subscribe_response.largest_location,
+                                  TrackExtensions());
                 break;
             }
             case RequestResponse::ReasonCode::kDoesNotExist:
@@ -369,17 +370,45 @@ namespace quicr {
         throw e;
     }
 
+    void Session::SendTrackStatusOk(ConnectionContext& conn_ctx,
+                                    DataContextId data_ctx_id,
+                                    const std::optional<messages::Location>& largest_object,
+                                    const TrackExtensions& track_properties)
+    {
+        SendRequestOk(conn_ctx,
+                      data_ctx_id,
+                      Parameters().AddOptional(ParameterType::kLargestObject, largest_object),
+                      track_properties);
+    }
+
+    void Session::SendSubscribeNamespaceOk(ConnectionContext& conn_ctx, DataContextId data_ctx_id)
+    {
+        SendRequestOk(conn_ctx, data_ctx_id, {});
+    }
+
+    void Session::SendRequestUpdateOk(ConnectionContext& conn_ctx,
+                                      DataContextId data_ctx_id,
+                                      std::optional<std::uint64_t> expires,
+                                      const std::optional<messages::Location>& largest_object)
+    {
+        SendRequestOk(conn_ctx,
+                      data_ctx_id,
+                      Parameters()
+                        .AddOptional(ParameterType::kExpires, expires)
+                        .AddOptional(ParameterType::kLargestObject, largest_object));
+    }
+
     void Session::SendRequestOk(ConnectionContext& conn_ctx,
                                 DataContextId data_ctx_id,
-                                messages::RequestID request_id,
-                                std::optional<Location> largest_location)
+                                const messages::Parameters& params,
+                                const TrackExtensions& track_properties)
     try {
-        auto params = Parameters{}.AddOptional(ParameterType::kLargestObject, largest_location);
+        SPDLOG_LOGGER_DEBUG(logger_,
+                            "Sending REQUEST_OK to conn_id: {} request_id: {}",
+                            conn_ctx.connection_handle,
+                            conn_ctx.request_id_by_data_ctx.at(data_ctx_id));
 
-        SPDLOG_LOGGER_DEBUG(
-          logger_, "Sending REQUEST_OK to conn_id: {} request_id: {}", conn_ctx.connection_handle, request_id);
-
-        SendCtrlMsg(conn_ctx, data_ctx_id, ControlMessageType::kRequestOk, UintVar(request_id), params);
+        SendCtrlMsg(conn_ctx, data_ctx_id, ControlMessageType::kRequestOk, params, track_properties);
     } catch (const std::exception& e) {
         SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending REQUEST_OK (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
@@ -2478,7 +2507,7 @@ namespace quicr {
             return;
         }
 
-        SendRequestOk(conn_it->second, data_ctx_id, request_id);
+        SendSubscribeNamespaceOk(conn_it->second, data_ctx_id);
 
         // Fan out PUBLISH_NAMESPACE for matching namespaces.
         for (const auto& name_space : response.namespaces) {
@@ -2510,7 +2539,7 @@ namespace quicr {
             return;
         }
 
-        SendRequestOk(conn_it->second, data_ctx_id, request_id);
+        SendSubscribeTracksOk(conn_it->second, data_ctx_id);
 
         // Fan out PUBLISH_NAMESPACE for matching namespaces.
         for (const auto& name_space : response.namespaces) {
@@ -2610,7 +2639,7 @@ namespace quicr {
                     response_data_ctx_id = *pub_ns_it->second.handler->GetDataContextId();
                 }
 
-                SendRequestOk(conn_it->second, response_data_ctx_id, request_id);
+                SendPublishNamespaceOk(conn_it->second, response_data_ctx_id);
 
                 fanout_subscribe_namespace_requestors();
                 break;
@@ -2682,7 +2711,9 @@ namespace quicr {
             return;
         }
 
-        SendRequestOk(conn_it->second, *track_it->second.handler->GetDataContextId(), request_id);
+        // TODO: Type the params in resolve, fill in here.
+        SendRequestUpdateOk(
+          conn_it->second, ResponseDataContext(conn_it->second, request_id), std::nullopt, std::nullopt);
     }
 
     std::optional<DataContextId> Session::FindSubscribeNamespaceDataContext(const ConnectionContext& conn_ctx,
@@ -3095,8 +3126,11 @@ namespace quicr {
                 return true;
             }
             case messages::ControlMessageType::kRequestOk: {
-                const auto request_id = messages::Message::ParseField<std::uint64_t>(msg_bytes);
+                const auto request_id = conn_ctx.request_id_by_data_ctx.at(data_ctx_id);
                 const auto parameters = messages::Message::ParseField<messages::Parameters>(msg_bytes);
+                const auto track_properties = Message::ParseField<messages::TrackExtensions>(msg_bytes);
+                // TODO: If track properties exist on anything other than TRACK_STATUS_OK, protocol violation. We can't
+                // tell here.
 
                 if (client_mode_) {
                     auto track_it = conn_ctx.request_handlers.find(request_id);


### PR DESCRIPTION
Initial pass of draft 18 REQUEST_OK, with typed variants to encode the parameter rules. More work to be done here, but it should be no worse than the current behaviour. 