### PR TITLE
Remove SafeStreamBuffer & mutex

### DIFF
--- a/benchmark/extensions.cpp
+++ b/benchmark/extensions.cpp
@@ -62,7 +62,7 @@ ExtensionsDeserialize(benchmark::State& state)
 
     for ([[maybe_unused]] const auto& _ : state) {
         // Create a stream buffer from the serialized data
-        auto stream_buffer = SafeStreamBuffer<uint8_t>();
+        auto stream_buffer = StreamBuffer<uint8_t>();
         stream_buffer.Push(std::span<const uint8_t>(serialized_data));
 
         // Parse the extensions
@@ -111,7 +111,7 @@ ExtensionsRoundTrip(benchmark::State& state)
         SerializeExtensions(serialized_data, original_extensions, original_immutable);
 
         // Deserialize
-        auto stream_buffer = SafeStreamBuffer<uint8_t>();
+        auto stream_buffer = StreamBuffer<uint8_t>();
         stream_buffer.Push(std::span<const uint8_t>(serialized_data));
 
         std::optional<std::size_t> extension_headers_length;

--- a/benchmark/stream_buffer.cpp
+++ b/benchmark/stream_buffer.cpp
@@ -81,88 +81,9 @@ StreamBuffer_Front(benchmark::State& state)
     }
 }
 
-static void
-SafeStreamBuffer_Construct(benchmark::State& state)
-{
-    for ([[maybe_unused]] const auto& _ : state) {
-        auto buffer = quicr::SafeStreamBuffer<std::uint8_t>();
-        benchmark::DoNotOptimize(buffer);
-        benchmark::ClobberMemory();
-    }
-}
-
-static void
-SafeStreamBuffer_Push(benchmark::State& state)
-{
-    quicr::SafeStreamBuffer<std::uint8_t> buffer;
-    for ([[maybe_unused]] const auto& _ : state) {
-        buffer.Push(std::numeric_limits<std::uint8_t>::max());
-    }
-}
-
-static void
-SafeStreamBuffer_PushBytes(benchmark::State& state)
-{
-    std::vector<uint8_t> buf(1280, 0);
-
-    for ([[maybe_unused]] const auto& _ : state) {
-        quicr::StreamBuffer<std::uint8_t>{}.Push(buf);
-    }
-}
-
-static void
-SafeStreamBuffer_PushLengthBytes(benchmark::State& state)
-{
-    std::vector<uint8_t> buf(1280, 0);
-
-    for ([[maybe_unused]] const auto& _ : state) {
-        quicr::StreamBuffer<std::uint8_t>{}.PushLengthBytes(buf);
-    }
-}
-
-static void
-SafeStreamBuffer_Pop(benchmark::State& state)
-{
-    quicr::SafeStreamBuffer<std::uint8_t> buffer;
-    for (int64_t i = 0; i < state.max_iterations; ++i) {
-        buffer.Push(std::vector<uint8_t>(1280, uint8_t(0)));
-    }
-
-    const std::size_t num = state.range(0);
-
-    int64_t items_count = 0;
-    for ([[maybe_unused]] const auto& _ : state) {
-        ++items_count;
-
-        buffer.Pop(num);
-    }
-
-    state.SetItemsProcessed(items_count);
-}
-
-static void
-SafeStreamBuffer_Front(benchmark::State& state)
-{
-    quicr::SafeStreamBuffer<std::uint8_t> buffer;
-
-    buffer.Push(std::vector<uint8_t>(1280, 0));
-
-    for ([[maybe_unused]] const auto& _ : state) {
-        auto data = buffer.Front(1280);
-        benchmark::DoNotOptimize(data);
-        benchmark::ClobberMemory();
-    }
-}
-
 BENCHMARK(StreamBuffer_Construct);
 BENCHMARK(StreamBuffer_Push);
 BENCHMARK(StreamBuffer_PushBytes);
 BENCHMARK(StreamBuffer_PushLengthBytes);
 BENCHMARK(StreamBuffer_Pop)->Iterations(1'000'000)->Arg(1)->Arg(16)->Arg(128)->Arg(1280);
 BENCHMARK(StreamBuffer_Front);
-BENCHMARK(SafeStreamBuffer_Construct);
-BENCHMARK(SafeStreamBuffer_Push);
-BENCHMARK(SafeStreamBuffer_PushBytes);
-BENCHMARK(SafeStreamBuffer_PushLengthBytes);
-BENCHMARK(SafeStreamBuffer_Pop)->Iterations(1'000'000)->Arg(1)->Arg(16)->Arg(128)->Arg(1280);
-BENCHMARK(SafeStreamBuffer_Front);

