### PR TITLE
Allow initial recv window config

### DIFF
--- a/include/quicr/transport.h
+++ b/include/quicr/transport.h
@@ -121,6 +121,7 @@ namespace quicr {
         std::size_t socket_buffer_size{ 1'000'000 }; ///< QUIC UDP socket buffer size
         uint32_t callback_queue_size{ 2000 };        ///< Callback function queue size for callbacks
         uint64_t metrics_sample_ms{ 5000 };          ///< Metrics sampling interval in milliseconds
+        uint64_t initial_max_stream_data{ 0 };       ///< Initial per-stream receive window (all streams). 0=default.
     };
 
     /// Stream action that should be done by send/receive processing

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -1016,6 +1016,12 @@ PicoQuicTransport::Start()
     local_tp_options_.max_ack_delay = 100000;
     local_tp_options_.min_ack_delay = 1000;
 
+    if (tconfig_.initial_max_stream_data > 0) {
+        local_tp_options_.initial_max_stream_data_uni = tconfig_.initial_max_stream_data;
+        local_tp_options_.initial_max_stream_data_bidi_local = tconfig_.initial_max_stream_data;
+        local_tp_options_.initial_max_stream_data_bidi_remote = tconfig_.initial_max_stream_data;
+    }
+
     picoquic_set_default_handshake_timeout(quic_ctx_, (tconfig_.idle_timeout_ms * 1000) / 2);
     picoquic_set_default_tp(quic_ctx_, &local_tp_options_);
 

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -145,7 +145,8 @@ class CallbackPublishTrackHandler final : public PublishTrackHandler
 
 static std::shared_ptr<TestServer>
 MakeTestServer(const std::optional<std::string>& qlog_path = std::nullopt,
-               std::optional<std::size_t> max_connections = std::nullopt)
+               std::optional<std::size_t> max_connections = std::nullopt,
+               std::optional<std::uint64_t> initial_max_stream_data = std::nullopt)
 {
     // Run the server.
     ServerConfig server_config;
@@ -161,6 +162,9 @@ MakeTestServer(const std::optional<std::string>& qlog_path = std::nullopt,
     }
     if (max_connections.has_value()) {
         server_config.transport_config.max_connections = *max_connections;
+    }
+    if (initial_max_stream_data.has_value()) {
+        server_config.transport_config.initial_max_stream_data = *initial_max_stream_data;
     }
     auto server = std::make_shared<TestServer>(server_config);
     const auto starting = server->Start();


### PR DESCRIPTION
Pass down initial recv size to pq from tconfig. 