### PR TITLE
Move request ID tracking from transport to session

### DIFF
--- a/include/quicr/detail/transport.h
+++ b/include/quicr/detail/transport.h
@@ -265,13 +265,13 @@ namespace quicr {
              * @param connection_handle Transport context identifier mapped to the connection
              * @param stream_id         Transport stream id.
              * @param rx_ctx            Stream Rx context with the handler info.
-             * @param request_id        Optional request ID of the handler
+             * @param data_ctx_id       Optional data context ID the stream belonged to
              * @param flag              Flag value for how the stream was closed. Values are FIN or RST
              */
             virtual void OnStreamClosed(const TransportConnId& connection_handle,
                                         std::uint64_t stream_id,
                                         std::shared_ptr<StreamRxContext> rx_ctx,
-                                        std::optional<uint64_t> request_id,
+                                        std::optional<uint64_t> data_ctx_id,
                                         StreamClosedFlag flag) = 0;
 
             /**
@@ -382,15 +382,13 @@ namespace quicr {
          *                                 	preferred for transporting data
          * @param[in] priority                Priority for stream (default is 1)
          * @param[in] bidir                   Set context to be bi-directional or unidirectional
-         * @param[in] request_id              optional request ID to lookup request handler if needed
          *
          * @return DataContextId identifying the data context via the connection
          */
         virtual DataContextId CreateDataContext(TransportConnId conn_id,
                                                 bool use_reliable_transport,
                                                 uint8_t priority = 1,
-                                                bool bidir = false,
-                                                std::optional<uint64_t> request_id = std::nullopt) = 0;
+                                                bool bidir = false) = 0;
 
         /**
          * @brief Close a transport context

--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -929,7 +929,7 @@ namespace quicr {
         void OnStreamClosed(const ConnectionHandle& connection_handle,
                             std::uint64_t stream_id,
                             std::shared_ptr<StreamRxContext> rx_ctx,
-                            std::optional<uint64_t> request_id,
+                            std::optional<uint64_t> data_ctx_id,
                             StreamClosedFlag flag) override;
 
         // -------------------------------------------------------------------------------------------------

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -792,7 +792,7 @@ namespace quicr {
                                     ? ControlMessageType::kSubscribeNamespace
                                     : ControlMessageType::kSubscribeTracks;
 
-        handler->SetDataContextId(quic_transport_->CreateDataContext(conn_id, true, 0, true, handler->GetRequestId()));
+        handler->SetDataContextId(quic_transport_->CreateDataContext(conn_id, true, 0, true));
         quic_transport_->CreateStream(conn_id, handler->GetDataContextId().value(), 0);
         conn_it->second.request_id_by_data_ctx[handler->GetDataContextId().value()] = handler->GetRequestId().value();
 
@@ -989,8 +989,7 @@ namespace quicr {
                 return;
             }
 
-            track_handler->SetDataContextId(
-              quic_transport_->CreateDataContext(conn_id, true, 0, true, track_handler->GetRequestId()));
+            track_handler->SetDataContextId(quic_transport_->CreateDataContext(conn_id, true, 0, true));
             quic_transport_->CreateStream(conn_id, track_handler->GetDataContextId().value(), 0);
             conn_it->second.request_id_by_data_ctx[track_handler->GetDataContextId().value()] =
               track_handler->GetRequestId().value();
@@ -1181,6 +1180,7 @@ namespace quicr {
 
         if (handler.publish_data_ctx_id_ != 0) {
             conn_ctx.pub_tracks_by_data_ctx_id.erase(handler.publish_data_ctx_id_);
+            // TODO: is_reset should propagate down here?
             quic_transport_->DeleteDataContext(connection_handle, handler.publish_data_ctx_id_);
             handler.publish_data_ctx_id_ = 0;
         }
@@ -1363,8 +1363,7 @@ namespace quicr {
 
         track_handler->SetStatus(PublishTrackHandler::Status::kPendingPublishOk);
 
-        track_handler->SetDataContextId(
-          quic_transport_->CreateDataContext(conn_id, true, 0, true, track_handler->GetRequestId()));
+        track_handler->SetDataContextId(quic_transport_->CreateDataContext(conn_id, true, 0, true));
         quic_transport_->CreateStream(conn_id, track_handler->GetDataContextId().value(), 0);
         conn_it->second.request_id_by_data_ctx[track_handler->GetDataContextId().value()] =
           track_handler->GetRequestId().value();
@@ -1397,8 +1396,7 @@ namespace quicr {
           quic_transport_->CreateDataContext(conn_id,
                                              track_handler->default_track_mode_ == TrackMode::kDatagram ? false : true,
                                              track_handler->default_priority_,
-                                             false,
-                                             track_handler->GetRequestId());
+                                             false);
 
         // Set this transport as the one for the publisher to use.
         track_handler->SetTransport(GetSharedPtr());
@@ -1434,8 +1432,7 @@ namespace quicr {
 
             ns_handler->SetStatus(PublishNamespaceHandler::Status::kPendingResponse);
 
-            ns_handler->SetDataContextId(
-              quic_transport_->CreateDataContext(conn_id, true, 0, true, ns_handler->GetRequestId()));
+            ns_handler->SetDataContextId(quic_transport_->CreateDataContext(conn_id, true, 0, true));
             quic_transport_->CreateStream(conn_id, ns_handler->GetDataContextId().value(), 0);
 
             lock.lock();
@@ -2003,31 +2000,33 @@ namespace quicr {
     void Session::OnStreamClosed(const ConnectionHandle& connection_handle,
                                  std::uint64_t stream_id,
                                  std::shared_ptr<StreamRxContext> rx_ctx,
-                                 std::optional<uint64_t> request_id,
+                                 std::optional<uint64_t> data_ctx_id,
                                  StreamClosedFlag flag)
     {
         SPDLOG_LOGGER_DEBUG(logger_, "Stream {} closed", stream_id);
 
-        if (request_id.has_value()) {
-            const bool is_bidir = (stream_id & 2) == 0;
-
+        if (data_ctx_id.has_value()) {
             try {
                 std::lock_guard<std::mutex> _(state_mutex_);
                 auto conn_it = connections_.find(connection_handle);
                 if (conn_it == connections_.end()) {
                     return;
                 }
+                auto& conn_ctx = conn_it->second;
 
-                if (is_bidir) {
-                    CloseRequestHandler(conn_it->second, connection_handle, *request_id, stream_id, flag);
+                // This is a request stream.
+                const auto req_it = conn_ctx.request_id_by_data_ctx.find(*data_ctx_id);
+                if (req_it != conn_ctx.request_id_by_data_ctx.end()) {
+                    const auto request_id = req_it->second;
+                    conn_ctx.request_id_by_data_ctx.erase(req_it);
+                    CloseRequestHandler(conn_ctx, connection_handle, request_id, stream_id, flag);
                     return;
                 }
 
-                const auto handler_it = conn_it->second.request_handlers.find(*request_id);
-                if (handler_it != conn_it->second.request_handlers.end()) {
-                    if (auto pub_handler = handler_it->second.Get<PublishTrackHandler>()) {
-                        pub_handler->StreamClosed(stream_id, flag == StreamClosedFlag::kReset);
-                    }
+                // This is a data stream.
+                const auto pub_it = conn_ctx.pub_tracks_by_data_ctx_id.find(*data_ctx_id);
+                if (pub_it != conn_ctx.pub_tracks_by_data_ctx_id.end()) {
+                    pub_it->second->StreamClosed(stream_id, flag == StreamClosedFlag::kReset);
                 }
             } catch (const std::exception& e) {
                 SPDLOG_LOGGER_ERROR(logger_, "Caught exception on stream closed: {}", e.what());
@@ -2036,7 +2035,7 @@ namespace quicr {
         }
 
         try {
-
+            // TODO: Replace this check with control stream IDs check.
             if ((stream_id & 2) == 0) { // bidir
                 auto& conn_ctx = connections_[connection_handle];
 
@@ -2887,8 +2886,7 @@ namespace quicr {
           quic_transport_->CreateDataContext(connection_handle,
                                              track_handler->default_track_mode_ == TrackMode::kDatagram ? false : true,
                                              track_handler->default_priority_,
-                                             false,
-                                             request_id);
+                                             false);
 
         // Set this transport as the one for the publisher to use.
         track_handler->SetTransport(GetSharedPtr());
@@ -3058,6 +3056,7 @@ namespace quicr {
                 conn_ctx.recv_req_id[request_id] = { .track_full_name = tfn,
                                                      .track_hash = th,
                                                      .data_ctx_id = data_ctx_id };
+                conn_ctx.request_id_by_data_ctx[data_ctx_id] = request_id;
 
                 if (client_mode_) {
                     auto ptd = GetPubTrackHandler(conn_ctx, th);
@@ -3241,6 +3240,8 @@ namespace quicr {
                                     request_id,
                                     th.track_fullname_hash);
 
+                conn_ctx.request_id_by_data_ctx[data_ctx_id] = request_id;
+
                 TrackStatusReceived(conn_ctx.connection_handle, request_id, tfn);
                 return true;
             }
@@ -3252,6 +3253,7 @@ namespace quicr {
                 conn_ctx.recv_req_id[request_id] = { .track_full_name = { track_namespace, {} },
                                                      .track_hash = TrackHash({ track_namespace, {} }),
                                                      .data_ctx_id = data_ctx_id };
+                conn_ctx.request_id_by_data_ctx[data_ctx_id] = request_id;
 
                 if (client_mode_) {
                     PublishNamespaceReceived(track_namespace, { .request_id = request_id });
@@ -3277,6 +3279,8 @@ namespace quicr {
                 } else if (parameters.Contains(messages::ParameterType::kTrackFilter)) {
                     filter = parameters.GetFilter(messages::FilterType::kTrackFilter);
                 }
+
+                conn_ctx.request_id_by_data_ctx[data_ctx_id] = request_id;
 
                 SubscribeTracksReceived(
                   conn_ctx.connection_handle,
@@ -3304,6 +3308,8 @@ namespace quicr {
                 } else if (parameters.Contains(messages::ParameterType::kTrackFilter)) {
                     filter = parameters.GetFilter(messages::FilterType::kTrackFilter);
                 }
+
+                conn_ctx.request_id_by_data_ctx[data_ctx_id] = request_id;
 
                 SubscribeNamespaceReceived(
                   conn_ctx.connection_handle,

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -213,7 +213,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
 
                     if (data_ctx != nullptr) {
                         transport->OnStreamClosed(
-                          conn_id, stream_id, nullptr, data_ctx->request_id, StreamClosedFlag::kFin);
+                          conn_id, stream_id, nullptr, data_ctx->data_ctx_id, StreamClosedFlag::kFin);
                         transport->DeleteDataContext(conn_id, data_ctx->data_ctx_id, false);
                     }
                 }
@@ -253,7 +253,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
                   stream_id);
 
                 // Cleanup the reset stream.
-                transport->OnStreamClosed(conn_id, stream_id, nullptr, data_ctx->request_id, StreamClosedFlag::kReset);
+                transport->OnStreamClosed(conn_id, stream_id, nullptr, data_ctx->data_ctx_id, StreamClosedFlag::kReset);
                 if (auto conn_ctx = transport->GetConnContext(conn_id)) {
                     transport->EraseStreamState(*conn_ctx, data_ctx, stream_id);
                 }
@@ -713,6 +713,11 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
                     transport->OnStreamClosed(
                       conn_id, stream_id, rx_buf_it->second.rx_ctx, std::nullopt, StreamClosedFlag::kFin);
                 }
+
+                if (data_ctx != nullptr) {
+                    transport->OnStreamClosed(
+                      conn_id, stream_id, nullptr, data_ctx->data_ctx_id, StreamClosedFlag::kFin);
+                }
             }
 
             break;
@@ -802,6 +807,11 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
                       conn_id, stream_id, rx_buf_it->second.rx_ctx, std::nullopt, StreamClosedFlag::kReset);
                 }
 
+                if (const auto data_ctx = GetDataCtxForWT(conn_ctx, stream_id)) {
+                    transport->OnStreamClosed(
+                      conn_id, stream_id, nullptr, data_ctx->data_ctx_id, StreamClosedFlag::kReset);
+                }
+
                 ClearDataCtxStream(conn_ctx, stream_id);
             }
 
@@ -829,6 +839,11 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
                     rx_buf_it->second.closed = true;
                     transport->OnStreamClosed(
                       conn_id, stream_id, rx_buf_it->second.rx_ctx, std::nullopt, StreamClosedFlag::kReset);
+                }
+
+                if (const auto data_ctx = GetDataCtxForWT(conn_ctx, stream_id)) {
+                    transport->OnStreamClosed(
+                      conn_id, stream_id, nullptr, data_ctx->data_ctx_id, StreamClosedFlag::kReset);
                 }
 
                 ClearDataCtxStream(conn_ctx, stream_id);
@@ -1222,8 +1237,7 @@ DataContextId
 PicoQuicTransport::CreateDataContext(const TransportConnId conn_id,
                                      bool use_reliable_transport,
                                      uint8_t priority,
-                                     bool bidir,
-                                     std::optional<uint64_t> request_id)
+                                     bool bidir)
 {
     std::unique_lock lock(state_mutex_);
 
@@ -1250,7 +1264,6 @@ PicoQuicTransport::CreateDataContext(const TransportConnId conn_id,
         data_ctx_it->second.conn_id = conn_id;
         data_ctx_it->second.is_bidir = bidir;
         data_ctx_it->second.data_ctx_id = conn_it->second.next_data_ctx_id++; // Set and bump next data_ctx_id
-        data_ctx_it->second.request_id = request_id;
 
         data_ctx_it->second.uses_reset_wait = tconfig_.use_reset_wait_strategy;
 
@@ -2173,12 +2186,12 @@ void
 PicoQuicTransport::OnStreamClosed(TransportConnId conn_id,
                                   uint64_t stream_id,
                                   std::shared_ptr<StreamRxContext> rx_ctx,
-                                  std::optional<uint64_t> request_id,
+                                  std::optional<uint64_t> data_ctx_id,
                                   StreamClosedFlag flag)
 {
     SPDLOG_DEBUG("Stream {} closed for connection {}", stream_id, conn_id);
     cbNotifyQueue_.Push([=, rx_ctx = std::move(rx_ctx), this]() {
-        delegate_.OnStreamClosed(conn_id, stream_id, std::move(rx_ctx), request_id, flag);
+        delegate_.OnStreamClosed(conn_id, stream_id, std::move(rx_ctx), data_ctx_id, flag);
     });
 }
 

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -85,7 +85,6 @@ namespace quicr {
             DataContext(DataContext&& other)
               : data_ctx_id(other.data_ctx_id)
               , conn_id(other.conn_id)
-              , request_id(other.request_id)
               , is_bidir(other.is_bidir)
               , uses_reset_wait(other.uses_reset_wait)
               , delete_on_empty(other.delete_on_empty)
@@ -101,7 +100,6 @@ namespace quicr {
           public:
             DataContextId data_ctx_id{ 0 };     /// The ID of this context
             TransportConnId conn_id{ 0 };       /// The connection ID this context is under
-            std::optional<uint64_t> request_id; /// Request ID of handler
             bool is_bidir : 1 { false };        /// Indicates if the stream is bidir (true) or unidir (false)
             bool uses_reset_wait : 1 { false }; /// Indicates if data context can/uses reset wait strategy
             bool delete_on_empty{ false };      /// Instructs TX objects to be discarded on POP instead
@@ -311,8 +309,7 @@ namespace quicr {
         DataContextId CreateDataContext(TransportConnId conn_id,
                                         bool use_reliable_transport,
                                         uint8_t priority,
-                                        bool bidir,
-                                        std::optional<uint64_t> request_id = std::nullopt) override;
+                                        bool bidir) override;
 
         void DeleteDataContext(const TransportConnId& conn_id,
                                DataContextId data_ctx_id,
@@ -394,7 +391,7 @@ namespace quicr {
         void OnStreamClosed(TransportConnId conn_id,
                             uint64_t stream_id,
                             std::shared_ptr<StreamRxContext> rx_ctx,
-                            std::optional<uint64_t> request_id,
+                            std::optional<uint64_t> data_ctx_id,
                             StreamClosedFlag flag);
 
         void CheckConnsForCongestion();


### PR DESCRIPTION
- Prep for QUIC stream verb control changes
- This also has the beneficial side effect of removing the need for the QUIC layer to know about MoQ request IDs