--- a/include/quicr/containers/stream_buffer.h
+++ b/include/quicr/containers/stream_buffer.h
@@ -150,7 +150,7 @@ namespace quicr {
          *
          * @returns span of bytes, or empty span if no data or length unavailable
          */
-        std::span<const T> Front(std::uint32_t length) noexcept
+        std::span<const T> Front(std::size_t length) noexcept
         {
             if (Empty()) {
                 return {};
@@ -163,6 +163,20 @@ namespace quicr {
                                          : std::span<const T>{ buffer_.data() + read_offset_, length };
         }
 
+        /**
+         * @brief All readable data bytes in the stream buffer
+         *
+         * @returns span of all bytes
+         */
+        std::span<const T> Data() noexcept
+        {
+            if (Empty()) {
+                return {};
+            }
+
+            return { buffer_.data() + read_offset_, buffer_.size() - read_offset_ };
+        }
+
         void Pop()
         {
             if (Empty()) {
@@ -173,7 +187,7 @@ namespace quicr {
             PopInternal(1);
         }
 
-        void Pop(std::uint32_t length)
+        void Pop(std::size_t length)
         {
             if (length == 0 || Empty()) {
                 return;
@@ -190,7 +204,7 @@ namespace quicr {
          *
          * @return True if data length is available, false if not.
          */
-        bool Available(std::uint32_t length) const noexcept
+        bool Available(std::size_t length) const noexcept
         {
             return length == 0 || (read_offset_ < buffer_.size() && buffer_.size() - read_offset_ >= length);
         }
@@ -271,7 +285,7 @@ namespace quicr {
             std::lock_guard _(rw_lock_);
 
             const auto& uv_msb = buffer_[read_offset_];
-            uint64_t uv_len = UintVar::Size(uv_msb);
+            std::size_t uv_len = UintVar::Size(uv_msb);
 
             const auto logical_size = buffer_.size() - read_offset_;
             if (logical_size >= uv_len) {
@@ -305,7 +319,7 @@ namespace quicr {
             std::lock_guard _(rw_lock_);
 
             const auto& uv_msb = buffer_[read_offset_];
-            uint64_t uv_len = UintVar::Size(uv_msb);
+            std::size_t uv_len = UintVar::Size(uv_msb);
 
             auto logical_size = buffer_.size() - read_offset_;
             if (logical_size >= uv_len) {
@@ -353,7 +367,7 @@ namespace quicr {
             read_offset_ = 0;
         }
 
-        FORCE_INLINE void PopInternal(std::uint32_t length)
+        FORCE_INLINE void PopInternal(std::size_t length)
         {
             if (read_offset_ >= buffer_.size() || length >= buffer_.size() - read_offset_) {
                 buffer_.clear();

--- a/include/quicr/containers/stream_buffer.h
+++ b/include/quicr/containers/stream_buffer.h
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <any>
 #include <cstring>
-#include <mutex>
 #include <optional>
 #include <span>
 #include <type_traits>
@@ -17,14 +16,7 @@
 namespace quicr {
 #define FORCE_INLINE inline __attribute__((always_inline))
 
-    struct NullMutex
-    {
-        constexpr void lock() {}
-        constexpr void unlock() {}
-        constexpr bool try_lock() { return true; }
-    };
-
-    template<typename T, class Mutex = NullMutex, class Allocator = std::allocator<T>>
+    template<typename T, class Allocator = std::allocator<T>>
     class StreamBuffer
     {
         using BufferT = std::vector<T, Allocator>;
@@ -139,7 +131,6 @@ namespace quicr {
                 return {};
             }
 
-            std::lock_guard _(rw_lock_);
             return { buffer_.data() + read_offset_, 1 };
         }
 
@@ -155,8 +146,6 @@ namespace quicr {
             if (Empty()) {
                 return {};
             }
-
-            std::lock_guard _(rw_lock_);
 
             const auto logical_size = buffer_.size() - read_offset_;
             return logical_size < length ? std::span<const T>{}
@@ -183,7 +172,6 @@ namespace quicr {
                 return;
             }
 
-            std::lock_guard _(rw_lock_);
             PopInternal(1);
         }
 
@@ -193,7 +181,6 @@ namespace quicr {
                 return;
             }
 
-            std::lock_guard _(rw_lock_);
             PopInternal(length);
         }
 
@@ -211,8 +198,6 @@ namespace quicr {
 
         void Push(const T& value)
         {
-            std::lock_guard _(rw_lock_);
-
             CompactFrontIfNeeded();
 
             buffer_.push_back(value);
@@ -220,8 +205,6 @@ namespace quicr {
 
         void Push(T&& value)
         {
-            std::lock_guard _(rw_lock_);
-
             CompactFrontIfNeeded();
 
             buffer_.push_back(std::move(value));
@@ -229,8 +212,6 @@ namespace quicr {
 
         void Push(std::span<const T> value)
         {
-            std::lock_guard _(rw_lock_);
-
             CompactFrontIfNeeded();
 
             buffer_.insert(buffer_.end(), value.begin(), value.end());
@@ -238,8 +219,6 @@ namespace quicr {
 
         void PushLengthBytes(std::span<const T> value)
         {
-            std::lock_guard _(rw_lock_);
-
             CompactFrontIfNeeded();
 
             UintVar len(static_cast<uint64_t>(value.size()));
@@ -282,8 +261,6 @@ namespace quicr {
                 return std::nullopt;
             }
 
-            std::lock_guard _(rw_lock_);
-
             const auto& uv_msb = buffer_[read_offset_];
             std::size_t uv_len = UintVar::Size(uv_msb);
 
@@ -315,8 +292,6 @@ namespace quicr {
             if (Empty()) {
                 return std::nullopt;
             }
-
-            std::lock_guard _(rw_lock_);
 
             const auto& uv_msb = buffer_[read_offset_];
             std::size_t uv_len = UintVar::Size(uv_msb);
@@ -380,16 +355,12 @@ namespace quicr {
 
       private:
         BufferT buffer_;
-        Mutex rw_lock_;
         std::any parsed_data_;                     /// Working buffer for parsed data
         std::any parsed_dataB_;                    /// Second Working buffer for parsed data
         std::optional<uint64_t> parsed_data_type_; /// working buffer type value
         std::size_t read_offset_{ 0 };
         std::size_t compact_threshold_{ 4096 };
     };
-
-    template<class T, class Allocator = std::allocator<T>>
-    using SafeStreamBuffer = StreamBuffer<T, std::mutex, Allocator>;
 
 #undef FORCE_INLINE
 }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -316,7 +316,6 @@ namespace quicr::messages {
     }
 
     template bool operator>> <StreamBuffer<uint8_t>>(StreamBuffer<uint8_t>&, FetchHeader&);
-    template bool operator>> <SafeStreamBuffer<uint8_t>>(SafeStreamBuffer<uint8_t>&, FetchHeader&);
 
     Bytes& operator<<(Bytes& buffer, const FetchHeader& msg)
     {
@@ -436,7 +435,6 @@ namespace quicr::messages {
     }
 
     template bool operator>> <StreamBuffer<uint8_t>>(StreamBuffer<uint8_t>&, FetchObject&);
-    template bool operator>> <SafeStreamBuffer<uint8_t>>(SafeStreamBuffer<uint8_t>&, FetchObject&);
 
     //
     // Object
@@ -565,7 +563,6 @@ namespace quicr::messages {
     }
 
     template bool operator>> <StreamBuffer<uint8_t>>(StreamBuffer<uint8_t>&, ObjectDatagram&);
-    template bool operator>> <SafeStreamBuffer<uint8_t>>(SafeStreamBuffer<uint8_t>&, ObjectDatagram&);
 
     Bytes& operator<<(Bytes& buffer, const ObjectDatagramStatus& msg)
     {
@@ -681,7 +678,6 @@ namespace quicr::messages {
     }
 
     template bool operator>> <StreamBuffer<uint8_t>>(StreamBuffer<uint8_t>&, ObjectDatagramStatus&);
-    template bool operator>> <SafeStreamBuffer<uint8_t>>(SafeStreamBuffer<uint8_t>&, ObjectDatagramStatus&);
 
     Bytes& operator<<(Bytes& buffer, const StreamHeaderSubGroup& msg)
     {
@@ -789,7 +785,6 @@ namespace quicr::messages {
     }
 
     template bool operator>> <StreamBuffer<uint8_t>>(StreamBuffer<uint8_t>&, StreamHeaderSubGroup&);
-    template bool operator>> <SafeStreamBuffer<uint8_t>>(SafeStreamBuffer<uint8_t>&, StreamHeaderSubGroup&);
 
     Bytes& operator<<(Bytes& buffer, const StreamSubGroupObject& msg)
     {
@@ -888,6 +883,5 @@ namespace quicr::messages {
     }
 
     template bool operator>> <StreamBuffer<uint8_t>>(StreamBuffer<uint8_t>&, StreamSubGroupObject&);
-    template bool operator>> <SafeStreamBuffer<uint8_t>>(SafeStreamBuffer<uint8_t>&, StreamSubGroupObject&);
 
 }


### PR DESCRIPTION
In looking at the thread safety of `SafeStreamBuffer` and realising it needed some work, I then realised we don't even use `SafeStreamBuffer`, or have cross-thread `StreamBufffer` usage at all. So it seemed rather than fix it, just remove it. 

If we do need a thread-safe stream buffer in the future, I would suggest using a lockable buffer like the pattern we have with the queues, in order to ensure safe access to spans during their lifetime. 