### PR TITLE
Extract StreamBuffer parsing from data receive

### DIFF
--- a/include/quicr/handlers/fetch_track_handler.h
+++ b/include/quicr/handlers/fetch_track_handler.h
@@ -76,6 +76,8 @@ namespace quicr {
                             uint64_t stream_id,
                             std::shared_ptr<const std::vector<uint8_t>> data) override;
 
+        void TryParseStreamBufferData(StreamContext& stream) override;
+
       private:
         messages::Location start_location_;
         messages::FetchEndLocation end_location_;

--- a/include/quicr/handlers/joining_fetch_handler.h
+++ b/include/quicr/handlers/joining_fetch_handler.h
@@ -26,6 +26,9 @@ namespace quicr {
                             uint64_t stream_id,
                             std::shared_ptr<const std::vector<uint8_t>> data) override;
 
+      protected:
+        void TryParseStreamBufferData(StreamContext& stream) override;
+
       private:
         std::shared_ptr<SubscribeTrackHandler> joining_subscribe_;
     };

--- a/include/quicr/handlers/subscribe_track_handler.h
+++ b/include/quicr/handlers/subscribe_track_handler.h
@@ -414,6 +414,13 @@ namespace quicr {
             uint64_t current_subgroup_id{ 0 };
         };
 
+        /**
+         * @brief When new data arrives, attempt to parse any complete messages.
+         * @details The stream buffer may contain zero or more objects and/or incomplete data.
+         * @param stream Context of stream with newly arrived data.
+         */
+        virtual void TryParseStreamBufferData(StreamContext& stream);
+
         std::optional<uint64_t> pending_new_group_request_id_;
         bool is_fetch_handler_{ false };
         std::map<std::uint64_t, StreamContext> streams_;

--- a/src/fetch_track_handler.cpp
+++ b/src/fetch_track_handler.cpp
@@ -34,6 +34,11 @@ namespace quicr {
             stream.buffer.Push(*data);
         }
 
+        TryParseStreamBufferData(stream);
+    }
+
+    void FetchTrackHandler::TryParseStreamBufferData(StreamContext& stream)
+    {
         if (not stream.buffer.AnyHasValueB()) {
             stream.buffer.InitAnyB<messages::FetchObject>();
         }

--- a/src/joining_fetch_handler.cpp
+++ b/src/joining_fetch_handler.cpp
@@ -30,6 +30,11 @@ namespace quicr {
             stream.buffer.Push(*data);
         }
 
+        TryParseStreamBufferData(stream);
+    }
+
+    void JoiningFetchHandler::TryParseStreamBufferData(StreamContext& stream)
+    {
         stream.buffer.InitAnyB<messages::FetchObject>();
         auto& obj = stream.buffer.GetAnyB<messages::FetchObject>();
 

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -48,6 +48,11 @@ namespace quicr {
             stream.buffer.Push(*data);
         }
 
+        TryParseStreamBufferData(stream);
+    }
+
+    void SubscribeTrackHandler::TryParseStreamBufferData(StreamContext& stream)
+    {
         auto& s_hdr = stream.buffer.GetAny<messages::StreamHeaderSubGroup>();
 
         if (not stream.buffer.AnyHasValueB()) {
@@ -62,10 +67,9 @@ namespace quicr {
                 stream_properties.emplace(*s_hdr.properties);
             }
 
-            SPDLOG_TRACE("Received stream_subgroup_object priority: {} stream_id: {} track_alias: {} "
+            SPDLOG_TRACE("Received stream_subgroup_object priority: {} track_alias: {} "
                          "group: {} subgroup: {} object: {} data size: {} type: {}",
                          s_hdr.priority,
-                         stream_id,
                          s_hdr.track_alias,
                          s_hdr.group_id,
                          s_hdr.subgroup_id.has_value() ? *s_hdr.subgroup_id : -1,


### PR DESCRIPTION
Move parsing of data-plane stream objects out of the receive notification and into its own protected function. The reason for this is specifically to setup the API for allowing the `Session` to pass in already filled stream buffer in the stream start case. That will provide simplified code on the stream data arrival callback in Session, and will also support the fix for the issue around small stream data callbacks. 