### PR TITLE
New routing for REQUEST_OK/UPDATE

### DIFF
--- a/cmd/examples/client.cpp
+++ b/cmd/examples/client.cpp
@@ -650,26 +650,6 @@ class MyClient : public quicr::Client
                       { joining_start, std::nullopt });
     }
 
-    void RequestOkReceived(quicr::ConnectionHandle,
-                           uint64_t request_id,
-                           std::optional<quicr::messages::Location> largest_location) override
-    {
-        SPDLOG_INFO("Request track status OK response request_id: {} largest group: {} object: {}",
-                    request_id,
-                    largest_location.has_value() ? largest_location->group : 0,
-                    largest_location.has_value() ? largest_location->object : 0);
-    }
-
-    void RequestErrorReceived(quicr::ConnectionHandle,
-                              uint64_t request_id,
-                              const quicr::RequestResponse& response) override
-    {
-        SPDLOG_INFO("Request track status response ERROR request_id: {} error: {} reason: {}",
-                    request_id,
-                    static_cast<int>(response.reason_code),
-                    response.error_reason.has_value() ? response.error_reason.value() : "");
-    }
-
     void PublishReceived(quicr::ConnectionHandle connection_handle,
                          uint64_t request_id,
                          const quicr::messages::PublishAttributes& publish_attributes,

--- a/include/quicr/detail/base_track_handler.h
+++ b/include/quicr/detail/base_track_handler.h
@@ -218,8 +218,18 @@ namespace quicr {
          */
         uint64_t GetConnectionId() const noexcept { return connection_handle_; };
 
-        virtual void RequestOk(uint64_t request_id, const messages::Parameters& params);
-        virtual void RequestUpdate(uint64_t request_id, const messages::Parameters& params);
+        /**
+         * Received an OK for this handler's request.
+         * @param params Parameters in the request.
+         */
+        virtual void RequestOkReceived(const messages::Parameters& params) = 0;
+
+        /**
+         * @brief Received an update for this handler's request.
+         * Implementations MUST call ResolveRequestUpdate to acknowledge the request.
+         * @param params The updated/new parameters for the request.
+         */
+        virtual void RequestUpdateReceived(const messages::Parameters& params) = 0;
 
         virtual void RequestError(messages::ErrorCode error_code, std::string reason);
 

--- a/include/quicr/publish_namespace_handler.h
+++ b/include/quicr/publish_namespace_handler.h
@@ -154,7 +154,9 @@ namespace quicr {
             SetStatus(Status::kError);
         }
 
-        void RequestOk(uint64_t, const messages::Parameters&) override { SetStatus(Status::kOk); }
+        void RequestOkReceived(const messages::Parameters&) override;
+
+        void RequestUpdateReceived(const messages::Parameters& params) override;
 
         void RequestError(messages::ErrorCode error_code, std::string reason) override
         {

--- a/include/quicr/publish_track_handler.h
+++ b/include/quicr/publish_track_handler.h
@@ -167,8 +167,8 @@ namespace quicr {
          */
         virtual void MetricsSampled(const PublishTrackMetrics& metrics);
 
-        void RequestUpdate(uint64_t request_id, const messages::Parameters& params) override;
-        void RequestOk(uint64_t request_id, const messages::Parameters& params) override;
+        void RequestUpdateReceived(const messages::Parameters& params) override;
+        void RequestOkReceived(const messages::Parameters& params) override;
 
         ///@}
 

--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -316,6 +316,18 @@ namespace quicr {
             std::optional<messages::ReasonPhrase> error_reason;
         };
 
+        struct RequestUpdateResponse
+        {
+            struct Error
+            {
+                const messages::ErrorCode error_code;
+                const std::chrono::milliseconds retry_interval;
+                const std::string reason;
+            };
+            const std::optional<Error> error;
+            const messages::Parameters params;
+        };
+
         // --BEGIN RESOLVE METHODS ---------------------------------------------------------------------------
         /** @name Resolve Methods
          *      Methods to accept or reject inbound requests. Most are used in server mode; `ResolveSubscribe()`
@@ -428,14 +440,12 @@ namespace quicr {
          * @brief Accept or reject a request update
          *
          * @param connection_handle     Source connection ID
-         * @param request_id            Request ID for the update
-         * @param existing_request_id   Existing request ID being updated
-         * @param params                Updated parameters
+         * @param request_id            Request being updated
+         * @param response              Request update response
          */
         void ResolveRequestUpdate(ConnectionHandle connection_handle,
                                   uint64_t request_id,
-                                  uint64_t existing_request_id,
-                                  const messages::Parameters& params);
+                                  const RequestUpdateResponse& response);
 
         /**
          * @brief Accept or reject track status that was received
@@ -590,48 +600,7 @@ namespace quicr {
         virtual void TrackStatusReceived(ConnectionHandle connection_handle,
                                          uint64_t request_id,
                                          const FullTrackName& track_full_name);
-        /**
-         * @brief Callback notification for Request Ok received
-         *
-         * @note The REQUEST_OK message is sent to a response to REQUEST_UPDATE, TRACK_STATUS, SUBSCRIBE_NAMESPACE and
-         *       PUBLISH_NAMESPACE requests. The unique request ID in the REQUEST_OK is used to associate it with the
-         *       correct type of request.
-         *
-         * @param connection_handle     Source connection ID
-         * @param request_id            Request ID received
-         * @param largest_location      Largest location (only set for responses from TRACK_STATUS and REQUEST_UPDATE)
-         */
-        virtual void RequestOkReceived(ConnectionHandle connection_handle,
-                                       uint64_t request_id,
-                                       std::optional<messages::Location> largest_location = std::nullopt);
 
-        /**
-         * @brief Callback notification for Request Error received
-         *
-         * @note The REQUEST_ERROR message is sent to a response to any request (SUBSCRIBE, FETCH, PUBLISH,
-         *       SUBSCRIBE_NAMESPACE, PUBLISH_NAMESPACE, TRACK_STATUS). The unique request ID in the REQUEST_ERROR is
-         *       used to associate it with the correct type of request.
-         *
-         * @param connection_handle     Source connection ID
-         * @param request_id            Request ID received
-         * @param response              Response message
-         */
-        virtual void RequestErrorReceived(ConnectionHandle connection_handle,
-                                          uint64_t request_id,
-                                          const RequestResponse& response);
-
-        /**
-         * @brief Callback notification on request update received
-         *
-         * @param connection_handle     Source connection ID
-         * @param request_id            Request ID for the update
-         * @param existing_request_id   Existing request ID being updated
-         * @param params                Updated parameters
-         */
-        virtual void RequestUpdateReceived(ConnectionHandle connection_handle,
-                                           uint64_t request_id,
-                                           uint64_t existing_request_id,
-                                           const messages::Parameters& params);
         ///@}
 
         /** @name Client Callbacks

--- a/include/quicr/subscribe_namespace_handler.h
+++ b/include/quicr/subscribe_namespace_handler.h
@@ -112,7 +112,9 @@ namespace quicr {
             SetStatus(Status::kError);
         }
 
-        void RequestOk(uint64_t, const messages::Parameters&) override { SetStatus(Status::kOk); }
+        void RequestOkReceived(const messages::Parameters&) override;
+
+        void RequestUpdateReceived(const messages::Parameters& params) override;
 
         void RequestError(messages::ErrorCode error_code, std::string reason) override
         {

--- a/include/quicr/subscribe_track_handler.h
+++ b/include/quicr/subscribe_track_handler.h
@@ -366,8 +366,8 @@ namespace quicr {
          */
         virtual void MetricsSampled([[maybe_unused]] const SubscribeTrackMetrics& metrics) {}
 
-        void RequestUpdate(uint64_t request_id, const messages::Parameters& params) override;
-        void RequestOk(uint64_t request_id, const messages::Parameters& params) override;
+        void RequestUpdateReceived(const messages::Parameters& params) override;
+        void RequestOkReceived(const messages::Parameters& params) override;
 
         ///@}
 

--- a/src/base_track_handler.cpp
+++ b/src/base_track_handler.cpp
@@ -46,9 +46,5 @@ namespace quicr {
         return ReasonCode::kOk;
     }
 
-    void BaseTrackHandler::RequestOk(uint64_t, const messages::Parameters&) {}
-
-    void BaseTrackHandler::RequestUpdate(uint64_t, const messages::Parameters&) {}
-
     void BaseTrackHandler::RequestError(messages::ErrorCode, std::string) {}
 }

--- a/src/publish_namespace_handler.cpp
+++ b/src/publish_namespace_handler.cpp
@@ -1,4 +1,5 @@
 #include "quicr/publish_namespace_handler.h"
+#include "quicr/detail/parameters.h"
 #include "quicr/session.h"
 
 #include <ranges>
@@ -104,4 +105,18 @@ quicr::PublishNamespaceHandler::PublishObject(uint64_t track_alias,
     }
 
     return PublishTrackHandler::PublishObjectStatus::kInternalError;
+}
+
+void
+quicr::PublishNamespaceHandler::RequestOkReceived(const messages::Parameters& params)
+{
+    messages::ValidateParameters(params, {});
+    SetStatus(Status::kOk);
+}
+
+void
+quicr::PublishNamespaceHandler::RequestUpdateReceived(const messages::Parameters& params)
+{
+    // TODO: See moq-wg #1769.
+    throw messages::ProtocolViolationException("Unexpected REQUEST_UPDATE");
 }

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024 Cisco Systems
 // SPDX-License-Identifier: BSD-2-Clause
 
+#include "quicr/detail/parameters.h"
 #include "quicr/session.h"
+
 #include <quicr/publish_track_handler.h>
 
 namespace quicr {
@@ -369,20 +371,56 @@ namespace quicr {
         }
     }
 
-    void PublishTrackHandler::RequestOk([[maybe_unused]] uint64_t request_id, const messages::Parameters& params)
+    void PublishTrackHandler::RequestOkReceived(const messages::Parameters& params)
     {
-        auto forward = params.Get<bool>(messages::ParameterType::kForward);
-        SetStatus(forward ? Status::kOk : Status::kPaused);
+        // TODO: Replace this condition to signal pending request update response.
+        if (true) {
+            // PUBLISH_OK.
+            messages::ValidateParameters(params,
+                                         { messages::ParameterType::kDeliveryTimeout,
+                                           messages::ParameterType::kSubgroupDeliveryTimeout,
+                                           messages::ParameterType::kSubscriberPriority,
+                                           messages::ParameterType::kGroupOrder,
+                                           messages::ParameterType::kSubscriptionFilter,
+                                           messages::ParameterType::kNewGroupRequest,
+                                           messages::ParameterType::kExpires,
+                                           messages::ParameterType::kForward });
+            // TODO: OBJECT_DELIVERY_TIMEOUT
+            // TODO: SUBGROUP_DELIVERY_TIMEOUT
+            // TODO: SUBSCRIBER_PRIORITY
+            // TODO: GROUP_ORDER
+            // TODO: SUBSCRIPTION_FILTER
+            // TODO: NEW_GROUP_REQUEST
+            // TODO: EXPIRES
+            const auto forward = messages::ResolveForward(params, true);
+            SetStatus(forward ? Status::kOk : Status::kPaused);
+        } else {
+            // REQUEST_UPDATE_OK.
+            // TODO: In theory largest_object here?
+            messages::ValidateParameters(params, { messages::ParameterType::kExpires });
+            // TODO: EXPIRES.
+        }
     }
 
-    void PublishTrackHandler::RequestUpdate([[maybe_unused]] uint64_t request_id, const messages::Parameters& params)
+    void PublishTrackHandler::RequestUpdateReceived(const messages::Parameters& params)
     {
+        // The subscriber can update their subscription with lots of details.
+        // TODO: AUTHORIZATION_TOKEN
+        // TODO: OBJECT_DELIVERY_TIMEOUT
+        // TODO: SUBGROUP_DELIVERY_TIMEOUT
+        // TODO: SUBSCRIBER_PRIORITY
+        // TODO: SUBSCRIPTION_FILTER
         if (auto forward = params.GetOptional<bool>(messages::ParameterType::kForward); forward) {
             SetStatus(*forward ? Status::kOk : Status::kPaused);
         }
 
         if (auto ngr = params.GetOptional<std::uint64_t>(messages::ParameterType::kNewGroupRequest); ngr) {
             SetStatus(Status::kNewGroupRequested);
+        }
+
+        if (const auto transport = GetTransport().lock()) {
+            transport->ResolveRequestUpdate(
+              GetConnectionId(), *GetRequestId(), { .error = std::nullopt, .params = {} });
         }
     }
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -264,10 +264,6 @@ namespace quicr {
         return request_id;
     }
 
-    void Session::RequestOkReceived(ConnectionHandle, uint64_t, std::optional<messages::Location>) {}
-
-    void Session::RequestErrorReceived(ConnectionHandle, uint64_t, const RequestResponse&) {}
-
     void Session::TrackStatusReceived(ConnectionHandle, uint64_t, const FullTrackName&) {}
 
     void Session::ResolveTrackStatus(ConnectionHandle connection_handle,
@@ -2678,49 +2674,42 @@ namespace quicr {
     }
 
     void Session::ResolveRequestUpdate(ConnectionHandle connection_handle,
-                                       uint64_t request_id,
-                                       uint64_t existing_request_id,
-                                       const messages::Parameters& params)
+                                       messages::RequestID request_id,
+                                       const RequestUpdateResponse& response)
     {
         auto conn_it = connections_.find(connection_handle);
         if (conn_it == connections_.end()) {
             return;
         }
 
-        auto track_it = conn_it->second.request_handlers.find(existing_request_id);
+        auto track_it = conn_it->second.request_handlers.find(request_id);
         if (track_it == conn_it->second.request_handlers.end()) {
-            if (client_mode_) {
-                const auto recv_it = conn_it->second.recv_req_id.find(existing_request_id);
-                if (recv_it == conn_it->second.recv_req_id.end()) {
-                    return;
-                }
-
-                SendRequestError(conn_it->second,
-                                 recv_it->second.data_ctx_id,
-                                 request_id,
-                                 messages::ErrorCode::kDoesNotExist,
-                                 0ms,
-                                 "Found no track for existing request ID");
-            }
+            SPDLOG_LOGGER_ERROR(logger_, "Resolve REQUEST_UPDATE for request {} had no handler", request_id);
             return;
         }
 
-        SPDLOG_LOGGER_DEBUG(
-          logger_, "Request Updated resolve req_id: {} existing_id: {}", request_id, existing_request_id);
-
-        track_it->second.handler->RequestUpdate(request_id, params);
+        SPDLOG_LOGGER_DEBUG(logger_, "Request Updated resolve req_id: {}", request_id);
 
         const auto data_ctx_id = track_it->second.handler->GetDataContextId();
         if (!data_ctx_id.has_value()) {
             SPDLOG_LOGGER_WARN(logger_,
-                               "ResolveRequestUpdate missing handler data context conn_id: {} existing_id: {}",
+                               "ResolveRequestUpdate missing handler data context conn_id: {} request_id: {}",
                                connection_handle,
-                               existing_request_id);
+                               request_id);
             return;
         }
 
-        // TODO: Type the params in resolve, fill in here.
-        SendRequestUpdateOk(conn_it->second, *data_ctx_id, std::nullopt, std::nullopt);
+        if (response.error.has_value()) {
+            SendRequestError(conn_it->second,
+                             *data_ctx_id,
+                             request_id,
+                             response.error->error_code,
+                             response.error->retry_interval,
+                             response.error->reason);
+        } else {
+            // TODO: Type the params in resolve, fill in here.
+            SendRequestUpdateOk(conn_it->second, *data_ctx_id, std::nullopt, std::nullopt);
+        }
     }
 
     std::optional<DataContextId> Session::FindSubscribeNamespaceDataContext(const ConnectionContext& conn_ctx,
@@ -2847,16 +2836,6 @@ namespace quicr {
     }
 
     void Session::FetchCancelReceived(ConnectionHandle connection_handle, uint64_t request_id) {}
-
-    void Session::RequestUpdateReceived(ConnectionHandle connection_handle,
-                                        uint64_t request_id,
-                                        uint64_t existing_request_id,
-                                        const messages::Parameters& params)
-    {
-        if (client_mode_) {
-            ResolveRequestUpdate(connection_handle, request_id, existing_request_id, params);
-        }
-    }
 
     // -- Server Relay Methods --
 
@@ -3140,6 +3119,7 @@ namespace quicr {
                                        "Received REQUEST_OK for unknown request conn_id: {} data_ctx_ic: {}, ignored",
                                        conn_ctx.connection_handle,
                                        data_ctx_id);
+                    return true;
                 }
                 const auto request_id = req_it->second;
 
