### PR TITLE
Subgroup original first object support

### DIFF
--- a/include/quicr/handlers/subscribe_track_handler.h
+++ b/include/quicr/handlers/subscribe_track_handler.h
@@ -282,7 +282,7 @@ namespace quicr {
          *
          * @param object_headers    Object headers, must include group and object Ids
          * @param data              Object payload data received, **MUST** match ObjectHeaders::payload_length.
-         * @param stream_mode       Subgroup header type
+         * @param stream_mode       If this is the first object of a subgroup, its properties.
          */
         virtual void ObjectReceived([[maybe_unused]] const ObjectHeaders& object_headers,
                                     [[maybe_unused]] BytesSpan data,

--- a/include/quicr/messages/messages.h
+++ b/include/quicr/messages/messages.h
@@ -111,17 +111,22 @@ namespace quicr::messages {
         // If true, the priority field is omitted and the subgroup inherits the publisher priority.
         // If false, the priority field is present and the subgroup has its own priority.
         const bool default_priority;
+        // If true, this is the original first object of this subgroup.
+        // If false, this may be the first object on the subgroup, but there are missing priors.
+        const bool first_object;
 
         static constexpr std::uint8_t kExtensionsBit = 0x01;
         static constexpr std::uint8_t kSubgroupIdBit = 0x06;
         static constexpr std::uint8_t kEndOfGroupBit = 0x08;
         static constexpr std::uint8_t kDefaultPriorityBit = 0x20;
+        static constexpr std::uint8_t kFirstObjectBit = 0x40;
 
         explicit constexpr StreamHeaderProperties(const std::uint64_t type)
           : extensions(type & kExtensionsBit)
           , subgroup_id_mode(static_cast<SubgroupIdType>((type & kSubgroupIdBit) >> 1))
           , end_of_group(type & kEndOfGroupBit)
           , default_priority(type & kDefaultPriorityBit)
+          , first_object(type & kFirstObjectBit)
         {
             if (!IsValid(type)) {
                 throw ProtocolViolationException("Invalid stream header type");
@@ -131,11 +136,13 @@ namespace quicr::messages {
         constexpr StreamHeaderProperties(const bool extensions,
                                          const SubgroupIdType subgroup_id_mode,
                                          const bool end_of_group,
-                                         const bool default_priority)
+                                         const bool default_priority,
+                                         const bool first_object)
           : extensions(extensions)
           , subgroup_id_mode(subgroup_id_mode)
           , end_of_group(end_of_group)
           , default_priority(default_priority)
+          , first_object(first_object)
         {
             if (subgroup_id_mode == SubgroupIdType::kReserved) {
                 throw ProtocolViolationException("Subgroup ID mode cannot be kReserved");
@@ -155,12 +162,15 @@ namespace quicr::messages {
             if (default_priority) {
                 type |= kDefaultPriorityBit;
             }
+            if (first_object) {
+                type |= kFirstObjectBit;
+            }
             return type;
         }
 
         static constexpr bool IsValid(const std::uint64_t type) noexcept
         {
-            if ((type & 0b11010000) != 0b00010000) {
+            if ((type & 0b10010000) != 0b00010000) {
                 return false;
             }
             if ((type & 0x06) == 0x06) {

--- a/include/quicr/messages/messages.h
+++ b/include/quicr/messages/messages.h
@@ -116,14 +116,17 @@ namespace quicr::messages {
         const bool first_object;
 
         static constexpr std::uint8_t kExtensionsBit = 0x01;
-        static constexpr std::uint8_t kSubgroupIdBit = 0x06;
+        static constexpr std::uint8_t kSubgroupIdMask = 0x06;
         static constexpr std::uint8_t kEndOfGroupBit = 0x08;
+        static constexpr std::uint8_t kTypeBit = 0x10;
         static constexpr std::uint8_t kDefaultPriorityBit = 0x20;
         static constexpr std::uint8_t kFirstObjectBit = 0x40;
+        static constexpr std::uint64_t kAllowedBitsMask =
+          kExtensionsBit | kSubgroupIdMask | kEndOfGroupBit | kTypeBit | kDefaultPriorityBit | kFirstObjectBit;
 
         explicit constexpr StreamHeaderProperties(const std::uint64_t type)
           : extensions(type & kExtensionsBit)
-          , subgroup_id_mode(static_cast<SubgroupIdType>((type & kSubgroupIdBit) >> 1))
+          , subgroup_id_mode(static_cast<SubgroupIdType>((type & kSubgroupIdMask) >> 1))
           , end_of_group(type & kEndOfGroupBit)
           , default_priority(type & kDefaultPriorityBit)
           , first_object(type & kFirstObjectBit)
@@ -151,7 +154,7 @@ namespace quicr::messages {
 
         constexpr std::uint64_t GetType() const
         {
-            std::uint64_t type = 0b00010000;
+            std::uint64_t type = kTypeBit;
             if (extensions) {
                 type |= kExtensionsBit;
             }
@@ -170,13 +173,8 @@ namespace quicr::messages {
 
         static constexpr bool IsValid(const std::uint64_t type) noexcept
         {
-            if ((type & 0b10010000) != 0b00010000) {
-                return false;
-            }
-            if ((type & 0x06) == 0x06) {
-                return false;
-            }
-            return true;
+            return (type & ~kAllowedBitsMask) == 0 && (type & kTypeBit) != 0 &&
+                   (type & kSubgroupIdMask) != kSubgroupIdMask;
         }
     };
 

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -32,7 +32,7 @@ namespace quicr {
                 if (stream_mode.has_value()) {
                     stream_mode_.emplace(*stream_mode);
                 } else {
-                    stream_mode_.emplace(true, messages::SubgroupIdType::kExplicit, false, false, false);
+                    stream_mode_.emplace(true, messages::SubgroupIdType::kExplicit, false, false, true);
                 }
                 break;
         }

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -32,7 +32,7 @@ namespace quicr {
                 if (stream_mode.has_value()) {
                     stream_mode_.emplace(*stream_mode);
                 } else {
-                    stream_mode_.emplace(true, messages::SubgroupIdType::kExplicit, false, false);
+                    stream_mode_.emplace(true, messages::SubgroupIdType::kExplicit, false, false, false);
                 }
                 break;
         }

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -57,6 +57,10 @@ namespace quicr {
         auto& obj = stream.buffer.GetAnyB<messages::StreamSubGroupObject>();
         obj.properties.emplace(*s_hdr.properties);
         if (stream.buffer >> obj) {
+            std::optional<messages::StreamHeaderProperties> stream_properties;
+            if (!stream.next_object_id.has_value()) {
+                stream_properties.emplace(*s_hdr.properties);
+            }
 
             SPDLOG_TRACE("Received stream_subgroup_object priority: {} stream_id: {} track_alias: {} "
                          "group: {} subgroup: {} object: {} data size: {} type: {}",
@@ -108,7 +112,7 @@ namespace quicr {
                     obj.immutable_extensions,
                   },
                   obj.payload,
-                  s_hdr.properties);
+                  std::move(stream_properties));
 
                 *stream.next_object_id += 1;
             } catch (const std::exception& e) {

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -107,7 +107,8 @@ namespace quicr {
                     obj.extensions,
                     obj.immutable_extensions,
                   },
-                  obj.payload);
+                  obj.payload,
+                  s_hdr.properties);
 
                 *stream.next_object_id += 1;
             } catch (const std::exception& e) {

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -185,6 +185,7 @@ class TestSubscribeHandler : public SubscribeTrackHandler
         ObjectStatus status;
         std::vector<uint8_t> data;
         std::optional<Extensions> extensions;
+        std::optional<messages::StreamHeaderProperties> stream_mode;
     };
 
     static std::shared_ptr<TestSubscribeHandler> Create(const FullTrackName& full_track_name,
@@ -238,7 +239,7 @@ class TestSubscribeHandler : public SubscribeTrackHandler
 
     void ObjectReceived(const ObjectHeaders& object_headers,
                         BytesSpan data,
-                        std::optional<messages::StreamHeaderProperties>) override
+                        std::optional<messages::StreamHeaderProperties> stream_mode) override
     {
         std::lock_guard lock(mutex_);
         if (!data.empty()) {
@@ -247,7 +248,8 @@ class TestSubscribeHandler : public SubscribeTrackHandler
                                           .object_id = object_headers.object_id,
                                           .status = object_headers.status,
                                           .data = std::vector<uint8_t>(data.begin(), data.end()),
-                                          .extensions = object_headers.extensions });
+                                          .extensions = object_headers.extensions,
+                                          .stream_mode = stream_mode });
 
             // Check if we've reached the target count
             if (object_count_promise_.has_value() && received_objects_.size() >= target_object_count_) {
@@ -1406,23 +1408,26 @@ TEST_CASE("Integration - New subgroup preserves object IDs")
         REQUIRE(sub_ready);
 
         // Publishes objects with headers in payload.
-        auto publish_object = [&](uint64_t group_id, uint64_t subgroup_id, uint64_t object_id) {
-            std::vector payload = { static_cast<uint8_t>(group_id),
-                                    static_cast<uint8_t>(subgroup_id),
-                                    static_cast<uint8_t>(object_id) };
-            ObjectHeaders headers = { .group_id = group_id,
-                                      .object_id = object_id,
-                                      .subgroup_id = subgroup_id,
-                                      .payload_length = payload.size(),
-                                      .status = ObjectStatus::kAvailable,
-                                      .priority = 3,
-                                      .ttl = 1000,
-                                      .track_mode = TrackMode::kStream,
-                                      .extensions = std::nullopt,
-                                      .immutable_extensions = std::nullopt };
-            auto status = pub_handler->PublishObject(headers, payload);
-            REQUIRE_EQ(status, PublishTrackHandler::PublishObjectStatus::kOk);
-        };
+        auto publish_object =
+          [&](uint64_t group_id, uint64_t subgroup_id, uint64_t object_id, bool first_object = true) {
+              std::vector payload = { static_cast<uint8_t>(group_id),
+                                      static_cast<uint8_t>(subgroup_id),
+                                      static_cast<uint8_t>(object_id) };
+              ObjectHeaders headers = { .group_id = group_id,
+                                        .object_id = object_id,
+                                        .subgroup_id = subgroup_id,
+                                        .payload_length = payload.size(),
+                                        .status = ObjectStatus::kAvailable,
+                                        .priority = 3,
+                                        .ttl = 1000,
+                                        .track_mode = TrackMode::kStream,
+                                        .extensions = std::nullopt,
+                                        .immutable_extensions = std::nullopt };
+              const messages::StreamHeaderProperties stream_mode(
+                true, messages::SubgroupIdType::kExplicit, false, false, first_object);
+              auto status = pub_handler->PublishObject(headers, payload, stream_mode);
+              REQUIRE_EQ(status, PublishTrackHandler::PublishObjectStatus::kOk);
+          };
 
         // Subgroup 0.
         publish_object(0, 0, 0);
@@ -1432,8 +1437,8 @@ TEST_CASE("Integration - New subgroup preserves object IDs")
         publish_object(0, 1, 2);
         pub_handler->EndSubgroup(0, 1, true);
         // Subgroup 2.
-        publish_object(0, 2, 3);
-        publish_object(0, 2, 4);
+        publish_object(0, 2, 3, false);
+        publish_object(0, 2, 4, false);
         // Let's end on a new group.
         publish_object(1, 0, 0);
 
@@ -1448,6 +1453,9 @@ TEST_CASE("Integration - New subgroup preserves object IDs")
             CHECK_EQ(obj.group_id, obj.data[0]);
             CHECK_EQ(obj.subgroup_id, obj.data[1]);
             CHECK_EQ(obj.object_id, obj.data[2]);
+            REQUIRE(obj.stream_mode.has_value());
+            const bool expected_first_object = obj.group_id != 0 || obj.subgroup_id != 2;
+            CHECK_EQ(obj.stream_mode->first_object, expected_first_object);
         }
     };
 

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1434,17 +1434,17 @@ TEST_CASE("Integration - New subgroup preserves object IDs")
         };
 
         // Subgroup 0.
-        publish_object(0, 0, 0, true);
+        publish_object(0, 0, 0);
         publish_object(0, 0, 1);
         pub_handler->EndSubgroup(0, 0, true);
         // Subgroup 1.
-        publish_object(0, 1, 2, true);
+        publish_object(0, 1, 2);
         pub_handler->EndSubgroup(0, 1, true);
         // Subgroup 2, replicating a relay mid-subgroup forward (non-original first object).
         publish_object(0, 2, 3, false);
         publish_object(0, 2, 4);
         // Let's end on a new group.
-        publish_object(1, 0, 0, true);
+        publish_object(1, 0, 0);
 
         // Make sure we got everything.
         auto receive_status = all_received_future.wait_for(std::chrono::milliseconds(3000));

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1408,39 +1408,43 @@ TEST_CASE("Integration - New subgroup preserves object IDs")
         REQUIRE(sub_ready);
 
         // Publishes objects with headers in payload.
-        auto publish_object =
-          [&](uint64_t group_id, uint64_t subgroup_id, uint64_t object_id, bool first_object = true) {
-              std::vector payload = { static_cast<uint8_t>(group_id),
-                                      static_cast<uint8_t>(subgroup_id),
-                                      static_cast<uint8_t>(object_id) };
-              ObjectHeaders headers = { .group_id = group_id,
-                                        .object_id = object_id,
-                                        .subgroup_id = subgroup_id,
-                                        .payload_length = payload.size(),
-                                        .status = ObjectStatus::kAvailable,
-                                        .priority = 3,
-                                        .ttl = 1000,
-                                        .track_mode = TrackMode::kStream,
-                                        .extensions = std::nullopt,
-                                        .immutable_extensions = std::nullopt };
-              const messages::StreamHeaderProperties stream_mode(
-                true, messages::SubgroupIdType::kExplicit, false, false, first_object);
-              auto status = pub_handler->PublishObject(headers, payload, stream_mode);
-              REQUIRE_EQ(status, PublishTrackHandler::PublishObjectStatus::kOk);
-          };
+        auto publish_object = [&](uint64_t group_id,
+                                  uint64_t subgroup_id,
+                                  uint64_t object_id,
+                                  std::optional<bool> first_object = std::nullopt) {
+            std::vector payload = { static_cast<uint8_t>(group_id),
+                                    static_cast<uint8_t>(subgroup_id),
+                                    static_cast<uint8_t>(object_id) };
+            ObjectHeaders headers = { .group_id = group_id,
+                                      .object_id = object_id,
+                                      .subgroup_id = subgroup_id,
+                                      .payload_length = payload.size(),
+                                      .status = ObjectStatus::kAvailable,
+                                      .priority = 3,
+                                      .ttl = 1000,
+                                      .track_mode = TrackMode::kStream,
+                                      .extensions = std::nullopt,
+                                      .immutable_extensions = std::nullopt };
+            std::optional<messages::StreamHeaderProperties> stream_mode;
+            if (first_object.has_value()) {
+                stream_mode.emplace(true, messages::SubgroupIdType::kExplicit, false, false, *first_object);
+            }
+            auto status = pub_handler->PublishObject(headers, payload, stream_mode);
+            REQUIRE_EQ(status, PublishTrackHandler::PublishObjectStatus::kOk);
+        };
 
         // Subgroup 0.
-        publish_object(0, 0, 0);
+        publish_object(0, 0, 0, true);
         publish_object(0, 0, 1);
         pub_handler->EndSubgroup(0, 0, true);
         // Subgroup 1.
-        publish_object(0, 1, 2);
+        publish_object(0, 1, 2, true);
         pub_handler->EndSubgroup(0, 1, true);
-        // Subgroup 2.
+        // Subgroup 2, replicating a relay mid-subgroup forward (non-original first object).
         publish_object(0, 2, 3, false);
-        publish_object(0, 2, 4, false);
+        publish_object(0, 2, 4);
         // Let's end on a new group.
-        publish_object(1, 0, 0);
+        publish_object(1, 0, 0, true);
 
         // Make sure we got everything.
         auto receive_status = all_received_future.wait_for(std::chrono::milliseconds(3000));
@@ -1453,9 +1457,17 @@ TEST_CASE("Integration - New subgroup preserves object IDs")
             CHECK_EQ(obj.group_id, obj.data[0]);
             CHECK_EQ(obj.subgroup_id, obj.data[1]);
             CHECK_EQ(obj.object_id, obj.data[2]);
-            REQUIRE(obj.stream_mode.has_value());
-            const bool expected_first_object = obj.group_id != 0 || obj.subgroup_id != 2;
-            CHECK_EQ(obj.stream_mode->first_object, expected_first_object);
+            // Validate original first object roundtrip. The subgroup header is only set on
+            // first object of the subgroup stream (which may or may not be the subgroup's original first object).
+            const bool is_first_subgroup_object = (obj.group_id == 0 && obj.subgroup_id == 0 && obj.object_id == 0) ||
+                                                  (obj.group_id == 0 && obj.subgroup_id == 1 && obj.object_id == 2) ||
+                                                  (obj.group_id == 0 && obj.subgroup_id == 2 && obj.object_id == 3) ||
+                                                  (obj.group_id == 1 && obj.subgroup_id == 0 && obj.object_id == 0);
+            CHECK_EQ(obj.stream_mode.has_value(), is_first_subgroup_object);
+            if (obj.stream_mode.has_value()) {
+                const bool expected_original_first = obj.group_id != 0 || obj.subgroup_id != 2;
+                CHECK_EQ(obj.stream_mode->first_object, expected_original_first);
+            }
         }
     };
 

--- a/test/moq_data_messages.cpp
+++ b/test/moq_data_messages.cpp
@@ -392,22 +392,28 @@ StreamHeaderEncodeDecode(StreamHeaderProperties type)
 
 TEST_CASE("StreamHeader Message encode/decode")
 {
+    CHECK_EQ(StreamHeaderProperties(false, SubgroupIdType::kIsZero, false, false, true).GetType(), 0x50);
+    CHECK(StreamHeaderProperties(0x50).first_object);
+
     const std::vector stream_headers = {
         // subgroup_id_mode = kIsZero
-        StreamHeaderProperties(false, SubgroupIdType::kIsZero, false, false),
-        StreamHeaderProperties(true, SubgroupIdType::kIsZero, false, false),
-        StreamHeaderProperties(false, SubgroupIdType::kIsZero, true, false),
-        StreamHeaderProperties(true, SubgroupIdType::kIsZero, true, false),
+        StreamHeaderProperties(false, SubgroupIdType::kIsZero, false, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kIsZero, false, false, false),
+        StreamHeaderProperties(false, SubgroupIdType::kIsZero, true, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kIsZero, true, false, false),
+        StreamHeaderProperties(false, SubgroupIdType::kIsZero, false, false, true),
         // subgroup_id_mode = kSetFromFirstObject
-        StreamHeaderProperties(false, SubgroupIdType::kSetFromFirstObject, false, false),
-        StreamHeaderProperties(true, SubgroupIdType::kSetFromFirstObject, false, false),
-        StreamHeaderProperties(false, SubgroupIdType::kSetFromFirstObject, true, false),
-        StreamHeaderProperties(true, SubgroupIdType::kSetFromFirstObject, true, false),
+        StreamHeaderProperties(false, SubgroupIdType::kSetFromFirstObject, false, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kSetFromFirstObject, false, false, false),
+        StreamHeaderProperties(false, SubgroupIdType::kSetFromFirstObject, true, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kSetFromFirstObject, true, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kSetFromFirstObject, false, false, true),
         // subgroup_id_mode = kExplicit
-        StreamHeaderProperties(false, SubgroupIdType::kExplicit, false, false),
-        StreamHeaderProperties(true, SubgroupIdType::kExplicit, false, false),
-        StreamHeaderProperties(false, SubgroupIdType::kExplicit, true, false),
-        StreamHeaderProperties(true, SubgroupIdType::kExplicit, true, false),
+        StreamHeaderProperties(false, SubgroupIdType::kExplicit, false, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kExplicit, false, false, false),
+        StreamHeaderProperties(false, SubgroupIdType::kExplicit, true, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kExplicit, true, false, false),
+        StreamHeaderProperties(false, SubgroupIdType::kExplicit, true, false, true),
     };
     for (const auto& props : stream_headers) {
         CAPTURE(props.GetType());
@@ -536,20 +542,20 @@ TEST_CASE("StreamPerSubGroup Object Message encode/decode")
     // - default_priority: false (for now, matching original tests)
     const std::vector stream_headers = {
         // subgroup_id_mode = kIsZero
-        StreamHeaderProperties(false, SubgroupIdType::kIsZero, false, false),
-        StreamHeaderProperties(true, SubgroupIdType::kIsZero, false, false),
-        StreamHeaderProperties(false, SubgroupIdType::kIsZero, true, false),
-        StreamHeaderProperties(true, SubgroupIdType::kIsZero, true, false),
+        StreamHeaderProperties(false, SubgroupIdType::kIsZero, false, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kIsZero, false, false, false),
+        StreamHeaderProperties(false, SubgroupIdType::kIsZero, true, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kIsZero, true, false, false),
         // subgroup_id_mode = kSetFromFirstObject
-        StreamHeaderProperties(false, SubgroupIdType::kSetFromFirstObject, false, false),
-        StreamHeaderProperties(true, SubgroupIdType::kSetFromFirstObject, false, false),
-        StreamHeaderProperties(false, SubgroupIdType::kSetFromFirstObject, true, false),
-        StreamHeaderProperties(true, SubgroupIdType::kSetFromFirstObject, true, false),
+        StreamHeaderProperties(false, SubgroupIdType::kSetFromFirstObject, false, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kSetFromFirstObject, false, false, false),
+        StreamHeaderProperties(false, SubgroupIdType::kSetFromFirstObject, true, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kSetFromFirstObject, true, false, false),
         // subgroup_id_mode = kExplicit
-        StreamHeaderProperties(false, SubgroupIdType::kExplicit, false, false),
-        StreamHeaderProperties(true, SubgroupIdType::kExplicit, false, false),
-        StreamHeaderProperties(false, SubgroupIdType::kExplicit, true, false),
-        StreamHeaderProperties(true, SubgroupIdType::kExplicit, true, false),
+        StreamHeaderProperties(false, SubgroupIdType::kExplicit, false, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kExplicit, false, false, false),
+        StreamHeaderProperties(false, SubgroupIdType::kExplicit, true, false, false),
+        StreamHeaderProperties(true, SubgroupIdType::kExplicit, true, false, false),
     };
     for (const auto& props : stream_headers) {
         CAPTURE(props.GetType());


### PR DESCRIPTION
Adds support for draft-18's first object bit (when true, the first object on that subgroup is the original first object on the subgroup, there are no priors in the past). 