### PR TITLE
Safe subgroup forward

### DIFF
--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -171,6 +171,61 @@ namespace quicr {
             return PublishObjectStatus::kInternalError;
         }
 
+        const auto status = GetStatus();
+        switch (status) {
+            case Status::kOk:
+                break;
+
+            case Status::kPaused:
+                publish_track_metrics_.objects_dropped_not_ok++;
+                return PublishObjectStatus::kPaused;
+
+            case Status::kUnsubscribed:
+                [[fallthrough]];
+            case Status::kDoneByFin:
+                [[fallthrough]];
+            case Status::kNoSubscribers:
+                publish_track_metrics_.objects_dropped_not_ok++;
+                return PublishObjectStatus::kNoSubscribers;
+
+            case Status::kPendingAnnounceResponse:
+                [[fallthrough]];
+            case Status::kNotAnnounced:
+                [[fallthrough]];
+            case Status::kNotConnected:
+                publish_track_metrics_.objects_dropped_not_ok++;
+                return PublishObjectStatus::kNotAnnounced;
+            case Status::kAnnounceNotAuthorized:
+                publish_track_metrics_.objects_dropped_not_ok++;
+                return PublishObjectStatus::kNotAuthorized;
+            case Status::kNewGroupRequested: {
+                // reset the status to ok to imply change
+                auto current = status;
+                publish_status_.compare_exchange_strong(
+                  current, Status::kOk, std::memory_order_acq_rel, std::memory_order_acquire);
+                break;
+            }
+            case Status::kSubscriptionUpdated: {
+
+                /*
+                 * TODO: Need to revisit the below since subgroups doesn't really support this
+                 * Always start a new stream on subscription update to support peering/pipelining
+                 */
+
+                auto current = status;
+                publish_status_.compare_exchange_strong(
+                  current, Status::kOk, std::memory_order_acq_rel, std::memory_order_acquire);
+                break;
+            }
+            default:
+                publish_track_metrics_.objects_dropped_not_ok++;
+                return PublishObjectStatus::kInternalError;
+        }
+
+        if (!GetRequestId().has_value()) {
+            return PublishTrackHandler::PublishObjectStatus::kNoSubscribers;
+        }
+
         std::uint16_t ttl = object_headers.ttl.value_or(default_ttl_);
         std::uint8_t priority = object_headers.priority.value_or(default_priority_);
 
@@ -238,67 +293,12 @@ namespace quicr {
             stream_id = subgroup_it->second.stream_id;
         }
 
-        const auto status = GetStatus();
-        switch (status) {
-            case Status::kOk:
-                break;
-
-            case Status::kPaused:
-                publish_track_metrics_.objects_dropped_not_ok++;
-                return PublishObjectStatus::kPaused;
-
-            case Status::kUnsubscribed:
-                [[fallthrough]];
-            case Status::kDoneByFin:
-                [[fallthrough]];
-            case Status::kNoSubscribers:
-                publish_track_metrics_.objects_dropped_not_ok++;
-                return PublishObjectStatus::kNoSubscribers;
-
-            case Status::kPendingAnnounceResponse:
-                [[fallthrough]];
-            case Status::kNotAnnounced:
-                [[fallthrough]];
-            case Status::kNotConnected:
-                publish_track_metrics_.objects_dropped_not_ok++;
-                return PublishObjectStatus::kNotAnnounced;
-            case Status::kAnnounceNotAuthorized:
-                publish_track_metrics_.objects_dropped_not_ok++;
-                return PublishObjectStatus::kNotAuthorized;
-            case Status::kNewGroupRequested: {
-                // reset the status to ok to imply change
-                auto current = status;
-                publish_status_.compare_exchange_strong(
-                  current, Status::kOk, std::memory_order_acq_rel, std::memory_order_acquire);
-                break;
-            }
-            case Status::kSubscriptionUpdated: {
-
-                /*
-                 * TODO: Need to revisit the below since subgroups doesn't really support this
-                 * Always start a new stream on subscription update to support peering/pipelining
-                 */
-
-                auto current = status;
-                publish_status_.compare_exchange_strong(
-                  current, Status::kOk, std::memory_order_acq_rel, std::memory_order_acquire);
-                break;
-            }
-            default:
-                publish_track_metrics_.objects_dropped_not_ok++;
-                return PublishObjectStatus::kInternalError;
-        }
-
         if (object_headers.track_mode.has_value() && object_headers.track_mode != default_track_mode_) {
             SetDefaultTrackMode(*object_headers.track_mode);
         }
 
         publish_track_metrics_.bytes_published += data.size();
         publish_track_metrics_.objects_published++;
