### PR TITLE
Hide MoQ request update implementation detail

### DIFF
--- a/include/quicr/handlers/base_track_handler.h
+++ b/include/quicr/handlers/base_track_handler.h
@@ -9,6 +9,7 @@
 #include "quicr/messages/parameters.h"
 #include "quicr/track_name.h"
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -17,6 +18,13 @@
 
 namespace quicr {
     class Session;
+
+    struct RequestError
+    {
+        messages::ErrorCode code;
+        std::chrono::milliseconds retry_interval;
+        std::string reason;
+    };
 
     /**
      * @brief Response to received MOQT Request message
@@ -220,11 +228,16 @@ namespace quicr {
         uint64_t GetConnectionId() const noexcept { return connection_id_; };
 
         /**
-         * @brief Received an update for this handler's request.
-         * Implementations MUST call ResolveRequestUpdate to acknowledge the request.
-         * @param params The updated/new parameters for the request.
+         * @brief Accept or reject a pending update.
+         * @param error nullopt to accept, otherwise reject with the given error.
+         *
+         * @remarks May be called synchronously from within the kSubscriptionUpdated callback, or later
+         * from any thread once the resolution is known, but updates MUST be resolved in order
+         * that they were received.
+         *
+         * @throws std::logic_error if there was no pending update to resolve.
          */
-        virtual void RequestUpdateReceived(const messages::Parameters& params) = 0;
+        void ResolveRequestUpdate(const std::optional<RequestError>& error = std::nullopt);
 
         virtual void RequestError(messages::ErrorCode error_code, std::string reason);
 
@@ -236,12 +249,21 @@ namespace quicr {
         virtual void RequestOkReceived(const messages::Parameters& params) = 0;
 
         /**
+         * @brief Received an update for this handler's request.
+         * Implementations MUST provide a means for ResolveRequestUpdate to acknowledge the request (status).
+         * @param params The updated/new parameters for the request.
+         */
+        virtual void RequestUpdateReceived(const messages::Parameters& params) = 0;
+
+        /**
          * Set the transport to use.
          * @param transport The new transport for the handler to use.
          */
         void SetTransport(std::shared_ptr<Session> transport);
 
         const std::weak_ptr<Session>& GetTransport() const noexcept;
+
+        std::atomic<std::uint64_t> pending_request_updates_{ 0 };
 
         // --------------------------------------------------------------------------
         // Internal

--- a/include/quicr/handlers/base_track_handler.h
+++ b/include/quicr/handlers/base_track_handler.h
@@ -9,9 +9,10 @@
 #include "quicr/messages/parameters.h"
 #include "quicr/track_name.h"
 
-#include <atomic>
 #include <cstdint>
+#include <deque>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <span>
 #include <vector>
@@ -253,7 +254,19 @@ namespace quicr {
          * Implementations MUST provide a means for ResolveRequestUpdate to acknowledge the request (status).
          * @param params The updated/new parameters for the request.
          */
-        virtual void RequestUpdateReceived(const messages::Parameters& params) = 0;
+        void RequestUpdateReceived(const messages::Parameters& params);
+
+        /**
+         * @brief Apply the active update to this handler.
+         * @param params The updated/new parameters for the request.
+         */
+        virtual void ApplyRequestUpdate(const messages::Parameters& params) = 0;
+
+        /**
+         * @brief Handle request termination after a rejected update.
+         * @remarks Called on the notifier thread.
+         */
+        virtual void RequestUpdateRejected() {}
 
         /**
          * Set the transport to use.
@@ -263,12 +276,27 @@ namespace quicr {
 
         const std::weak_ptr<Session>& GetTransport() const noexcept;
 
-        std::atomic<std::uint64_t> pending_request_updates_{ 0 };
-
         // --------------------------------------------------------------------------
         // Internal
         // --------------------------------------------------------------------------
       private:
+        // Request update queue support.
+        enum class RequestUpdateState : std::uint8_t
+        {
+            // No update pending.
+            kIdle,
+            // An update has been applied and is awaiting resolution.
+            kAwaitingResolution,
+            // The current update is being resolved.
+            kResolving,
+            // A queued update is waiting to be applied.
+            kPendingApply,
+            // An update was rejected, the request is over.
+            kTerminal,
+        };
+        void ApplyNextRequestUpdate();
+        void ClearRequestUpdates();
+
         /**
          * @brief Set the connection ID
          *
@@ -300,6 +328,11 @@ namespace quicr {
         std::optional<uint64_t> request_stream_id_{ std::nullopt };
 
         std::weak_ptr<Session> transport_;
+
+        // Request update queuing.
+        std::mutex request_update_mutex_;
+        std::deque<messages::Parameters> pending_request_updates_;
+        RequestUpdateState request_update_state_{ RequestUpdateState::kIdle };
     };
 
 } // namespace moq

--- a/include/quicr/handlers/publish_namespace_handler.h
+++ b/include/quicr/handlers/publish_namespace_handler.h
@@ -156,7 +156,7 @@ namespace quicr {
 
         void RequestOkReceived(const messages::Parameters&) override;
 
-        void RequestUpdateReceived(const messages::Parameters& params) override;
+        void ApplyRequestUpdate(const messages::Parameters& params) override;
 
         void RequestError(messages::ErrorCode error_code, std::string reason) override
         {

--- a/include/quicr/handlers/publish_track_handler.h
+++ b/include/quicr/handlers/publish_track_handler.h
@@ -376,7 +376,9 @@ namespace quicr {
       protected:
         void RequestOkReceived(const messages::Parameters& params) override;
 
-        void RequestUpdateReceived(const messages::Parameters& params) override;
+        void ApplyRequestUpdate(const messages::Parameters& params) override;
+
+        void RequestUpdateRejected() override;
 
         // --------------------------------------------------------------------------
         // Member variables

--- a/include/quicr/handlers/publish_track_handler.h
+++ b/include/quicr/handlers/publish_track_handler.h
@@ -149,8 +149,6 @@ namespace quicr {
          */
         virtual void MetricsSampled(const PublishTrackMetrics& metrics);
 
-        void RequestUpdateReceived(const messages::Parameters& params) override;
-
         ///@}
 
         // --------------------------------------------------------------------------
@@ -377,6 +375,8 @@ namespace quicr {
         // --------------------------------------------------------------------------
       protected:
         void RequestOkReceived(const messages::Parameters& params) override;
+
+        void RequestUpdateReceived(const messages::Parameters& params) override;
 
         // --------------------------------------------------------------------------
         // Member variables

--- a/include/quicr/handlers/subscribe_namespace_handler.h
+++ b/include/quicr/handlers/subscribe_namespace_handler.h
@@ -114,7 +114,7 @@ namespace quicr {
 
         void RequestOkReceived(const messages::Parameters&) override;
 
-        void RequestUpdateReceived(const messages::Parameters& params) override;
+        void ApplyRequestUpdate(const messages::Parameters& params) override;
 
         void RequestError(messages::ErrorCode error_code, std::string reason) override
         {

--- a/include/quicr/handlers/subscribe_track_handler.h
+++ b/include/quicr/handlers/subscribe_track_handler.h
@@ -394,7 +394,7 @@ namespace quicr {
       protected:
         void RequestOkReceived(const messages::Parameters& params) override;
 
-        void RequestUpdateReceived(const messages::Parameters& params) override;
+        void ApplyRequestUpdate(const messages::Parameters& params) override;
 
         /**
          * @brief Set the subscribe status

--- a/include/quicr/handlers/subscribe_track_handler.h
+++ b/include/quicr/handlers/subscribe_track_handler.h
@@ -46,6 +46,7 @@ namespace quicr {
             kPendingResponse,
             kSendingUnsubscribe, ///< In this state, callbacks will not be called,
             kPaused,
+            kSubscriptionUpdated,
             kNewGroupRequested,
             kCancelled,
             kDoneByFin,
@@ -353,7 +354,7 @@ namespace quicr {
          *
          * @param status        Indicates status of the subscribe
          */
-        virtual void StatusChanged([[maybe_unused]] Status status) {}
+        virtual void StatusChanged(Status status);
 
         /**
          * @brief Notification callback to provide sampled metrics
@@ -365,8 +366,6 @@ namespace quicr {
          * @param metrics           Copy of the subscribed metrics for the sample period
          */
         virtual void MetricsSampled([[maybe_unused]] const SubscribeTrackMetrics& metrics) {}
-
-        void RequestUpdateReceived(const messages::Parameters& params) override;
 
         ///@}
 
@@ -394,6 +393,8 @@ namespace quicr {
 
       protected:
         void RequestOkReceived(const messages::Parameters& params) override;
+
+        void RequestUpdateReceived(const messages::Parameters& params) override;
 
         /**
          * @brief Set the subscribe status

--- a/include/quicr/messages/ctrl_message_types.h
+++ b/include/quicr/messages/ctrl_message_types.h
@@ -664,6 +664,7 @@ namespace quicr::messages {
         kGoingAway,
         kExpired,
         kTooFarBehind,
+        kUpdateFailed = 0x8,
     };
 
     Bytes& operator<<(Bytes& buffer, PublishDoneStatusCode value);

--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -312,18 +312,6 @@ namespace quicr {
             std::optional<Bytes> error_reason;
         };
 
-        struct RequestUpdateResponse
-        {
-            struct Error
-            {
-                const messages::ErrorCode error_code;
-                const std::chrono::milliseconds retry_interval;
-                const std::string reason;
-            };
-            const std::optional<Error> error;
-            const messages::Parameters params;
-        };
-
         // --BEGIN RESOLVE METHODS ---------------------------------------------------------------------------
         /** @name Resolve Methods
          *      Methods to accept or reject inbound requests. Most are used in server mode; `ResolveSubscribe()`
@@ -431,17 +419,6 @@ namespace quicr {
         void ResolvePublishNamespaceDone(std::uint64_t connection_id,
                                          std::uint64_t request_id,
                                          const std::vector<std::uint64_t>& subscribers);
-
-        /**
-         * @brief Accept or reject a request update
-         *
-         * @param connection_id         Source connection ID
-         * @param request_id            Request being updated
-         * @param response              Request update response
-         */
-        void ResolveRequestUpdate(std::uint64_t connection_id,
-                                  uint64_t request_id,
-                                  const RequestUpdateResponse& response);
 
         /**
          * @brief Accept or reject track status that was received
@@ -1202,6 +1179,8 @@ namespace quicr {
 
         std::uint64_t ResponseDataContext(const ConnectionContext& conn_ctx, std::uint64_t request_id) const;
 
+        void ResolveRequestUpdate(const BaseTrackHandler& handler, const std::optional<RequestError>& error);
+
         /*===================================================================*/
         // Track Status
         /*===================================================================*/
@@ -1310,6 +1289,7 @@ namespace quicr {
         std::shared_ptr<timeq::tick_service> tick_service_;
         std::shared_ptr<ITransport> quic_transport_; // **MUST** be last for proper order of destruction
 
+        friend class BaseTrackHandler;
         friend class PublishTrackHandler;
         friend class PublishFetchHandler;
         friend class SubscribeTrackHandler;

--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -1179,7 +1179,12 @@ namespace quicr {
 
         std::uint64_t ResponseDataContext(const ConnectionContext& conn_ctx, std::uint64_t request_id) const;
 
-        void ResolveRequestUpdate(const BaseTrackHandler& handler, const std::optional<RequestError>& error);
+        std::shared_ptr<BaseTrackHandler> ResolveRequestUpdate(const BaseTrackHandler& handler,
+                                                               const std::optional<RequestError>& error);
+
+        void DispatchRequestUpdateCompletion(std::shared_ptr<BaseTrackHandler> handler,
+                                             bool rejected,
+                                             bool apply_next) const;
 
         /*===================================================================*/
         // Track Status

--- a/include/quicr/transport.h
+++ b/include/quicr/transport.h
@@ -12,6 +12,7 @@
 #include <any>
 #include <chrono>
 #include <cstdlib>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -438,6 +439,11 @@ namespace quicr {
         virtual void SetRemoteDataCtxId(std::uint64_t conn_id,
                                         std::uint64_t data_ctx_id,
                                         std::uint64_t remote_data_ctx_id) = 0;
+
+        /**
+         * @brief Run a callback on the notifier thread.
+         */
+        virtual void Dispatch(std::function<void()> callback) = 0;
 
         /**
          * Enqueue flags

--- a/src/base_track_handler.cpp
+++ b/src/base_track_handler.cpp
@@ -1,5 +1,6 @@
 #include "quicr/handlers/base_track_handler.h"
 #include "quicr/session.h"
+#include <spdlog/spdlog.h>
 
 namespace quicr {
     void BaseTrackHandler::SetTransport(std::shared_ptr<Session> transport)
@@ -12,22 +13,97 @@ namespace quicr {
         return transport_;
     }
 
-    void BaseTrackHandler::ResolveRequestUpdate(const std::optional<quicr::RequestError>& error)
+    void BaseTrackHandler::RequestUpdateReceived(const messages::Parameters& params)
     {
-        // Consume a pending request.
-        auto pending = pending_request_updates_.load(std::memory_order_acquire);
-        while (pending != 0) {
-            if (pending_request_updates_.compare_exchange_weak(
-                  pending, pending - 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
-
-                // Resolve.
-                if (const auto transport = GetTransport().lock()) {
-                    transport->ResolveRequestUpdate(*this, error);
-                }
+        std::optional<messages::Parameters> active_update;
+        {
+            std::lock_guard lock(request_update_mutex_);
+            if (request_update_state_ == RequestUpdateState::kTerminal) {
+                // Ignore.
+                SPDLOG_WARN("Ignoring request update for terminal request");
                 return;
             }
+
+            // Store in queue.
+            pending_request_updates_.push_back(params);
+
+            // If we can immediately apply, do so.
+            if (request_update_state_ == RequestUpdateState::kIdle) {
+                request_update_state_ = RequestUpdateState::kAwaitingResolution;
+                active_update = pending_request_updates_.front();
+            }
         }
-        throw std::logic_error("ResolveRequestUpdate called with no update pending");
+        if (active_update.has_value()) {
+            ApplyRequestUpdate(*active_update);
+        }
+    }
+
+    void BaseTrackHandler::ResolveRequestUpdate(const std::optional<quicr::RequestError>& error)
+    {
+        {
+            // Check/update queue state.
+            std::lock_guard lock(request_update_mutex_);
+            if (pending_request_updates_.empty() || request_update_state_ != RequestUpdateState::kAwaitingResolution) {
+                throw std::logic_error("ResolveRequestUpdate called with no update pending");
+            }
+            request_update_state_ = RequestUpdateState::kResolving;
+        }
+
+        // Get the session for this request.
+        const auto session = GetTransport().lock();
+        if (!session) {
+            ClearRequestUpdates();
+            return;
+        }
+
+        auto live_handler = session->ResolveRequestUpdate(*this, error);
+        if (!live_handler) {
+            ClearRequestUpdates();
+            return;
+        }
+
+        // Complete the current update.
+        bool activate_next = false;
+        {
+            std::lock_guard lock(request_update_mutex_);
+            if (error.has_value()) {
+                // We're done.
+                pending_request_updates_.clear();
+                request_update_state_ = RequestUpdateState::kTerminal;
+            } else {
+                pending_request_updates_.pop_front();
+                if (pending_request_updates_.empty()) {
+                    request_update_state_ = RequestUpdateState::kIdle;
+                } else {
+                    request_update_state_ = RequestUpdateState::kPendingApply;
+                    activate_next = true;
+                }
+            }
+        }
+
+        session->DispatchRequestUpdateCompletion(std::move(live_handler), error.has_value(), activate_next);
+    }
+
+    void BaseTrackHandler::ApplyNextRequestUpdate()
+    {
+        // Apply the next queued update, if any.
+        messages::Parameters params;
+        {
+            std::lock_guard lock(request_update_mutex_);
+            if (request_update_state_ != RequestUpdateState::kPendingApply || pending_request_updates_.empty()) {
+                return;
+            }
+            request_update_state_ = RequestUpdateState::kAwaitingResolution;
+            params = pending_request_updates_.front();
+        }
+        ApplyRequestUpdate(params);
+    }
+
+    void BaseTrackHandler::ClearRequestUpdates()
+    {
+        std::lock_guard lock(request_update_mutex_);
+        pending_request_updates_.clear();
+        request_update_state_ = RequestUpdateState::kTerminal;
     }
 
     RequestResponse::ReasonCode RequestResponse::FromErrorCode(messages::ErrorCode error_code)

--- a/src/base_track_handler.cpp
+++ b/src/base_track_handler.cpp
@@ -12,6 +12,24 @@ namespace quicr {
         return transport_;
     }
 
+    void BaseTrackHandler::ResolveRequestUpdate(const std::optional<quicr::RequestError>& error)
+    {
+        // Consume a pending request.
+        auto pending = pending_request_updates_.load(std::memory_order_acquire);
+        while (pending != 0) {
+            if (pending_request_updates_.compare_exchange_weak(
+                  pending, pending - 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
+
+                // Resolve.
+                if (const auto transport = GetTransport().lock()) {
+                    transport->ResolveRequestUpdate(*this, error);
+                }
+                return;
+            }
+        }
+        throw std::logic_error("ResolveRequestUpdate called with no update pending");
+    }
+
     RequestResponse::ReasonCode RequestResponse::FromErrorCode(messages::ErrorCode error_code)
     {
         switch (error_code) {

--- a/src/publish_namespace_handler.cpp
+++ b/src/publish_namespace_handler.cpp
@@ -117,7 +117,7 @@ quicr::PublishNamespaceHandler::RequestOkReceived(const messages::Parameters& pa
 }
 
 void
-quicr::PublishNamespaceHandler::RequestUpdateReceived(const messages::Parameters& params)
+quicr::PublishNamespaceHandler::ApplyRequestUpdate(const messages::Parameters& params)
 {
     // TODO: See moq-wg #1769.
     throw messages::ProtocolViolationException("Unexpected REQUEST_UPDATE");

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -456,7 +456,7 @@ namespace quicr {
         }
     }
 
-    void PublishTrackHandler::RequestUpdateReceived(const messages::Parameters& params)
+    void PublishTrackHandler::ApplyRequestUpdate(const messages::Parameters& params)
     {
         // The subscriber can update their subscription with lots of details.
         // TODO: AUTHORIZATION_TOKEN
@@ -473,8 +473,12 @@ namespace quicr {
             SetStatus(Status::kNewGroupRequested);
         }
 
-        ++pending_request_updates_;
         StatusChanged(Status::kSubscriptionUpdated);
+    }
+
+    void PublishTrackHandler::RequestUpdateRejected()
+    {
+        SetStatus(Status::kUnsubscribed);
     }
 
     void PublishTrackHandler::StreamClosed(std::uint64_t stream_id, bool reset)

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -38,7 +38,12 @@ namespace quicr {
         }
     }
 
-    void PublishTrackHandler::StatusChanged(Status) {}
+    void PublishTrackHandler::StatusChanged(Status status)
+    {
+        if (status == Status::kSubscriptionUpdated) {
+            ResolveRequestUpdate();
+        }
+    }
 
     void PublishTrackHandler::MetricsSampled(const PublishTrackMetrics&) {}
 
@@ -459,6 +464,7 @@ namespace quicr {
         // TODO: SUBGROUP_DELIVERY_TIMEOUT
         // TODO: SUBSCRIBER_PRIORITY
         // TODO: SUBSCRIPTION_FILTER
+
         if (auto forward = params.GetOptional<bool>(messages::ParameterType::kForward); forward) {
             SetStatus(*forward ? Status::kOk : Status::kPaused);
         }
@@ -467,10 +473,8 @@ namespace quicr {
             SetStatus(Status::kNewGroupRequested);
         }
 
-        if (const auto transport = GetTransport().lock()) {
-            transport->ResolveRequestUpdate(
-              GetConnectionId(), *GetRequestId(), { .error = std::nullopt, .params = {} });
-        }
+        ++pending_request_updates_;
+        StatusChanged(Status::kSubscriptionUpdated);
     }
 
     void PublishTrackHandler::StreamClosed(std::uint64_t stream_id, bool reset)

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -2722,41 +2722,37 @@ namespace quicr {
         }
     }
 
-    void Session::ResolveRequestUpdate(std::uint64_t connection_id,
-                                       std::uint64_t request_id,
-                                       const RequestUpdateResponse& response)
+    void Session::ResolveRequestUpdate(const BaseTrackHandler& handler, const std::optional<RequestError>& error)
     {
-        auto conn_it = connections_.find(connection_id);
-        if (conn_it == connections_.end()) {
+        const auto connection_id = handler.GetConnectionId();
+        const auto request_id = handler.GetRequestId();
+        const auto data_ctx_id = handler.GetDataContextId();
+        if (!request_id.has_value() || !data_ctx_id.has_value()) {
+            SPDLOG_LOGGER_ERROR(logger_, "ResolveRequestUpdate: Handler not setup");
             return;
         }
 
-        auto track_it = conn_it->second.request_handlers.find(request_id);
-        if (track_it == conn_it->second.request_handlers.end()) {
-            SPDLOG_LOGGER_ERROR(logger_, "Resolve REQUEST_UPDATE for request {} had no handler", request_id);
+        std::lock_guard _(state_mutex_);
+        const auto conn_it = connections_.find(connection_id);
+        if (conn_it == connections_.end() || conn_it->second.closed) {
+            SPDLOG_LOGGER_WARN(logger_, "ResolveRequestUpdate: Connection doesn't exist");
             return;
         }
 
-        SPDLOG_LOGGER_DEBUG(logger_, "Request Updated resolve req_id: {}", request_id);
-
-        const auto data_ctx_id = track_it->second.handler->GetDataContextId();
-        if (!data_ctx_id.has_value()) {
-            SPDLOG_LOGGER_WARN(logger_,
-                               "ResolveRequestUpdate missing handler data context conn_id: {} request_id: {}",
-                               connection_id,
-                               request_id);
+        // Ensure this handler is still live.
+        const auto handler_it = conn_it->second.request_handlers.find(*request_id);
+        if (handler_it == conn_it->second.request_handlers.end()) {
+            SPDLOG_LOGGER_WARN(logger_, "ResolveRequestUpdate: Stale handler");
             return;
         }
+        // TODO: Ensure the given handler matches handler_it? Should be impossible.
 
-        if (response.error.has_value()) {
-            SendRequestError(conn_it->second,
-                             *data_ctx_id,
-                             request_id,
-                             response.error->error_code,
-                             response.error->retry_interval,
-                             response.error->reason);
+        if (error.has_value()) {
+            // TODO: Implement redirect.
+            SendRequestError(
+              conn_it->second, *data_ctx_id, *request_id, error->code, error->retry_interval, error->reason);
         } else {
-            // TODO: Type the params in resolve, fill in here.
+            // TODO: These parameters might be set in certain request update oks.
             SendRequestUpdateOk(conn_it->second, *data_ctx_id, std::nullopt, std::nullopt);
         }
     }
@@ -3593,6 +3589,9 @@ namespace quicr {
             }
             case messages::ControlMessageType::kRequestUpdate: {
                 const auto update_request_id = messages::Message::ParseField<std::uint64_t>(msg_bytes);
+                const auto parameters = messages::Message::ParseField<messages::Parameters>(msg_bytes);
+
+                std::unique_lock lock(state_mutex_);
                 const auto request_it = conn_ctx.request_id_by_data_ctx.find(data_ctx_id);
                 if (request_it == conn_ctx.request_id_by_data_ctx.end()) {
                     SPDLOG_LOGGER_WARN(logger_,
@@ -3604,67 +3603,51 @@ namespace quicr {
                     return true;
                 }
                 const auto request_id = request_it->second;
-                const auto parameters = messages::Message::ParseField<messages::Parameters>(msg_bytes);
 
-                if (client_mode_) {
-                    auto track_it = conn_ctx.request_handlers.find(request_id);
-                    if (track_it == conn_ctx.request_handlers.end()) {
-                        SPDLOG_LOGGER_WARN(logger_,
-                                           "Received REQUEST_UPDATE to unknown track conn_id: {} request_id: {}, "
-                                           "ignored",
-                                           conn_ctx.connection_id,
-                                           request_id);
+                const auto handler_it = conn_ctx.request_handlers.find(request_id);
+                if (handler_it == conn_ctx.request_handlers.end()) {
+                    SPDLOG_LOGGER_WARN(logger_,
+                                       "Received REQUEST_UPDATE on unknown request stream conn_id: {} data_ctx_id: {}"
+                                       "request_id: {} update_request_id: {}, ignored",
+                                       conn_ctx.connection_id,
+                                       data_ctx_id,
+                                       request_id,
+                                       update_request_id);
+                    return true;
+                }
+                const auto handler = handler_it->second;
+
+                // Server session level NGR callback.
+                std::optional<std::pair<FullTrackName, std::uint64_t>> new_group_request;
+                if (!client_mode_) {
+                    const auto sub_ctx_it = conn_ctx.recv_req_id.find(request_id);
+                    if (sub_ctx_it == conn_ctx.recv_req_id.end()) {
+                        // TODO: This shouldn;t really be able to happen if we got this far already.
+                        SPDLOG_LOGGER_WARN(
+                          logger_,
+                          "Received REQUEST_UPDATE for unknown subscription conn_id: {} request_id: {}",
+                          conn_ctx.connection_id,
+                          request_id);
+                        SendRequestError(conn_ctx,
+                                         data_ctx_id,
+                                         request_id,
+                                         messages::ErrorCode::kDoesNotExist,
+                                         0ms,
+                                         "Subscription not found");
                         return true;
                     }
-
-                    track_it->second.handler->RequestUpdateReceived(parameters);
-                    return true;
-                }
-
-                // TODO: This should be migrated to the above pattern.
-                auto sub_ctx_it = conn_ctx.recv_req_id.find(request_id);
-                if (sub_ctx_it == conn_ctx.recv_req_id.end()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received subscribe_update for unknown subscription conn_id: {} request_id: {}",
-                                       conn_ctx.connection_id,
-                                       request_id);
-
-                    SendRequestError(conn_ctx,
-                                     data_ctx_id,
-                                     request_id,
-                                     messages::ErrorCode::kDoesNotExist,
-                                     0ms,
-                                     "Subscription not found");
-                    return true;
-                }
-
-                [[maybe_unused]] auto delivery_timeout =
-                  parameters.Get<std::uint64_t>(messages::ParameterType::kDeliveryTimeout);
-                [[maybe_unused]] auto priority = parameters.Get<uint8_t>(messages::ParameterType::kSubscriberPriority);
-                auto forward = parameters.Get<bool>(messages::ParameterType::kForward);
-                auto new_group_request_id =
-                  parameters.GetOptional<std::uint64_t>(messages::ParameterType::kNewGroupRequest);
-
-                if (new_group_request_id.has_value()) {
-                    NewGroupRequested(sub_ctx_it->second.track_full_name, new_group_request_id.value());
-                }
-
-                SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Received subscribe_update to recv request_id: {} forward: {} ngr: {}",
-                                    request_id,
-                                    forward,
-                                    new_group_request_id.has_value());
-
-                for (const auto& pub :
-                     conn_ctx.pub_tracks_by_track_alias[sub_ctx_it->second.track_hash.track_fullname_hash]) {
-                    if (not forward) {
-                        pub.second->SetStatus(PublishTrackHandler::Status::kPaused);
-                    } else {
-                        pub.second->SetStatus(PublishTrackHandler::Status::kNewGroupRequested);
+                    if (const auto new_group_request_id =
+                          parameters.GetOptional<std::uint64_t>(messages::ParameterType::kNewGroupRequest)) {
+                        new_group_request = { sub_ctx_it->second.track_full_name, *new_group_request_id };
                     }
                 }
 
-                SendRequestUpdateOk(conn_ctx, data_ctx_id, std::nullopt, std::nullopt);
+                // Fire callbacks.
+                lock.unlock();
+                handler.handler->RequestUpdateReceived(parameters);
+                if (new_group_request.has_value()) {
+                    NewGroupRequested(new_group_request->first, new_group_request->second);
+                }
                 return true;
             }
             default: {

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -2722,38 +2722,79 @@ namespace quicr {
         }
     }
 
-    void Session::ResolveRequestUpdate(const BaseTrackHandler& handler, const std::optional<RequestError>& error)
+    std::shared_ptr<BaseTrackHandler> Session::ResolveRequestUpdate(const BaseTrackHandler& handler,
+                                                                    const std::optional<RequestError>& error)
     {
         const auto connection_id = handler.GetConnectionId();
         const auto request_id = handler.GetRequestId();
         const auto data_ctx_id = handler.GetDataContextId();
         if (!request_id.has_value() || !data_ctx_id.has_value()) {
             SPDLOG_LOGGER_ERROR(logger_, "ResolveRequestUpdate: Handler not setup");
+            return nullptr;
+        }
+
+        TrackHandler live_handler;
+        {
+            std::lock_guard lock(state_mutex_);
+            const auto conn_it = connections_.find(connection_id);
+            if (conn_it == connections_.end() || conn_it->second.closed) {
+                SPDLOG_LOGGER_WARN(logger_, "ResolveRequestUpdate: Connection doesn't exist");
+            } else {
+                const auto handler_it = conn_it->second.request_handlers.find(*request_id);
+                if (handler_it == conn_it->second.request_handlers.end()) {
+                    SPDLOG_LOGGER_WARN(logger_, "ResolveRequestUpdate: Stale handler");
+                } else if (handler_it->second.handler.get() != &handler) {
+                    SPDLOG_LOGGER_WARN(logger_, "ResolveRequestUpdate: Handler has been replaced");
+                } else {
+                    live_handler = handler_it->second;
+
+                    if (error.has_value()) {
+                        // TODO: Implement redirect.
+                        SendRequestError(conn_it->second,
+                                         *data_ctx_id,
+                                         *request_id,
+                                         error->code,
+                                         error->retry_interval,
+                                         error->reason);
+                        if (live_handler.Get<PublishTrackHandler>()) {
+                            SendPublishDone(conn_it->second,
+                                            *data_ctx_id,
+                                            *request_id,
+                                            messages::PublishDoneStatusCode::kUpdateFailed,
+                                            error->reason);
+                        }
+                    } else {
+                        // TODO: These parameters might be set in certain request update oks.
+                        SendRequestUpdateOk(conn_it->second, *data_ctx_id, std::nullopt, std::nullopt);
+                    }
+                }
+            }
+        }
+
+        return live_handler.handler;
+    }
+
+    void Session::DispatchRequestUpdateCompletion(std::shared_ptr<BaseTrackHandler> handler,
+                                                  bool rejected,
+                                                  bool apply_next) const
+    {
+        assert(!(rejected && apply_next));
+
+        if (!quic_transport_) {
+            SPDLOG_LOGGER_ERROR(logger_, "DispatchRequestUpdateCompletion: No quic_transport");
+            handler->ClearRequestUpdates();
             return;
         }
 
-        std::lock_guard _(state_mutex_);
-        const auto conn_it = connections_.find(connection_id);
-        if (conn_it == connections_.end() || conn_it->second.closed) {
-            SPDLOG_LOGGER_WARN(logger_, "ResolveRequestUpdate: Connection doesn't exist");
+        if (rejected) {
+            // TODO: Possibly this one shouldn't blindly dispatch, depends on what handlers need to do.
+            quic_transport_->Dispatch([handler = std::move(handler)] { handler->RequestUpdateRejected(); });
             return;
         }
 
-        // Ensure this handler is still live.
-        const auto handler_it = conn_it->second.request_handlers.find(*request_id);
-        if (handler_it == conn_it->second.request_handlers.end()) {
-            SPDLOG_LOGGER_WARN(logger_, "ResolveRequestUpdate: Stale handler");
-            return;
-        }
-        // TODO: Ensure the given handler matches handler_it? Should be impossible.
-
-        if (error.has_value()) {
-            // TODO: Implement redirect.
-            SendRequestError(
-              conn_it->second, *data_ctx_id, *request_id, error->code, error->retry_interval, error->reason);
-        } else {
-            // TODO: These parameters might be set in certain request update oks.
-            SendRequestUpdateOk(conn_it->second, *data_ctx_id, std::nullopt, std::nullopt);
+        if (apply_next) {
+            // Dispatch to replicate arrival.
+            quic_transport_->Dispatch([handler = std::move(handler)] { handler->ApplyNextRequestUpdate(); });
         }
     }
 

--- a/src/subscribe_namespace_handler.cpp
+++ b/src/subscribe_namespace_handler.cpp
@@ -69,7 +69,7 @@ quicr::SubscribeNamespaceHandler::RequestOkReceived(const messages::Parameters& 
 }
 
 void
-quicr::SubscribeNamespaceHandler::RequestUpdateReceived([[maybe_unused]] const messages::Parameters& params)
+quicr::SubscribeNamespaceHandler::ApplyRequestUpdate([[maybe_unused]] const messages::Parameters& params)
 {
     throw messages::ProtocolViolationException("Unexpected REQUEST_UPDATE");
 }

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -270,7 +270,7 @@ namespace quicr {
         // TODO: LARGEST_OBJECT
     }
 
-    void SubscribeTrackHandler::RequestUpdateReceived(const messages::Parameters& params)
+    void SubscribeTrackHandler::ApplyRequestUpdate(const messages::Parameters& params)
     {
         if (IsPublisherInitiated()) {
             // Publish can rev keys but nothing else.
@@ -279,7 +279,6 @@ namespace quicr {
                                            messages::ParameterType::kAuthorizationToken,
                                          });
             // TODO: AUTHORIZATION_TOKEN
-            ++pending_request_updates_;
             StatusChanged(Status::kSubscriptionUpdated);
             return;
         }

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -12,6 +12,13 @@
 
 namespace quicr {
 
+    void SubscribeTrackHandler::StatusChanged(Status status)
+    {
+        if (status == Status::kSubscriptionUpdated) {
+            ResolveRequestUpdate();
+        }
+    }
+
     void SubscribeTrackHandler::SupportNewGroupRequest(bool is_supported) noexcept
     {
         support_new_group_request_ = is_supported;
@@ -272,10 +279,8 @@ namespace quicr {
                                            messages::ParameterType::kAuthorizationToken,
                                          });
             // TODO: AUTHORIZATION_TOKEN
-            if (const auto transport = GetTransport().lock()) {
-                transport->ResolveRequestUpdate(
-                  GetConnectionId(), *GetRequestId(), { .error = std::nullopt, .params = {} });
-            }
+            ++pending_request_updates_;
+            StatusChanged(Status::kSubscriptionUpdated);
             return;
         }
 

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -2735,6 +2735,12 @@ PicoQuicTransport::CbNotifier()
     SPDLOG_LOGGER_INFO(logger, "Done with transport callback notifier thread");
 }
 
+void
+PicoQuicTransport::Dispatch(std::function<void()> callback)
+{
+    cbNotifyQueue_.Push(std::move(callback));
+}
+
 std::uint64_t
 PicoQuicTransport::CreateStream(std::uint64_t conn_id, std::uint64_t data_ctx_id, uint8_t priority)
 {

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -333,6 +333,8 @@ namespace quicr {
                                 std::uint64_t data_ctx_id,
                                 std::uint64_t remote_data_ctx_id) override;
 
+        void Dispatch(std::function<void()> callback) override;
+
         /*
          * Internal public methods
          */

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -10,6 +10,7 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
@@ -113,6 +114,60 @@ class CallbackPublishTrackHandler final : public PublishTrackHandler
 
   private:
     const StatusCallback on_status_;
+};
+
+class QueuedUpdatePublishTrackHandler final : public TestPublishTrackHandler
+{
+  public:
+    QueuedUpdatePublishTrackHandler(const FullTrackName& full_track_name,
+                                    std::uint8_t default_priority,
+                                    std::uint32_t default_ttl)
+      : TestPublishTrackHandler(full_track_name, TrackMode::kStream, default_priority, default_ttl)
+    {
+    }
+
+    void StatusChanged(Status status) override
+    {
+        if (status != Status::kSubscriptionUpdated) {
+            return;
+        }
+
+        bool resolve = false;
+        {
+            std::lock_guard lock(mutex_);
+            ++callback_depth_;
+            max_callback_depth_ = std::max(max_callback_depth_, callback_depth_);
+            ++update_count_;
+            resolve = update_count_ > 1;
+        }
+
+        if (resolve) {
+            ResolveRequestUpdate();
+        }
+
+        {
+            std::lock_guard lock(mutex_);
+            --callback_depth_;
+        }
+    }
+
+    std::size_t UpdateCount() const
+    {
+        std::lock_guard lock(mutex_);
+        return update_count_;
+    }
+
+    std::size_t MaxCallbackDepth() const
+    {
+        std::lock_guard lock(mutex_);
+        return max_callback_depth_;
+    }
+
+  private:
+    mutable std::mutex mutex_;
+    std::size_t update_count_{ 0 };
+    std::size_t callback_depth_{ 0 };
+    std::size_t max_callback_depth_{ 0 };
 };
 
 static std::shared_ptr<TestServer>
@@ -1723,5 +1778,99 @@ TEST_CASE("Integration - Request updates use handler data context")
     SUBCASE("WebTransport")
     {
         test_request_update_data_context("https");
+    }
+}
+
+TEST_CASE("Integration - Request updates are serialised")
+{
+    auto server = MakeTestServer();
+
+    auto test_serialised_updates = [&](const std::string& protocol_scheme) {
+        FullTrackName ftn;
+        ftn.name_space = TrackNamespace(std::vector<std::string>{ "ctrl", "serial-update" });
+        ftn.name = { 7, 8, 9 };
+
+        const auto server_handler = std::make_shared<QueuedUpdatePublishTrackHandler>(ftn, 0, 5000);
+        server->SetNextSubscribePublishHandler(server_handler);
+
+        auto subscriber = MakeTestClient(true, std::nullopt, protocol_scheme);
+
+        const auto subscriber_handler = TestSubscribeHandler::Create(ftn, 0, std::nullopt);
+        CHECK_NOTHROW(subscriber->SubscribeTrack(subscriber_handler));
+        REQUIRE(WaitFor([&]() { return subscriber_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; }));
+
+        subscriber_handler->Pause();
+        subscriber_handler->Resume();
+        subscriber_handler->Pause();
+
+        REQUIRE(WaitFor([&]() { return server_handler->UpdateCount() == 1; }));
+        std::this_thread::sleep_for(kNegativeTimeout);
+        CHECK_EQ(server_handler->UpdateCount(), 1);
+        CHECK_EQ(server_handler->GetStatus(), PublishTrackHandler::Status::kPaused);
+
+        server_handler->ResolveRequestUpdate();
+
+        REQUIRE(WaitFor([&]() { return server_handler->UpdateCount() == 3; }));
+        REQUIRE(WaitFor([&]() { return subscriber_handler->RequestUpdateOks() == 3; }));
+
+        CHECK_EQ(server_handler->MaxCallbackDepth(), 1);
+        CHECK_EQ(server_handler->GetStatus(), PublishTrackHandler::Status::kPaused);
+    };
+
+    SUBCASE("Raw QUIC")
+    {
+        test_serialised_updates("moq");
+    }
+
+    SUBCASE("WebTransport")
+    {
+        test_serialised_updates("https");
+    }
+}
+
+TEST_CASE("Integration - Rejected request update terminates the subscription")
+{
+    auto server = MakeTestServer();
+
+    auto test_rejected_update = [&](const std::string& protocol_scheme) {
+        FullTrackName ftn;
+        ftn.name_space = TrackNamespace(std::vector<std::string>{ "ctrl", "rejected-update" });
+        ftn.name = { 7, 8, 9 };
+
+        const auto server_handler = std::make_shared<QueuedUpdatePublishTrackHandler>(ftn, 0, 5000);
+        server->SetNextSubscribePublishHandler(server_handler);
+
+        auto subscriber = MakeTestClient(true, std::nullopt, protocol_scheme);
+
+        const auto subscriber_handler = TestSubscribeHandler::Create(ftn, 0, std::nullopt);
+        CHECK_NOTHROW(subscriber->SubscribeTrack(subscriber_handler));
+        REQUIRE(WaitFor([&]() { return subscriber_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; }));
+
+        subscriber_handler->Pause();
+        subscriber_handler->Resume();
+
+        REQUIRE(WaitFor([&]() { return server_handler->UpdateCount() == 1; }));
+        server_handler->ResolveRequestUpdate(RequestError{
+          .code = messages::ErrorCode::kUnauthorized,
+          .retry_interval = std::chrono::milliseconds::zero(),
+          .reason = "rejected",
+        });
+
+        REQUIRE(
+          WaitFor([&]() { return subscriber_handler->GetStatus() == SubscribeTrackHandler::Status::kNotSubscribed; }));
+        REQUIRE(WaitFor([&]() { return server_handler->GetStatus() == PublishTrackHandler::Status::kUnsubscribed; }));
+        std::this_thread::sleep_for(kNegativeTimeout);
+        CHECK_EQ(server_handler->UpdateCount(), 1);
+        CHECK_THROWS_AS(server_handler->ResolveRequestUpdate(), std::logic_error);
+    };
+
+    SUBCASE("Raw QUIC")
+    {
+        test_rejected_update("moq");
+    }
+
+    SUBCASE("WebTransport")
+    {
+        test_rejected_update("https");
     }
 }

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -22,6 +22,9 @@ TestPublishTrackHandler::StatusChanged(Status status)
             }
             break;
         }
+        case Status::kSubscriptionUpdated:
+            ResolveRequestUpdate();
+            break;
         case Status::kUnsubscribed: {
             if (const auto svr = server_.lock()) {
                 if (svr->unsubscribe_promise_.has_value()) {

--- a/test/integration_test/test_server.cpp
+++ b/test/integration_test/test_server.cpp
@@ -134,12 +134,15 @@ TestServer::SubscribeReceived(std::uint64_t connection_id,
                                 : 5000;
 
     // Create a publish track handler to send objects to this subscriber
-    auto pub_track_handler =
-      std::make_shared<TestPublishTrackHandler>(track_full_name,
-                                                TrackMode::kStream,
-                                                subscribe_attributes.priority,
-                                                ttl,
-                                                std::static_pointer_cast<TestServer>(shared_from_this()));
+    auto pub_track_handler = std::move(next_subscribe_publish_handler_);
+    if (!pub_track_handler) {
+        pub_track_handler =
+          std::make_shared<TestPublishTrackHandler>(track_full_name,
+                                                    TrackMode::kStream,
+                                                    subscribe_attributes.priority,
+                                                    ttl,
+                                                    std::static_pointer_cast<TestServer>(shared_from_this()));
+    }
 
     if (!subscribe_attributes.is_publisher_initiated) {
         ResolveSubscribe(connection_id,

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -188,6 +188,12 @@ namespace quicr_test {
             expected_unsubscribe_handler_type_ = handler_type;
         }
 
+        void SetNextSubscribePublishHandler(std::shared_ptr<TestPublishTrackHandler> handler)
+        {
+            std::lock_guard lock(state_mutex_);
+            next_subscribe_publish_handler_ = std::move(handler);
+        }
+
         // PublishNamespaceDone received.
         void SetPublishNamespaceDonePromise(std::promise<uint64_t> promise)
         {
@@ -294,6 +300,7 @@ namespace quicr_test {
         std::optional<std::promise<uint64_t>> publish_namespace_done_promise_;
         std::optional<std::promise<UnsubscribeReceivedDetails>> unsubscribe_received_promise_;
         std::optional<UnsubscribeReceivedDetails::HandlerType> expected_unsubscribe_handler_type_;
+        std::shared_ptr<TestPublishTrackHandler> next_subscribe_publish_handler_;
         std::map<std::uint64_t, bool> closed_streams_;
         std::vector<quicr::TrackNamespace> known_published_namespaces_;
         std::shared_ptr<quicr::PublishNamespaceHandler> publish_namespace_handler_;

--- a/test/track_handlers.cpp
+++ b/test/track_handlers.cpp
@@ -58,6 +58,47 @@ TEST_CASE("Publish Track Handler updates don't override status")
     CHECK_EQ(handler->statuses[1], quicr::PublishTrackHandler::Status::kSubscriptionUpdated);
 }
 
+TEST_CASE("Publish Track Handler abandons queued request updates without a transport")
+{
+    auto handler = TestPublishTrackHandler::Create();
+    const auto pause = quicr::messages::Parameters{}.Add(quicr::messages::ParameterType::kForward, false);
+    const auto resume = quicr::messages::Parameters{}.Add(quicr::messages::ParameterType::kForward, true);
+
+    handler->RequestUpdateReceived(pause);
+    handler->RequestUpdateReceived(resume);
+
+    CHECK_EQ(handler->GetStatus(), quicr::PublishTrackHandler::Status::kPaused);
+    REQUIRE_EQ(handler->statuses.size(), 2);
+
+    handler->ResolveRequestUpdate();
+
+    CHECK_EQ(handler->GetStatus(), quicr::PublishTrackHandler::Status::kPaused);
+    CHECK_EQ(handler->statuses.size(), 2);
+    CHECK_THROWS_AS(handler->ResolveRequestUpdate(), std::logic_error);
+}
+
+TEST_CASE("Publish Track Handler rejection clears queued request updates")
+{
+    auto handler = TestPublishTrackHandler::Create();
+    const auto pause = quicr::messages::Parameters{}.Add(quicr::messages::ParameterType::kForward, false);
+    const auto resume = quicr::messages::Parameters{}.Add(quicr::messages::ParameterType::kForward, true);
+
+    handler->RequestUpdateReceived(pause);
+    handler->RequestUpdateReceived(resume);
+
+    handler->ResolveRequestUpdate(quicr::RequestError{
+      .code = quicr::messages::ErrorCode::kUnauthorized,
+      .retry_interval = std::chrono::milliseconds::zero(),
+      .reason = "rejected",
+    });
+
+    CHECK_EQ(handler->GetStatus(), quicr::PublishTrackHandler::Status::kPaused);
+    const auto status_count = handler->statuses.size();
+    handler->RequestUpdateReceived(resume);
+    CHECK_EQ(handler->statuses.size(), status_count);
+    CHECK_THROWS_AS(handler->ResolveRequestUpdate(), std::logic_error);
+}
+
 class TestSubscribeTrackHandler : public quicr::SubscribeTrackHandler
 {
   public:

--- a/test/track_handlers.cpp
+++ b/test/track_handlers.cpp
@@ -8,6 +8,8 @@
 
 #include <doctest/doctest.h>
 
+#include <stdexcept>
+
 class TestPublishTrackHandler : public quicr::PublishTrackHandler
 {
     TestPublishTrackHandler()
@@ -20,6 +22,12 @@ class TestPublishTrackHandler : public quicr::PublishTrackHandler
     {
         return std::shared_ptr<TestPublishTrackHandler>(new TestPublishTrackHandler());
     }
+
+    void StatusChanged(Status status) override { statuses.push_back(status); }
+
+    using quicr::PublishTrackHandler::RequestUpdateReceived;
+
+    std::vector<Status> statuses;
 };
 
 TEST_CASE("Create Track Handler")
@@ -35,6 +43,21 @@ TEST_CASE("Publish Track Handler CanPublish")
     CHECK_FALSE(handler->CanPublish());
 }
 
+TEST_CASE("Publish Track Handler updates don't override status")
+{
+    auto handler = TestPublishTrackHandler::Create();
+    const auto parameters = quicr::messages::Parameters{}
+                              .Add(quicr::messages::ParameterType::kSubscriberPriority, std::uint8_t{ 42 })
+                              .Add(quicr::messages::ParameterType::kForward, false);
+
+    handler->RequestUpdateReceived(parameters);
+
+    CHECK_EQ(handler->GetStatus(), quicr::PublishTrackHandler::Status::kPaused);
+    REQUIRE_EQ(handler->statuses.size(), 2);
+    CHECK_EQ(handler->statuses[0], quicr::PublishTrackHandler::Status::kPaused);
+    CHECK_EQ(handler->statuses[1], quicr::PublishTrackHandler::Status::kSubscriptionUpdated);
+}
+
 class TestSubscribeTrackHandler : public quicr::SubscribeTrackHandler
 {
   public:
@@ -48,15 +71,22 @@ class TestSubscribeTrackHandler : public quicr::SubscribeTrackHandler
         std::optional<quicr::Extensions> immutable_extensions;
     };
 
-    TestSubscribeTrackHandler()
-      : SubscribeTrackHandler({ {}, {} }, 0, quicr::messages::GroupOrder::kAscending)
+    explicit TestSubscribeTrackHandler(bool publisher_initiated = false)
+      : SubscribeTrackHandler({ {}, {} },
+                              0,
+                              quicr::messages::GroupOrder::kAscending,
+                              {},
+                              std::nullopt,
+                              publisher_initiated)
     {
     }
 
-    static std::shared_ptr<TestSubscribeTrackHandler> Create()
+    static std::shared_ptr<TestSubscribeTrackHandler> Create(bool publisher_initiated = false)
     {
-        return std::shared_ptr<TestSubscribeTrackHandler>(new TestSubscribeTrackHandler());
+        return std::shared_ptr<TestSubscribeTrackHandler>(new TestSubscribeTrackHandler(publisher_initiated));
     }
+
+    void StatusChanged(Status status) override { statuses.push_back(status); }
 
     void ObjectStatusReceived(const uint64_t group_id,
                               const uint64_t object_id,
@@ -69,9 +99,48 @@ class TestSubscribeTrackHandler : public quicr::SubscribeTrackHandler
         status_received_count++;
     }
 
+    using quicr::SubscribeTrackHandler::RequestUpdateReceived;
+
     std::optional<ReceivedStatus> last_status;
     int status_received_count{ 0 };
+    std::vector<Status> statuses;
 };
+
+TEST_CASE("Subscribe Track Handler updates don't override status")
+{
+    auto handler = TestSubscribeTrackHandler::Create(true);
+
+    handler->RequestUpdateReceived({});
+
+    CHECK_EQ(handler->GetStatus(), quicr::SubscribeTrackHandler::Status::kOk);
+    REQUIRE_EQ(handler->statuses.size(), 1);
+    CHECK_EQ(handler->statuses[0], quicr::SubscribeTrackHandler::Status::kSubscriptionUpdated);
+}
+
+TEST_CASE("Track Handler resolves exactly one update per received update")
+{
+    std::shared_ptr<quicr::BaseTrackHandler> handler;
+    std::function<void()> receive_update;
+    SUBCASE("Publish")
+    {
+        auto h = TestPublishTrackHandler::Create();
+        receive_update = [h] { h->RequestUpdateReceived({}); };
+        handler = h;
+    }
+    SUBCASE("Subscribe")
+    {
+        auto h = TestSubscribeTrackHandler::Create(true);
+        receive_update = [h] { h->RequestUpdateReceived({}); };
+        handler = h;
+    }
+
+    // Request arrives.
+    receive_update();
+    // Consume should work.
+    CHECK_NOTHROW(handler->ResolveRequestUpdate());
+    // Another consume should throw.
+    CHECK_THROWS_AS(handler->ResolveRequestUpdate(), std::logic_error);
+}
 
 TEST_CASE("Subscribe Track Handler ObjectStatusReceived - kDoesNotExist")
 {


### PR DESCRIPTION
Redesigns the public facing API to hide away MoQ request update internals, e.g: parameters. We can safely do this because libquicr must understand a parameter in order to parse it, and so we can work in "resolved" concepts like updated forward state or priority instead of kicking a parameter blob back to the app.  

The new flow looks like this:

- Internally, a REQUEST_UPDATE arrives with some parameters. 
- Internally, Session forwards this to the respective handler's internal request update callback.
- Internally, this callback parses the parameters and validates them according to the per-request rules. It then updates the internal state of the handler as appropriate (e.g the forward state). 
- Publicly, the handler notifies the app it has been updated (right now, through the existing Status callback). 
- At this point, the app can inspect the new state, and make a decision about whether to accept or reject the update. We can do this *after* setting the state because a rejection is terminal, so I figured we can avoid dealing with pending state since it's going to either be accepted or ended anyway. This may need some more thought, we could keep it pending until it's accepted.  
- The app then calls `ResolveRequestUpdate` to get libquicr to emit the right REQUEST_UPDATE_OK or REQUEST_ERROR. It can do this synchronously in the callback, or asynchronously later on (but it needs to understand the next bit).

The other thing to understand is that request updates have changed slightly, they're now only identifiable to each other based on the arrival ordering on the request stream, so they need to be resolved by the app in receipt order (FIFO). Multiple can be in-flight / pending at once as well, and the app resolve callbacks could be async, hence the atomic pending dance. It is up to the app to manage to resolve ordering though. `MAX_REQUEST_UPDATES` will come into play here later in draft-19. 

One thing that we might want to change is have updated be a dedicated callback instead of driven from status. We may also want to callback *what* properties have changed. 

You'll see in the default status callback I now resolve a request update blindly. This is a bit odd, but I do this because it allows the non-subclassed handlers to work out the box in the straight forward simple case, rather than falling over on any update. Anyone doing really work should subclass these anyway, so it seemed like the right thing to do. 