@@ -3158,14 +3138,9 @@ namespace quicr {
                         return true;
                     }
 
-                    track_it->second.handler->RequestOk(request_id, parameters);
-                    RequestOkReceived(conn_ctx.connection_handle, request_id);
+                    track_it->second.handler->RequestOkReceived(parameters);
                     return true;
                 }
-
-                auto largest_location =
-                  parameters.GetOptional<messages::Location>(messages::ParameterType::kLargestObject);
-                RequestOkReceived(conn_ctx.connection_handle, request_id, largest_location);
                 return true;
             }
             case messages::ControlMessageType::kRequestError: {
@@ -3190,7 +3165,6 @@ namespace quicr {
                     }
 
                     track_it->second.handler->RequestError(error_code, response.error_reason.value());
-                    RequestErrorReceived(conn_ctx.connection_handle, request_id, response);
                     return true;
                 }
 
@@ -3199,7 +3173,6 @@ namespace quicr {
                                     request_id,
                                     static_cast<std::uint64_t>(error_code),
                                     response.error_reason.value());
-                RequestErrorReceived(conn_ctx.connection_handle, request_id, response);
                 return true;
             }
             case messages::ControlMessageType::kTrackStatus: {
@@ -3720,8 +3693,7 @@ namespace quicr {
                         return true;
                     }
 
-                    track_it->second.handler->RequestUpdate(request_id, parameters);
-                    RequestUpdateReceived(conn_ctx.connection_handle, request_id, existing_request_id, parameters);
+                    track_it->second.handler->RequestUpdateReceived(parameters);
                     return true;
                 }
 