-
-        if (!GetRequestId().has_value()) {
-            return PublishTrackHandler::PublishObjectStatus::kNoSubscribers;
-        }
 
         ITransport::EnqueueFlags eflags;
 

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1561,6 +1561,53 @@ TEST_CASE("Integration - Subgroup and Stream Testing")
     }
 }
 
+TEST_CASE("Integration - Failed publish does not create subgroup state")
+{
+    // Setup a publisher.
+    auto server = MakeTestServer();
+    auto publisher = MakeTestClient();
+    FullTrackName ftn;
+    ftn.name_space = TrackNamespace(std::vector<std::string>{ "test", "paused_publish" });
+    ftn.name = { 0x01 };
+    auto pub_handler = PublishTrackHandler::Create(ftn, TrackMode::kStream, 3, 1000, { 0, 0 });
+    publisher->PublishTrack(pub_handler);
+    REQUIRE(WaitFor([&pub_handler]() { return pub_handler->CanPublish(); }));
+
+    // Pause.
+    pub_handler->SetStatus(PublishTrackHandler::Status::kPaused);
+
+    // Publish an object against paused handler.
+    constexpr uint64_t group_id = 0;
+    constexpr uint64_t subgroup_id = 0;
+    const std::vector<uint8_t> payload{ 0x01 };
+    const ObjectHeaders headers{ .group_id = group_id,
+                                 .object_id = 0,
+                                 .subgroup_id = subgroup_id,
+                                 .payload_length = payload.size(),
+                                 .status = ObjectStatus::kAvailable,
+                                 .priority = 128,
+                                 .ttl = 1000,
+                                 .track_mode = TrackMode::kStream };
+    REQUIRE_EQ(pub_handler->PublishObject(headers, payload), PublishTrackHandler::PublishObjectStatus::kPaused);
+
+    // Unpause.
+    pub_handler->SetStatus(PublishTrackHandler::Status::kOk);
+
+    // If the caller attempts to forward the next object in the subgroup as though the first passed, we should fail
+    // due to no stream state setup.
+    messages::StreamSubGroupObject next_object;
+    next_object.object_delta = 0;
+    next_object.object_status = ObjectStatus::kAvailable;
+    next_object.payload = payload;
+    const auto stream_mode = pub_handler->GetStreamMode();
+    next_object.properties.emplace(stream_mode.value());
+    Bytes encoded_object;
+    encoded_object << next_object;
+    const auto status = pub_handler->ForwardPublishedData(
+      false, group_id, subgroup_id, std::make_shared<const std::vector<uint8_t>>(std::move(encoded_object)));
+    CHECK_EQ(status, PublishTrackHandler::PublishObjectStatus::kInternalError);
+}
+
 TEST_CASE("Integration - New subgroup preserves object IDs")
 {
     auto server = MakeTestServer(std::nullopt, 2);

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1563,20 +1563,26 @@ TEST_CASE("Integration - Subgroup and Stream Testing")
 
 TEST_CASE("Integration - Failed publish does not create subgroup state")
 {
-    // Setup a publisher.
-    auto server = MakeTestServer();
+    // Setup a subscriber and publisher.
+    auto server = MakeTestServer(std::nullopt, 2);
+    auto subscriber = MakeTestClient();
     auto publisher = MakeTestClient();
     FullTrackName ftn;
     ftn.name_space = TrackNamespace(std::vector<std::string>{ "test", "paused_publish" });
     ftn.name = { 0x01 };
+
+    auto sub_handler = TestSubscribeHandler::Create(ftn, 3, std::nullopt);
+    subscriber->SubscribeTrack(sub_handler);
+    REQUIRE(WaitFor([&sub_handler]() { return sub_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; }));
+
     auto pub_handler = PublishTrackHandler::Create(ftn, TrackMode::kStream, 3, 1000, { 0, 0 });
     publisher->PublishTrack(pub_handler);
     REQUIRE(WaitFor([&pub_handler]() { return pub_handler->CanPublish(); }));
 
-    // Pause.
+    // Pause the publisher.
     pub_handler->SetStatus(PublishTrackHandler::Status::kPaused);
 
-    // Publish an object against paused handler.
+    // Publish a subgroup-opening object against paused handler.
     constexpr uint64_t group_id = 0;
     constexpr uint64_t subgroup_id = 0;
     const std::vector<uint8_t> payload{ 0x01 };
@@ -1593,19 +1599,48 @@ TEST_CASE("Integration - Failed publish does not create subgroup state")
     // Unpause.
     pub_handler->SetStatus(PublishTrackHandler::Status::kOk);
 
+    // If the caller attempts to publish the next object in the subgroup as though the first passed, we should
+    // succeed on this next object, having now created stream state.
+    SUBCASE("PublishObject")
+    {
+        const ObjectHeaders next_header = { .group_id = group_id,
+                                            .object_id = 1,
+                                            .subgroup_id = subgroup_id,
+                                            .payload_length = payload.size(),
+                                            .status = ObjectStatus::kAvailable,
+                                            .priority = 128,
+                                            .ttl = 1000,
+                                            .track_mode = TrackMode::kStream };
+        const auto status = pub_handler->PublishObject(next_header, payload);
+        REQUIRE_EQ(status, PublishTrackHandler::PublishObjectStatus::kOk);
+        REQUIRE(WaitFor([&sub_handler]() { return sub_handler->GetReceivedCount() == 1; }));
+
+        const auto received_objects = sub_handler->GetReceivedObjects();
+        REQUIRE_EQ(received_objects.size(), 1);
+        const auto recv = received_objects.front();
+        CHECK_EQ(recv.group_id, group_id);
+        CHECK_EQ(recv.subgroup_id, subgroup_id);
+        CHECK_EQ(recv.object_id, next_header.object_id);
+        CHECK_EQ(recv.status, next_header.status);
+        CHECK_EQ(recv.data, payload);
+    }
+
     // If the caller attempts to forward the next object in the subgroup as though the first passed, we should fail
     // due to no stream state setup.
-    messages::StreamSubGroupObject next_object;
-    next_object.object_delta = 0;
-    next_object.object_status = ObjectStatus::kAvailable;
-    next_object.payload = payload;
-    const auto stream_mode = pub_handler->GetStreamMode();
-    next_object.properties.emplace(stream_mode.value());
-    Bytes encoded_object;
-    encoded_object << next_object;
-    const auto status = pub_handler->ForwardPublishedData(
-      false, group_id, subgroup_id, std::make_shared<const std::vector<uint8_t>>(std::move(encoded_object)));
-    CHECK_EQ(status, PublishTrackHandler::PublishObjectStatus::kInternalError);
+    SUBCASE("ForwardPublishedData")
+    {
+        messages::StreamSubGroupObject next_object;
+        next_object.object_delta = 0;
+        next_object.object_status = ObjectStatus::kAvailable;
+        next_object.payload = payload;
+        const auto stream_mode = pub_handler->GetStreamMode();
+        next_object.properties.emplace(stream_mode.value());
+        Bytes encoded_object;
+        encoded_object << next_object;
+        const auto status = pub_handler->ForwardPublishedData(
+          false, group_id, subgroup_id, std::make_shared<const std::vector<uint8_t>>(std::move(encoded_object)));
+        CHECK_EQ(status, PublishTrackHandler::PublishObjectStatus::kInternalError);
+    }
 }
 
 TEST_CASE("Integration - New subgroup preserves object IDs")


### PR DESCRIPTION
I think I found a bug here. If a caller calls `PublishObject()` on the first object of a subgroup while the status is something that should that will suppress the publish (e.g `kPaused`) the subgroup state would have still be set up internally. This meant a subsequent successful publish (or forward) for a later object, on the same subgroup, would think that the relevant header had already been sent and would write raw subgroup object bytes on the stream. 

Now a PublishObject() will correctly not setup the stream state, a subsequent one will if needed, and a corresponding Forward() will fail in the same way as it would as though you had never called `PublishObject()` (which was guarded). 

This was particularly an issue on top-n filtering. 