### PR TITLE
Move metrics callback to notify thread

### DIFF
--- a/src/session.cpp
+++ b/src/session.cpp
@@ -2330,7 +2330,6 @@ namespace quicr {
                                              const std::uint64_t conn_id,
                                              const QuicConnectionMetrics& quic_connection_metrics)
     {
-        // TODO: doesn't require lock right now, but might need to add lock
         auto conn_it = connections_.find(conn_id);
         if (conn_it == connections_.end()) {
             // Connection no longer exists, skip metrics sampling

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -2200,19 +2200,28 @@ PicoQuicTransport::EmitMetrics()
 {
     for (auto& [conn_id, conn_ctx] : conn_context_) {
         const auto sample_time = std::chrono::system_clock::now();
+        const bool queue_space = cbNotifyQueue_.Size() < (tconfig_.callback_queue_size * 3) / 4;
 
-        cbNotifyQueue_.Push([this, sample_time, conn_id = conn_id, metrics = conn_ctx.metrics]() {
-            delegate_.OnConnectionMetricsSampled(sample_time, conn_id, metrics);
-        });
-
+        std::vector<std::pair<std::uint64_t, QuicDataContextMetrics>> data_metrics;
         for (auto& [data_ctx_id, data_ctx] : conn_ctx.active_data_contexts) {
-            cbNotifyQueue_.Push(
-              [this, sample_time, conn_id = conn_id, data_ctx_id = data_ctx_id, metrics = data_ctx.metrics]() {
-                  delegate_.OnDataMetricsStampled(sample_time, conn_id, data_ctx_id, metrics);
-              });
+            if (queue_space) {
+                data_metrics.emplace_back(data_ctx_id, data_ctx.metrics);
+            }
             data_ctx.metrics.ResetPeriod();
         }
 
+        if (queue_space) {
+            cbNotifyQueue_.Push([this,
+                                 sample_time,
+                                 conn_id = conn_id,
+                                 conn_metrics = conn_ctx.metrics,
+                                 data_metrics = std::move(data_metrics)]() {
+                delegate_.OnConnectionMetricsSampled(sample_time, conn_id, conn_metrics);
+                for (const auto& [data_ctx_id, metrics] : data_metrics) {
+                    delegate_.OnDataMetricsStampled(sample_time, conn_id, data_ctx_id, metrics);
+                }
+            });
+        }
         conn_ctx.metrics.ResetPeriod();
     }
 }

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -2201,10 +2201,15 @@ PicoQuicTransport::EmitMetrics()
     for (auto& [conn_id, conn_ctx] : conn_context_) {
         const auto sample_time = std::chrono::system_clock::now();
 
-        delegate_.OnConnectionMetricsSampled(sample_time, conn_id, conn_ctx.metrics);
+        cbNotifyQueue_.Push([this, sample_time, conn_id = conn_id, metrics = conn_ctx.metrics]() {
+            delegate_.OnConnectionMetricsSampled(sample_time, conn_id, metrics);
+        });
 
         for (auto& [data_ctx_id, data_ctx] : conn_ctx.active_data_contexts) {
-            delegate_.OnDataMetricsStampled(sample_time, conn_id, data_ctx_id, data_ctx.metrics);
+            cbNotifyQueue_.Push(
+              [this, sample_time, conn_id = conn_id, data_ctx_id = data_ctx_id, metrics = data_ctx.metrics]() {
+                  delegate_.OnDataMetricsStampled(sample_time, conn_id, data_ctx_id, metrics);
+              });
             data_ctx.metrics.ResetPeriod();
         }
 


### PR DESCRIPTION
`OnConnectionMetricsSampled` was being called directly on the transport thread, rather than delegated to the notifier thread. This meant two things: firstly a client could in theory stall the transport, which would be bad, and secondly any session level state would be racing between the two threads (notify and transport). The time is already encoded in the structure, so a delayed metrics callback is no issue. I take a copy of what we need so we can continue to immediately reset period on the originating thread. 

Because the notify queue is lossy, we want to make sure a metrics callback will never pop a "real" callback. I also changed it to fire all the metrics events in one delegation (one queue entry) rather than N at a time, to reduce the chance of that happening. 