--- a/src/subscribe_namespace_handler.cpp
+++ b/src/subscribe_namespace_handler.cpp
@@ -1,5 +1,6 @@
 #include "quicr/subscribe_namespace_handler.h"
 #include "quicr/detail/messages.h"
+#include "quicr/detail/parameters.h"
 #include "quicr/session.h"
 #include "quicr/subscribe_track_handler.h"
 
@@ -56,4 +57,17 @@ quicr::SubscribeNamespaceHandler::StatusChanged(Status status)
         default:
             break;
     }
+}
+
+void
+quicr::SubscribeNamespaceHandler::RequestOkReceived(const messages::Parameters& params)
+{
+    messages::ValidateParameters(params, {});
+    SetStatus(Status::kOk);
+}
+
+void
+quicr::SubscribeNamespaceHandler::RequestUpdateReceived([[maybe_unused]] const messages::Parameters& params)
+{
+    throw messages::ProtocolViolationException("Unexpected REQUEST_UPDATE");
 }

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -273,6 +273,10 @@ namespace quicr {
                                            messages::ParameterType::kAuthorizationToken,
                                          });
             // TODO: AUTHORIZATION_TOKEN
+            if (const auto transport = GetTransport().lock()) {
+                transport->ResolveRequestUpdate(
+                  GetConnectionId(), *GetRequestId(), { .error = std::nullopt, .params = {} });
+            }
             return;
         }
 

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -4,6 +4,7 @@
 #include "quicr/subscribe_track_handler.h"
 
 #include "quicr/detail/messages.h"
+#include "quicr/detail/parameters.h"
 #include "quicr/detail/stream_buffer.h"
 #include "quicr/session.h"
 
@@ -251,31 +252,31 @@ namespace quicr {
         streams_.erase(stream_id);
     }
 
-    void SubscribeTrackHandler::RequestOk([[maybe_unused]] uint64_t request_id, const messages::Parameters& params)
+    void SubscribeTrackHandler::RequestOkReceived(const messages::Parameters& params)
     {
-        auto forward = params.Get<bool>(messages::ParameterType::kForward);
-        SetStatus(forward ? Status::kOk : Status::kPaused);
+        // SUBSCRIBE request OK itself is SUBSCRIBE_OK, so any RequestOk will be REQUEST_UPDATE_OK.
+        messages::ValidateParameters(params,
+                                     {
+                                       messages::ParameterType::kExpires,
+                                       messages::ParameterType::kLargestObject,
+                                     });
+        // TODO: EXPIRES
+        // TODO: LARGEST_OBJECT
     }
 
-    void SubscribeTrackHandler::RequestUpdate([[maybe_unused]] uint64_t request_id, const messages::Parameters& params)
+    void SubscribeTrackHandler::RequestUpdateReceived(const messages::Parameters& params)
     {
-        if (auto delivery_timeout = params.GetOptional<std::uint64_t>(messages::ParameterType::kDeliveryTimeout);
-            delivery_timeout) {
-            SetDeliveryTimeout(std::chrono::milliseconds(*delivery_timeout));
+        if (IsPublisherInitiated()) {
+            // Publish can rev keys but nothing else.
+            messages::ValidateParameters(params,
+                                         {
+                                           messages::ParameterType::kAuthorizationToken,
+                                         });
+            // TODO: AUTHORIZATION_TOKEN
+            return;
         }
 
-        if (auto priority = params.GetOptional<uint8_t>(messages::ParameterType::kSubscriberPriority); priority) {
-            SetPriority(*priority);
-        }
-
-        if (auto new_group_request_id = params.GetOptional<std::uint64_t>(messages::ParameterType::kNewGroupRequest);
-            new_group_request_id) {
-            RequestNewGroup(*new_group_request_id);
-        }
-
-        if (auto forward = params.GetOptional<bool>(messages::ParameterType::kForward); forward) {
-            SetStatus(*forward ? Status::kOk : Status::kPaused);
-        }
+        throw messages::ProtocolViolationException("Unexpected REQUEST_UPDATE");
     }
 
 } // namespace quicr


### PR DESCRIPTION
Migrated API design for REQUEST_OK and REQUEST_UPDATEs. In Draft 18, each OK and UPDATE is the same message, with different parameters depending on the "logical" message type it represents. They are now kicked to the handlers who apply their specific processing rules. I renamed them to "<>Received" because even I being the implementor was getting confused over the directionality of OKs and Updates when writing them. 

Note that I didn't implement actual individual data updates just yet, but I did go through the draft and write out all the valid parameters and TODO their values being applied. I just wanted to get agreement on the design before actually handling the update logic (except where we already did, and it's important, like `FORWARD`). 

There is some more to be done here, like ensuring a REQUEST_UPDATE for a RequestUpdateOks are arriving for request update, not for an OK, etc etc. Possibly we want to be strict on a single update also, per the draft. Also errors. But all of these gaps are existing gaps rather than regressions.

IMO we should move TrackStatus to a handler type API just for consistency, even though it's more of a 1 shot type request vs. others. So TrackStatus is sort of broken here. 