### PR TITLE
Remove Spdlog and add abstract logger interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ if (HAVE_STD_FORMAT)
     " VFORMAT_COMPILES)
 endif()
 
-if (NOT HAS_STD_FORMAT OR NOT VFORMAT_COMPILES)
+if (NOT VFORMAT_COMPILES)
     CPMAddPackage("gh:fmtlib/fmt#12.2.0")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,20 +86,30 @@ set(CPM_USE_LOCAL_PACKAGES ON)
 include(CheckIncludeFileCXX)
 check_include_file_cxx(format HAVE_STD_FORMAT)
 if (HAVE_STD_FORMAT)
+    unset(HAS_STD_VFORMAT CACHE)
+    set(CMAKE_REQUIRED_FLAGS "-std=c++20")
+
     include(CheckCXXSourceCompiles)
     check_cxx_source_compiles("
         #include <format>
         #include <string>
         int main() {
             std::string fmt = \"Hello {}\";
-            std::string result = std::vformat(fmt, std::make_format_args(\"World\"););
-            return 0;
+            std::string result = std::vformat(fmt, std::make_format_args(\"World\"));
+            return result.empty() ? 1 : 0;
         }
-    " VFORMAT_COMPILES)
+    " HAS_STD_VFORMAT)
+
+    unset(CMAKE_REQUIRED_FLAGS)
 endif()
 
-if (NOT VFORMAT_COMPILES)
+if (NOT HAS_STD_VFORMAT)
+    message(STATUS "Using fmt::format")
     CPMAddPackage("gh:fmtlib/fmt#12.2.0")
+    set(SPDLOG_FMT_EXTERNAL ON)
+else()
+    add_compile_definitions(QUICR_HAVE_STD_FORMAT)
+    message(STATUS "Using std::format")
 endif()
 
 CPMAddPackage("gh:gabime/spdlog@1.17.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,9 +83,16 @@ include(CPM)
 
 set(CPM_USE_LOCAL_PACKAGES ON)
 
+include(CheckIncludeFileCXX)
+check_include_file_cxx(format HAVE_STD_FORMAT)
+if (NOT HAVE_STD_FORMAT)
+    CPMAddPackage("gh:fmtlib/fmt@12.2.0")
+endif()
+
 CPMAddPackage("gh:gabime/spdlog@1.17.0")
 
 add_subdirectory(dependencies)
+
 
 #=============================================================================#
 # Build the library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ set(CPM_USE_LOCAL_PACKAGES ON)
 include(CheckIncludeFileCXX)
 check_include_file_cxx(format HAVE_STD_FORMAT)
 if (NOT HAVE_STD_FORMAT)
-    CPMAddPackage("gh:fmtlib/fmt@12.2.0")
+    CPMAddPackage("gh:fmtlib/fmt#12.2.0")
 endif()
 
 CPMAddPackage("gh:gabime/spdlog@1.17.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,20 @@ set(CPM_USE_LOCAL_PACKAGES ON)
 
 include(CheckIncludeFileCXX)
 check_include_file_cxx(format HAVE_STD_FORMAT)
-if (NOT HAVE_STD_FORMAT)
+if (HAVE_STD_FORMAT)
+    include(CheckCXXSourceCompiles)
+    check_cxx_source_compiles("
+        #include <format>
+        #include <string>
+        int main() {
+            std::string fmt = \"Hello {}\";
+            std::string result = std::vformat(fmt, std::make_format_args(\"World\"););
+            return 0;
+        }
+    " VFORMAT_COMPILES)
+endif()
+
+if (NOT HAS_STD_FORMAT OR NOT VFORMAT_COMPILES)
     CPMAddPackage("gh:fmtlib/fmt#12.2.0")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,6 @@ endif()
 
 include(CPM)
 
-set(CPM_USE_LOCAL_PACKAGES ON)
-
 include(CheckIncludeFileCXX)
 check_include_file_cxx(format HAVE_STD_FORMAT)
 if (HAVE_STD_FORMAT)
@@ -106,13 +104,10 @@ endif()
 if (NOT HAS_STD_VFORMAT)
     message(STATUS "Using fmt::format")
     CPMAddPackage("gh:fmtlib/fmt#12.2.0")
-    set(SPDLOG_FMT_EXTERNAL ON)
 else()
     add_compile_definitions(QUICR_HAVE_STD_FORMAT)
     message(STATUS "Using std::format")
 endif()
-
-CPMAddPackage("gh:gabime/spdlog@1.17.0")
 
 add_subdirectory(dependencies)
 

--- a/c-bridge/CMakeLists.txt
+++ b/c-bridge/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(PkgConfig REQUIRED)
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/dependencies/spdlog/include
 )
 
 # Collect source files
@@ -43,7 +42,6 @@ add_library(quicr-bridge STATIC ${BRIDGE_SOURCES} ${BRIDGE_HEADERS})
 target_link_libraries(quicr-bridge
     PRIVATE
     quicr
-    spdlog::spdlog
 )
 
 # Set include directories for the library

--- a/examples/qclient/CMakeLists.txt
+++ b/examples/qclient/CMakeLists.txt
@@ -28,8 +28,6 @@ set_target_properties(qclient
         CXX_STANDARD_REQUIRED YES
         CXX_EXTENSIONS OFF)
 
-target_compile_definitions(qclient PRIVATE SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
-
 if(LINT)
         include(Lint)
         Lint(qclient)

--- a/examples/qclient/CMakeLists.txt
+++ b/examples/qclient/CMakeLists.txt
@@ -1,20 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 Cisco Systems
 # SPDX-License-Identifier: BSD-2-Clause
 
-include(FetchContent)
+CPMAddPackage("gh:nlohmann/json@3.11.3")
+CPMAddPackage("gh:cisco/sframe#9af3e9942180a754fc953d7205e26355ad9fe31e")
 
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
-FetchContent_MakeAvailable(json)
+if (NOT HAS_STD_VFORMAT)
+    set(SPDLOG_FMT_EXTERNAL ON)
+endif()
 
-FetchContent_Declare(
-        sframe
-        GIT_REPOSITORY https://github.com/cisco/sframe.git
-        GIT_TAG 9af3e9942180a754fc953d7205e26355ad9fe31e
-)
-FetchContent_MakeAvailable(sframe)
+CPMAddPackage("gh:gabime/spdlog@1.17.0")
 
 add_executable(qclient client.cpp)
-target_link_libraries(qclient PRIVATE quicr nlohmann_json::nlohmann_json sframe)
+target_link_libraries(qclient PRIVATE quicr nlohmann_json::nlohmann_json sframe spdlog::spdlog)
 target_include_directories(qclient PRIVATE ../dependencies )
 
 target_compile_options(qclient

--- a/examples/qclient/client.cpp
+++ b/examples/qclient/client.cpp
@@ -15,6 +15,8 @@
 #include <quicr/session_manager.h>
 #include <quicr/utilities/defer.h>
 #include <sframe/sframe.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
 #include <timeq/tick_service.h>
 
 #include <filesystem>
@@ -24,6 +26,55 @@
 #include <set>
 
 using json = nlohmann::json; // NOLINT
+
+class SpdlogLogger : public quicr::Logger
+{
+  public:
+    SpdlogLogger(const std::string& name)
+      : logger_(spdlog::get(name) ? spdlog::get(name) : spdlog::stderr_color_mt(name))
+    {
+    }
+
+    virtual ~SpdlogLogger() = default;
+
+    void SetLevel(quicr::Logger::Level max_level) override { logger_->set_level(ConvertLevelType(max_level)); }
+
+    void Log(quicr::Logger::Level level,
+             std::string_view msg,
+             std::source_location location = std::source_location::current()) override
+    try {
+        logger_->log(spdlog::source_loc(location.file_name(), location.line(), location.function_name()),
+                     ConvertLevelType(level),
+                     msg);
+    } catch (const std::exception& e) {
+        logger_->log(spdlog::source_loc(location.file_name(), location.line(), location.function_name()),
+                     spdlog::level::err,
+                     "log failed to format (error={})",
+                     e.what());
+    }
+
+  private:
+    spdlog::level::level_enum ConvertLevelType(Logger::Level level)
+    {
+        switch (level) {
+            case Logger::Level::Trace:
+                return spdlog::level::trace;
+            case Logger::Level::Debug:
+                return spdlog::level::debug;
+            case Logger::Level::Info:
+                return spdlog::level::info;
+            case Logger::Level::Warn:
+                return spdlog::level::warn;
+            case Logger::Level::Error:
+                return spdlog::level::err;
+            case Logger::Level::Critical:
+                return spdlog::level::critical;
+        }
+    }
+
+  private:
+    std::shared_ptr<spdlog::logger> logger_;
+};
 
 /**
  * @brief Defines an object received from an announcer that lives in the cache.
@@ -56,6 +107,7 @@ namespace qclient_vars {
     std::optional<sframe::MLSContext> mls_ctx = sframe::MLSContext(sframe::CipherSuite::AES_GCM_128_SHA256, 1);
     std::optional<std::filesystem::path> watch_path;
     std::chrono::milliseconds watch_interval_ms(5000);
+    std::shared_ptr<quicr::Logger> logger = std::make_shared<SpdlogLogger>("QCLIENT");
 
 }
 
@@ -171,7 +223,10 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
             moq_fs_.open(dir / (name_str + ".moq"), std::ios::in | std::ios::out | std::ios::trunc);
             moq_fs_ << json::array();
 
-            QUICR_INFO("Creating recording files for track name {} in directory {}", name_str, dir.string());
+            QUICR_LOGGER_INFO(qclient_vars::logger,
+                              "Creating recording files for track name {} in directory {}",
+                              name_str,
+                              dir.string());
         }
     }
 
@@ -223,17 +278,19 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
 
         std::string msg(data.begin(), data.end());
 
-        QUICR_INFO("Received message: {} Group:{}, Subgroup: {} Object:{} - {}",
-                   ext.str(),
-                   hdr.group_id,
-                   hdr.subgroup_id,
-                   hdr.object_id,
-                   msg);
+        QUICR_LOGGER_INFO(qclient_vars::logger,
+                          "Received message: {} Group:{}, Subgroup: {} Object:{} - {}",
+                          ext.str(),
+                          hdr.group_id,
+                          hdr.subgroup_id,
+                          hdr.object_id,
+                          msg);
 
         if (qclient_vars::new_group_request_id.has_value() && not new_group_requested_) {
-            QUICR_INFO("Track alias: {} requesting new group {}",
-                       GetTrackAlias().value(),
-                       qclient_vars::new_group_request_id.value());
+            QUICR_LOGGER_INFO(qclient_vars::logger,
+                              "Track alias: {} requesting new group {}",
+                              GetTrackAlias().value(),
+                              qclient_vars::new_group_request_id.value());
             RequestNewGroup(qclient_vars::new_group_request_id.value());
             new_group_requested_ = true;
         }
@@ -244,7 +301,7 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
         switch (status) {
             case Status::kOk: {
                 if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                    QUICR_INFO("Track alias: {0} is ready to read", track_alias.value());
+                    QUICR_LOGGER_INFO(qclient_vars::logger, "Track alias: {0} is ready to read", track_alias.value());
                 }
             } break;
 
@@ -327,38 +384,41 @@ class MyPublishTrackHandler : public quicr::PublishTrackHandler
     {
         auto track_alias_opt = GetTrackAlias();
         if (!track_alias_opt.has_value()) {
-            QUICR_WARN("StatusChanged called but track alias not available, status: {}", static_cast<int>(status));
+            QUICR_LOGGER_WARN(qclient_vars::logger,
+                              "StatusChanged called but track alias not available, status: {}",
+                              static_cast<int>(status));
             return;
         }
         const auto alias = track_alias_opt.value();
         switch (status) {
             case Status::kOk: {
-                QUICR_INFO("Publish track alias: {0} is ready to send", alias);
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Publish track alias: {0} is ready to send", alias);
                 break;
             }
             case Status::kNoSubscribers: {
-                QUICR_INFO("Publish track alias: {0} has no subscribers", alias);
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Publish track alias: {0} has no subscribers", alias);
                 break;
             }
             case Status::kNewGroupRequested: {
-                QUICR_INFO("Publish track alias: {0} has new group request", alias);
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Publish track alias: {0} has new group request", alias);
                 break;
             }
             case Status::kSubscriptionUpdated: {
-                QUICR_INFO("Publish track alias: {0} has updated subscription", alias);
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Publish track alias: {0} has updated subscription", alias);
                 break;
             }
             case Status::kPaused: {
-                QUICR_INFO("Publish track alias: {0} is paused", alias);
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Publish track alias: {0} is paused", alias);
                 break;
             }
             case Status::kPendingPublishOk: {
-                QUICR_INFO("Publish track alias: {0} is pending publish ok", alias);
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Publish track alias: {0} is pending publish ok", alias);
                 break;
             }
 
             default:
-                QUICR_INFO("Publish track alias: {0} has status {1}", alias, static_cast<int>(status));
+                QUICR_LOGGER_INFO(
+                  qclient_vars::logger, "Publish track alias: {0} has status {1}", alias, static_cast<int>(status));
                 break;
         }
     }
@@ -419,8 +479,11 @@ class MyFetchTrackHandler : public quicr::FetchTrackHandler
                         std::optional<quicr::messages::StreamHeaderProperties>) override
     {
         std::string msg(data.begin(), data.end());
-        QUICR_INFO(
-          "Received fetched object group_id: {} object_id: {} value: {}", headers.group_id, headers.object_id, msg);
+        QUICR_LOGGER_INFO(qclient_vars::logger,
+                          "Received fetched object group_id: {} object_id: {} value: {}",
+                          headers.group_id,
+                          headers.object_id,
+                          msg);
     }
 
     void StatusChanged(Status status) override
@@ -428,21 +491,21 @@ class MyFetchTrackHandler : public quicr::FetchTrackHandler
         switch (status) {
             case Status::kOk: {
                 if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                    QUICR_INFO("Track alias: {0} is ready to read", track_alias.value());
+                    QUICR_LOGGER_INFO(qclient_vars::logger, "Track alias: {0} is ready to read", track_alias.value());
                 }
             } break;
 
             case Status::kError: {
-                QUICR_INFO("Fetch failed");
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Fetch failed");
                 break;
             }
             case Status::kDoneByFin: {
-                QUICR_INFO("Fetch completed");
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Fetch completed");
                 break;
             }
 
             case Status::kDoneByReset: {
-                QUICR_INFO("Fetch failed");
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Fetch failed");
                 break;
             }
             default:
@@ -469,17 +532,17 @@ class MyClient : public quicr::Session::ClientCallbacks
     {
         switch (status) {
             case quicr::Session::Status::kReady:
-                QUICR_INFO("Connection ready");
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Connection ready");
                 moq_example::connected = true;
                 moq_example::cv.notify_all();
                 break;
             case quicr::Session::Status::kConnecting:
                 break;
             case quicr::Session::Status::kPendingServerSetup:
-                QUICR_INFO("Connection connected and now pending server setup");
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Connection connected and now pending server setup");
                 break;
             default:
-                QUICR_INFO("Connection failed {0}", static_cast<int>(status));
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Connection failed {0}", static_cast<int>(status));
                 moq_example::terminate = true;
                 moq_example::termination_reason = "Connection failed";
                 moq_example::cv.notify_all();
@@ -492,9 +555,10 @@ class MyClient : public quicr::Session::ClientCallbacks
     quicr::Reply<void, int> ServerSetupReceived([[maybe_unused]] const std::shared_ptr<quicr::Session>& session,
                                                 const quicr::ServerSetupAttributes& server_setup_attributes) override
     {
-        QUICR_INFO("Server setup received from '{}' (MOQT version: {})",
-                   server_setup_attributes.server_id,
-                   server_setup_attributes.moqt_version);
+        QUICR_LOGGER_INFO(qclient_vars::logger,
+                          "Server setup received from '{}' (MOQT version: {})",
+                          server_setup_attributes.server_id,
+                          server_setup_attributes.moqt_version);
         return {};
     }
 
@@ -503,7 +567,9 @@ class MyClient : public quicr::Session::ClientCallbacks
       const quicr::FullTrackName& track_full_name,
       [[maybe_unused]] const quicr::SubscribeAttributes& subscribe_attributes) override
     {
-        QUICR_INFO("Received subscribe for a track that is not currently published: {}", track_full_name.NameStr());
+        QUICR_LOGGER_INFO(qclient_vars::logger,
+                          "Received subscribe for a track that is not currently published: {}",
+                          track_full_name.NameStr());
         return {};
     }
 
@@ -513,7 +579,7 @@ class MyClient : public quicr::Session::ClientCallbacks
       [[maybe_unused]] const quicr::PublishNamespaceAttributes& publish_namespace_attributes) override
     {
         auto th = quicr::TrackHash({ track_namespace, {} });
-        QUICR_INFO("Received announce for namespace_hash: {}", th.track_namespace_hash);
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Received announce for namespace_hash: {}", th.track_namespace_hash);
         return {};
     }
 
@@ -524,7 +590,8 @@ class MyClient : public quicr::Session::ClientCallbacks
       std::weak_ptr<quicr::SubscribeNamespaceHandler> ns_handler) override
     {
         auto th = quicr::TrackHash(publish_attributes.track_full_name);
-        QUICR_INFO(
+        QUICR_LOGGER_INFO(
+          qclient_vars::logger,
           "Received PUBLISH from relay for track namespace_hash: {} name_hash: {} track_hash: {} request_id: {} ns: {}",
           th.track_namespace_hash,
           th.track_name_hash,
@@ -583,7 +650,7 @@ class MyClient : public quicr::Session::ClientCallbacks
       [[maybe_unused]] const std::shared_ptr<quicr::Session>& session,
       std::uint64_t request_id) override
     {
-        QUICR_INFO("Fetch cancelled for request_id: {}", request_id);
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Fetch cancelled for request_id: {}", request_id);
         return {};
     }
 
@@ -593,7 +660,10 @@ class MyClient : public quicr::Session::ClientCallbacks
       const quicr::FullTrackName& track_full_name) override
     {
         const auto largest_location = GetLargestAvailable(track_full_name);
-        QUICR_INFO("Track status requested request_id: {} track: {}", request_id, track_full_name.NameStr());
+        QUICR_LOGGER_INFO(qclient_vars::logger,
+                          "Track status requested request_id: {} track: {}",
+                          request_id,
+                          track_full_name.NameStr());
         return quicr::RequestResponse{ false, largest_location, quicr::messages::GroupOrder::kAscending };
     }
 
@@ -646,10 +716,11 @@ class MyClient : public quicr::Session::ClientCallbacks
                                                                           "No objects available for fetch");
         }
 
-        QUICR_INFO("Fetch received request id: {} largest group: {} object: {}",
-                   request_id,
-                   largest_location->group,
-                   largest_location->object);
+        QUICR_LOGGER_INFO(qclient_vars::logger,
+                          "Fetch received request id: {} largest group: {} object: {}",
+                          request_id,
+                          largest_location->group,
+                          largest_location->object);
 
         if (start.group > end.group || largest_location->group < start.group) {
             return quicr::Unexpected<quicr::Error<quicr::FetchErrorCode>>(quicr::FetchErrorCode::kInvalidRange,
@@ -686,8 +757,10 @@ class MyClient : public quicr::Session::ClientCallbacks
                         return;
                     }
 
-                    QUICR_DEBUG(
-                      "Fetch sending group: {} object: {}", object.headers.group_id, object.headers.object_id);
+                    QUICR_LOGGER_DEBUG(qclient_vars::logger,
+                                       "Fetch sending group: {} object: {}",
+                                       object.headers.group_id,
+                                       object.headers.object_id);
 
                     pub_fetch_h->PublishObject(object.headers, object.data);
                 }
@@ -731,7 +804,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                    const std::shared_ptr<quicr::PublishTrackHandler> track_handler,
                    bool& stop)
 {
-    QUICR_INFO("Started publisher track");
+    QUICR_LOGGER_INFO(qclient_vars::logger, "Started publisher track");
 
     const auto& full_track_name = track_handler->GetFullTrackName();
 
@@ -779,7 +852,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
 
     while (not stop) {
         if ((!published_track) && (session->GetStatus() == quicr::Session::Status::kReady)) {
-            QUICR_INFO("Publish track ");
+            QUICR_LOGGER_INFO(qclient_vars::logger, "Publish track ");
             session->PublishTrack(track_handler);
             published_track = true;
         }
@@ -794,11 +867,11 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                     object_id = 0;
                     subgroup_id = 0;
                 }
-                QUICR_INFO("New Group Requested: Now using group {0}", group_id);
+                QUICR_LOGGER_INFO(qclient_vars::logger, "New Group Requested: Now using group {0}", group_id);
 
                 break;
             case MyPublishTrackHandler::Status::kSubscriptionUpdated:
-                QUICR_INFO("subscribe updated");
+                QUICR_LOGGER_INFO(qclient_vars::logger, "subscribe updated");
                 break;
             case MyPublishTrackHandler::Status::kNoSubscribers:
                 // Start a new group when a subscriber joins
@@ -815,15 +888,17 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
         }
 
         if (!sending) {
-            QUICR_INFO("--------------------------------------------------------------------------");
+            QUICR_LOGGER_INFO(qclient_vars::logger,
+                              "--------------------------------------------------------------------------");
 
             if (qclient_vars::publish_clock) {
-                QUICR_INFO(" Publishing clock timestamp every second");
+                QUICR_LOGGER_INFO(qclient_vars::logger, " Publishing clock timestamp every second");
             } else {
-                QUICR_INFO(" Type message and press enter to send");
+                QUICR_LOGGER_INFO(qclient_vars::logger, " Type message and press enter to send");
             }
 
-            QUICR_INFO("--------------------------------------------------------------------------");
+            QUICR_LOGGER_INFO(qclient_vars::logger,
+                              "--------------------------------------------------------------------------");
             sending = true;
         }
 
@@ -862,7 +937,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
 
                 std::ifstream file(watch_path, std::ios::binary);
                 if (!file) {
-                    QUICR_WARN("Failed to read watch file: {}", watch_path.string());
+                    QUICR_LOGGER_WARN(qclient_vars::logger, "Failed to read watch file: {}", watch_path.string());
                     std::this_thread::sleep_for(poll_tick);
                     continue;
                 }
@@ -874,7 +949,11 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                 object_id = 0;
                 subgroup_id = 0;
 
-                QUICR_INFO("Publishing file {} ({} bytes) group_id: {}", watch_path.string(), data.size(), group_id);
+                QUICR_LOGGER_INFO(qclient_vars::logger,
+                                  "Publishing file {} ({} bytes) group_id: {}",
+                                  watch_path.string(),
+                                  data.size(),
+                                  group_id);
 
                 quicr::ObjectHeaders obj_headers = {
                     group_id,         object_id,      subgroup_id,  data.size(),  quicr::ObjectStatus::kAvailable,
@@ -886,11 +965,12 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                         auto status = track_handler->PublishObject(
                           obj_headers, { reinterpret_cast<uint8_t*>(data.data()), data.size() });
                         if (status != decltype(status)::kOk) {
-                            QUICR_WARN("PublishObject returned status={}", static_cast<int>(status));
+                            QUICR_LOGGER_WARN(
+                              qclient_vars::logger, "PublishObject returned status={}", static_cast<int>(status));
                         }
                     }
                 } catch (const std::exception& e) {
-                    QUICR_ERROR("Exception publishing watch file: {}", e.what());
+                    QUICR_LOGGER_ERROR(qclient_vars::logger, "Exception publishing watch file: {}", e.what());
                 }
 
                 last_publish = now;
@@ -903,7 +983,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
             const auto [hdr, msg] = messages.front();
             messages.pop_front();
 
-            QUICR_INFO("Send message: {0}", std::string(msg.begin(), msg.end()));
+            QUICR_LOGGER_INFO(qclient_vars::logger, "Send message: {0}", std::string(msg.begin(), msg.end()));
 
             try {
                 auto status = track_handler->PublishObject(hdr, msg);
@@ -912,7 +992,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                                              std::to_string(static_cast<int>(status)));
                 }
             } catch (const std::exception& e) {
-                QUICR_ERROR("Caught exception trying to publish. (error={})", e.what());
+                QUICR_LOGGER_ERROR(qclient_vars::logger, "Caught exception trying to publish. (error={})", e.what());
             }
 
             std::this_thread::sleep_for(qclient_vars::playback_speed_ms);
@@ -943,12 +1023,12 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
         if (qclient_vars::publish_clock) {
             std::this_thread::sleep_for(std::chrono::milliseconds(999));
             msg = quicr::example::GetTimeStr();
-            QUICR_INFO("Group:{0} Object:{1}, Msg:{2}", group_id, object_id, msg);
+            QUICR_LOGGER_INFO(qclient_vars::logger, "Group:{0} Object:{1}, Msg:{2}", group_id, object_id, msg);
         } else { // stdin
             if (!getline(std::cin, msg)) {
                 break;
             }
-            QUICR_INFO("Send message: {0}", msg);
+            QUICR_LOGGER_INFO(qclient_vars::logger, "Send message: {0}", msg);
         }
 
         quicr::ObjectHeaders obj_headers = {
@@ -962,20 +1042,20 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                   track_handler->PublishObject(obj_headers, { reinterpret_cast<uint8_t*>(msg.data()), msg.size() });
 
                 if (status == decltype(status)::kPaused) {
-                    QUICR_INFO("Publish is paused");
+                    QUICR_LOGGER_INFO(qclient_vars::logger, "Publish is paused");
                 } else if (status == decltype(status)::kNoSubscribers) {
-                    QUICR_INFO("Publish has no subscribers");
+                    QUICR_LOGGER_INFO(qclient_vars::logger, "Publish has no subscribers");
                 } else if (status != decltype(status)::kOk) {
                     throw std::runtime_error("PublishObject returned status=" +
                                              std::to_string(static_cast<int>(status)));
                 }
             }
         } catch (const std::exception& e) {
-            QUICR_ERROR("Caught exception trying to publish. (error={})", e.what());
+            QUICR_LOGGER_ERROR(qclient_vars::logger, "Caught exception trying to publish. (error={})", e.what());
         }
     }
 
-    QUICR_INFO("Publisher done track");
+    QUICR_LOGGER_INFO(qclient_vars::logger, "Publisher done track");
 }
 
 void
@@ -1015,7 +1095,7 @@ DoPublisher(const std::string prefix_str,
     std::this_thread::sleep_for(1s);
 
     if (ns_handler->GetStatus() != MyPublisherNamespaceHandler::Status::kOk) {
-        QUICR_ERROR("Did not get Publish Namespace OK for prefix, exiting...");
+        QUICR_LOGGER_ERROR(qclient_vars::logger, "Did not get Publish Namespace OK for prefix, exiting...");
         return;
     }
 
@@ -1061,14 +1141,14 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
         track_handler->SetTrackAlias(*qclient_vars::track_alias);
     }
 
-    QUICR_INFO("Started subgroup/stream test publisher");
+    QUICR_LOGGER_INFO(qclient_vars::logger, "Started subgroup/stream test publisher");
 
     bool published_track{ false };
 
     // Wait for connection and publish track
     while (not stop) {
         if ((!published_track) && (session->GetStatus() == quicr::Session::Status::kReady)) {
-            QUICR_INFO("Publish track for subgroup test");
+            QUICR_LOGGER_INFO(qclient_vars::logger, "Publish track for subgroup test");
             session->PublishTrack(track_handler);
             published_track = true;
             break;
@@ -1086,13 +1166,16 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    QUICR_INFO("--------------------------------------------------------------------------");
-    QUICR_INFO(" Subgroup/Stream Test: {} groups, {} subgroups, {} messages/phase",
-               qclient_vars::subgroup_test_num_groups,
-               qclient_vars::subgroup_test_num_subgroups,
-               qclient_vars::subgroup_test_messages_per_phase);
-    QUICR_INFO(" Test will repeat until stopped (Ctrl+C)");
-    QUICR_INFO("--------------------------------------------------------------------------");
+    QUICR_LOGGER_INFO(qclient_vars::logger,
+                      "--------------------------------------------------------------------------");
+    QUICR_LOGGER_INFO(qclient_vars::logger,
+                      " Subgroup/Stream Test: {} groups, {} subgroups, {} messages/phase",
+                      qclient_vars::subgroup_test_num_groups,
+                      qclient_vars::subgroup_test_num_subgroups,
+                      qclient_vars::subgroup_test_messages_per_phase);
+    QUICR_LOGGER_INFO(qclient_vars::logger, " Test will repeat until stopped (Ctrl+C)");
+    QUICR_LOGGER_INFO(qclient_vars::logger,
+                      "--------------------------------------------------------------------------");
 
     const std::size_t num_groups = qclient_vars::subgroup_test_num_groups;
     const std::size_t num_subgroups = qclient_vars::subgroup_test_num_subgroups;
@@ -1125,20 +1208,22 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
                   track_handler->PublishObject(headers, { reinterpret_cast<uint8_t*>(msg.data()), msg.size() });
 
                 if (status == decltype(status)::kOk) {
-                    QUICR_INFO("Published: group={} subgroup={} object={} end_subgroup={} end_group={}",
-                               group_id,
-                               subgroup_id,
-                               object_id,
-                               end_of_subgroup,
-                               end_of_group);
+                    QUICR_LOGGER_INFO(qclient_vars::logger,
+                                      "Published: group={} subgroup={} object={} end_subgroup={} end_group={}",
+                                      group_id,
+                                      subgroup_id,
+                                      object_id,
+                                      end_of_subgroup,
+                                      end_of_group);
                 } else if (status == decltype(status)::kNoSubscribers) {
-                    QUICR_WARN("No subscribers for group={} subgroup={}", group_id, subgroup_id);
+                    QUICR_LOGGER_WARN(
+                      qclient_vars::logger, "No subscribers for group={} subgroup={}", group_id, subgroup_id);
                 } else {
-                    QUICR_ERROR("Publish failed with status={}", static_cast<int>(status));
+                    QUICR_LOGGER_ERROR(qclient_vars::logger, "Publish failed with status={}", static_cast<int>(status));
                 }
             }
         } catch (const std::exception& e) {
-            QUICR_ERROR("Exception publishing: {}", e.what());
+            QUICR_LOGGER_ERROR(qclient_vars::logger, "Exception publishing: {}", e.what());
         }
     };
 
@@ -1148,7 +1233,7 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
     // Repeat the test until stopped
     while (!stop) {
         iteration++;
-        QUICR_INFO("========== Starting Test Iteration {} ==========", iteration);
+        QUICR_LOGGER_INFO(qclient_vars::logger, "========== Starting Test Iteration {} ==========", iteration);
 
         // Track object IDs per group+subgroup (reset each iteration)
         std::map<std::pair<uint64_t, uint64_t>, uint64_t> next_object_id;
@@ -1178,9 +1263,11 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
             // TODO(tievens): See if this is needed or if it is a hangover from a previous iteration.
             [[maybe_unused]] bool is_last_subgroup = (phase == num_subgroups - 1);
 
-            QUICR_INFO("=== Iteration {} Phase {} ===", iteration, phase + 1);
-            QUICR_INFO(
-              "Publishing {} messages to {} active subgroups per group", messages_per_phase, num_subgroups - phase);
+            QUICR_LOGGER_INFO(qclient_vars::logger, "=== Iteration {} Phase {} ===", iteration, phase + 1);
+            QUICR_LOGGER_INFO(qclient_vars::logger,
+                              "Publishing {} messages to {} active subgroups per group",
+                              messages_per_phase,
+                              num_subgroups - phase);
 
             // Publish messages_per_phase messages to all active subgroups
             for (std::size_t msg = 0; msg < messages_per_phase && !stop; ++msg) {
@@ -1205,8 +1292,10 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
                 active_subgroups[group].erase(subgroup_to_close);
             }
 
-            QUICR_INFO(
-              "Closed subgroup {} in all groups. {} subgroups remain.", subgroup_to_close, active_subgroups[0].size());
+            QUICR_LOGGER_INFO(qclient_vars::logger,
+                              "Closed subgroup {} in all groups. {} subgroups remain.",
+                              subgroup_to_close,
+                              active_subgroups[0].size());
         }
 
         // Calculate and report totals for this iteration
@@ -1216,15 +1305,15 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
             total_messages += messages_for_subgroup * num_groups;
         }
 
-        QUICR_INFO("=== Iteration {} Complete ===", iteration);
-        QUICR_INFO("Messages published this iteration: {}", total_messages);
-        QUICR_INFO("Groups used: {} - {}", base_group_id, base_group_id + num_groups - 1);
+        QUICR_LOGGER_INFO(qclient_vars::logger, "=== Iteration {} Complete ===", iteration);
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Messages published this iteration: {}", total_messages);
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Groups used: {} - {}", base_group_id, base_group_id + num_groups - 1);
 
         // Move to next set of group IDs for next iteration
         base_group_id += num_groups;
 
         // Brief pause between iterations
-        QUICR_INFO("Pausing before next iteration...");
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Pausing before next iteration...");
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
 
@@ -1234,7 +1323,7 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
     session->UnpublishTrack(track_handler);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    QUICR_INFO("Subgroup test publisher done after {} iterations", iteration);
+    QUICR_LOGGER_INFO(qclient_vars::logger, "Subgroup test publisher done after {} iterations", iteration);
     moq_example::terminate = true;
     moq_example::cv.notify_all();
 }
@@ -1257,13 +1346,13 @@ DoSubscriber(const quicr::FullTrackName& full_track_name,
     const auto track_handler = std::make_shared<MySubscribeTrackHandler>(full_track_name, joining_fetch);
     track_handler->SetPriority(128);
 
-    QUICR_INFO("Started subscriber");
+    QUICR_LOGGER_INFO(qclient_vars::logger, "Started subscriber");
 
     bool subscribe_track{ false };
 
     while (not stop) {
         if ((!subscribe_track) && (session->GetStatus() == quicr::Session::Status::kReady)) {
-            QUICR_INFO("Subscribing to track");
+            QUICR_LOGGER_INFO(qclient_vars::logger, "Subscribing to track");
             session->SubscribeTrack(track_handler);
             subscribe_track = true;
         }
@@ -1275,7 +1364,7 @@ DoSubscriber(const quicr::FullTrackName& full_track_name,
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    QUICR_INFO("Subscriber done track");
+    QUICR_LOGGER_INFO(qclient_vars::logger, "Subscriber done track");
     moq_example::terminate = true;
 }
 
@@ -1292,17 +1381,18 @@ DoFetch(const quicr::FullTrackName& full_track_name,
 {
     auto track_handler = MyFetchTrackHandler::Create(full_track_name, start_location, end_location);
 
-    QUICR_INFO("Started fetch start: {}.{} end: {}.{}",
-               start_location.group,
-               start_location.object,
-               end_location.group,
-               end_location.object.has_value() ? std::to_string(end_location.object.value()) : "to_end");
+    QUICR_LOGGER_INFO(qclient_vars::logger,
+                      "Started fetch start: {}.{} end: {}.{}",
+                      start_location.group,
+                      start_location.object,
+                      end_location.group,
+                      end_location.object.has_value() ? std::to_string(end_location.object.value()) : "to_end");
 
     bool fetch_track{ false };
 
     while (not stop) {
         if ((!fetch_track) && (session->GetStatus() == quicr::Session::Status::kReady)) {
-            QUICR_INFO("Fetching track");
+            QUICR_LOGGER_INFO(qclient_vars::logger, "Fetching track");
             session->FetchTrack(track_handler);
             fetch_track = true;
         }
@@ -1310,7 +1400,9 @@ DoFetch(const quicr::FullTrackName& full_track_name,
         if (track_handler->GetStatus() == quicr::FetchTrackHandler::Status::kPendingResponse) {
             // do nothing...
         } else if (!fetch_track || (track_handler->GetStatus() != quicr::FetchTrackHandler::Status::kOk)) {
-            QUICR_DEBUG("GetStatus() != quicr::FetchTrackHandler::Status::kOk {}", (int)track_handler->GetStatus());
+            QUICR_LOGGER_DEBUG(qclient_vars::logger,
+                               "GetStatus() != quicr::FetchTrackHandler::Status::kOk {}",
+                               (int)track_handler->GetStatus());
             moq_example::terminate = true;
             moq_example::cv.notify_all();
             break;
@@ -1341,12 +1433,12 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     }
 
     if (cli_opts.count("debug") && cli_opts["debug"].as<bool>() == true) {
-        QUICR_INFO("setting debug level");
-        quicr::Logger::GetDefault()->SetLevel(quicr::Logger::Level::Debug);
+        QUICR_LOGGER_INFO(qclient_vars::logger, "setting debug level");
+        qclient_vars::logger->SetLevel(quicr::Logger::Level::Debug);
     }
 
     if (cli_opts.count("version") && cli_opts["version"].as<bool>() == true) {
-        QUICR_INFO("QuicR library version: {}", QUICR_VERSION);
+        QUICR_LOGGER_INFO(qclient_vars::logger, "QuicR library version: {}", QUICR_VERSION);
         exit(0);
     }
 
@@ -1358,33 +1450,36 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
             name_str += name + ",";
         }
 
-        QUICR_INFO("Publisher enabled using track namespace: {0} name: {1}",
-                   cli_opts["pub_namespace"].as<std::string>(),
-                   name_str);
+        QUICR_LOGGER_INFO(qclient_vars::logger,
+                          "Publisher enabled using track namespace: {0} name: {1}",
+                          cli_opts["pub_namespace"].as<std::string>(),
+                          name_str);
     }
 
     if (cli_opts.count("use_announce")) {
         use_announce = true;
-        QUICR_INFO("Publisher will use announce flow");
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Publisher will use announce flow");
     }
 
     if (cli_opts.count("clock") && cli_opts["clock"].as<bool>() == true) {
-        QUICR_INFO("Running in clock publish mode");
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Running in clock publish mode");
         qclient_vars::publish_clock = true;
     }
 
     if (cli_opts.count("sub_namespace") && cli_opts.count("sub_name")) {
         enable_sub = true;
-        QUICR_INFO("Subscriber enabled using track namespace: {0} name: {1}",
-                   cli_opts["sub_namespace"].as<std::string>(),
-                   cli_opts["sub_name"].as<std::string>());
+        QUICR_LOGGER_INFO(qclient_vars::logger,
+                          "Subscriber enabled using track namespace: {0} name: {1}",
+                          cli_opts["sub_namespace"].as<std::string>(),
+                          cli_opts["sub_name"].as<std::string>());
     }
 
     if (cli_opts.count("fetch_namespace") && cli_opts.count("fetch_name")) {
         enable_fetch = true;
-        QUICR_INFO("Subscriber enabled using track namespace: {0} name: {1}",
-                   cli_opts["fetch_namespace"].as<std::string>(),
-                   cli_opts["fetch_name"].as<std::string>());
+        QUICR_LOGGER_INFO(qclient_vars::logger,
+                          "Subscriber enabled using track namespace: {0} name: {1}",
+                          cli_opts["fetch_namespace"].as<std::string>(),
+                          cli_opts["fetch_name"].as<std::string>());
     }
 
     if (cli_opts.count("track_alias")) {
@@ -1392,7 +1487,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     }
 
     if (cli_opts.count("record")) {
-        QUICR_WARN("!!! RECORDING !!!");
+        QUICR_LOGGER_WARN(qclient_vars::logger, "!!! RECORDING !!!");
         qclient_vars::record = true;
     }
 
@@ -1401,7 +1496,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     }
 
     if (cli_opts.count("gaps") && cli_opts["gaps"].as<bool>() == true) {
-        QUICR_INFO("Adding gaps to group and objects");
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Adding gaps to group and objects");
         qclient_vars::add_gaps = true;
     }
 
@@ -1416,7 +1511,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     if (cli_opts.count("subgroup_test")) {
         qclient_vars::subgroup_test = true;
         qclient_vars::publish_clock = true; // Enable clock mode for timing
-        QUICR_INFO("Subgroup/stream test mode enabled");
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Subgroup/stream test mode enabled");
     }
 
     if (cli_opts.count("subgroup_num_groups")) {
@@ -1446,7 +1541,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
 
     if (cli_opts.count("watch")) {
         qclient_vars::watch_path = cli_opts["watch"].as<std::string>();
-        QUICR_INFO("Watch mode enabled for file: {}", qclient_vars::watch_path->string());
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Watch mode enabled for file: {}", qclient_vars::watch_path->string());
     }
 
     if (cli_opts.count("watch_interval_ms")) {
@@ -1454,7 +1549,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     }
 
     if (cli_opts.count("ssl_keylog") && cli_opts["ssl_keylog"].as<bool>() == true) {
-        QUICR_INFO("SSL Keylog enabled");
+        QUICR_LOGGER_INFO(qclient_vars::logger, "SSL Keylog enabled");
     }
 
     if (cli_opts.count("mls_key")) {
@@ -1478,10 +1573,10 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
             size_t scheme_end = config.connect_uri.find("://");
             if (scheme_end != std::string::npos) {
                 config.connect_uri = "https://" + config.connect_uri.substr(scheme_end + 3);
-                QUICR_INFO("Using WebTransport with URL: {}", config.connect_uri);
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Using WebTransport with URL: {}", config.connect_uri);
             }
         } else if (!config.connect_uri.starts_with("https://")) {
-            QUICR_WARN("WebTransport requires https:// URL scheme");
+            QUICR_LOGGER_WARN(qclient_vars::logger, "WebTransport requires https:// URL scheme");
         }
     } else if (transport_type == "quic") {
         // Convert URL scheme to moq:// for raw QUIC if needed
@@ -1489,11 +1584,12 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
             size_t scheme_end = config.connect_uri.find("://");
             if (scheme_end != std::string::npos) {
                 config.connect_uri = "moq://" + config.connect_uri.substr(scheme_end + 3);
-                QUICR_INFO("Using raw QUIC with URL: {}", config.connect_uri);
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Using raw QUIC with URL: {}", config.connect_uri);
             }
         }
     } else {
-        QUICR_ERROR("Invalid transport type: {}. Valid options: quic, webtransport", transport_type);
+        QUICR_LOGGER_ERROR(
+          qclient_vars::logger, "Invalid transport type: {}. Valid options: quic, webtransport", transport_type);
         exit(-1);
     }
 
@@ -1602,13 +1698,13 @@ main(int argc, char* argv[])
         while (not stop_threads) {
             const auto status = session->GetStatus();
             if (status == quicr::Session::Status::kReady) {
-                QUICR_INFO("Connected to server");
+                QUICR_LOGGER_INFO(qclient_vars::logger, "Connected to server");
                 break;
             }
 
             if (status == quicr::Session::Status::kFailedToConnect || status == quicr::Session::Status::kNotConnected ||
                 status == quicr::Session::Status::kInternalError || status == quicr::Session::Status::kInvalidParams) {
-                QUICR_ERROR("Connection failed with status {}", static_cast<int>(status));
+                QUICR_LOGGER_ERROR(qclient_vars::logger, "Connection failed with status {}", static_cast<int>(status));
                 stop_threads = true;
                 moq_example::terminate = true;
                 moq_example::termination_reason = "Connection failed";
@@ -1628,9 +1724,10 @@ main(int argc, char* argv[])
 
             auto th = quicr::TrackHash(prefix_ns);
 
-            QUICR_INFO("Sending subscribe announces for prefix '{}' namespace_hash: {}",
-                       result["sub_announces"].as<std::string>(),
-                       th.track_namespace_hash);
+            QUICR_LOGGER_INFO(qclient_vars::logger,
+                              "Sending subscribe announces for prefix '{}' namespace_hash: {}",
+                              result["sub_announces"].as<std::string>(),
+                              th.track_namespace_hash);
 
             session->SubscribeNamespace(MySubscribeNamespaceHandler::Create(
               prefix_ns.name_space, quicr::SubscribeNamespaceHandler::Mode::kTracks));
@@ -1687,7 +1784,7 @@ main(int argc, char* argv[])
         moq_example::cv.wait(lock, [&]() { return moq_example::terminate; });
 
         stop_threads = true;
-        QUICR_INFO("Stopping threads...");
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Stopping threads...");
 
         if (pub_thread.joinable()) {
             pub_thread.join();
@@ -1701,7 +1798,7 @@ main(int argc, char* argv[])
             fetch_thread.join();
         }
 
-        QUICR_INFO("Client done");
+        QUICR_LOGGER_INFO(qclient_vars::logger, "Client done");
         std::this_thread::sleep_for(std::chrono::milliseconds(3000));
 
     } catch (const std::invalid_argument& e) {
@@ -1715,7 +1812,7 @@ main(int argc, char* argv[])
         result_code = EXIT_FAILURE;
     }
 
-    QUICR_INFO("Exit");
+    QUICR_LOGGER_INFO(qclient_vars::logger, "Exit");
 
     return result_code;
 }

--- a/examples/qclient/client.cpp
+++ b/examples/qclient/client.cpp
@@ -8,14 +8,13 @@
 #include <oss/cxxopts.hpp>
 #include <quicr/containers/cache.h>
 #include <quicr/handlers/publish_fetch_handler.h>
+#include <quicr/log.h>
 #include <quicr/messages/object.h>
 #include <quicr/session.h>
 #include <quicr/session_callbacks.h>
 #include <quicr/session_manager.h>
 #include <quicr/utilities/defer.h>
 #include <sframe/sframe.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
 #include <timeq/tick_service.h>
 
 #include <filesystem>
@@ -172,7 +171,7 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
             moq_fs_.open(dir / (name_str + ".moq"), std::ios::in | std::ios::out | std::ios::trunc);
             moq_fs_ << json::array();
 
-            SPDLOG_INFO("Creating recording files for track name {} in directory {}", name_str, dir.string());
+            QUICR_INFO("Creating recording files for track name {} in directory {}", name_str, dir.string());
         }
     }
 
@@ -224,17 +223,17 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
 
         std::string msg(data.begin(), data.end());
 
-        SPDLOG_INFO("Received message: {} Group:{}, Subgroup: {} Object:{} - {}",
-                    ext.str(),
-                    hdr.group_id,
-                    hdr.subgroup_id,
-                    hdr.object_id,
-                    msg);
+        QUICR_INFO("Received message: {} Group:{}, Subgroup: {} Object:{} - {}",
+                   ext.str(),
+                   hdr.group_id,
+                   hdr.subgroup_id,
+                   hdr.object_id,
+                   msg);
 
         if (qclient_vars::new_group_request_id.has_value() && not new_group_requested_) {
-            SPDLOG_INFO("Track alias: {} requesting new group {}",
-                        GetTrackAlias().value(),
-                        qclient_vars::new_group_request_id.value());
+            QUICR_INFO("Track alias: {} requesting new group {}",
+                       GetTrackAlias().value(),
+                       qclient_vars::new_group_request_id.value());
             RequestNewGroup(qclient_vars::new_group_request_id.value());
             new_group_requested_ = true;
         }
@@ -245,7 +244,7 @@ class MySubscribeTrackHandler : public quicr::SubscribeTrackHandler
         switch (status) {
             case Status::kOk: {
                 if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                    SPDLOG_INFO("Track alias: {0} is ready to read", track_alias.value());
+                    QUICR_INFO("Track alias: {0} is ready to read", track_alias.value());
                 }
             } break;
 
@@ -328,38 +327,38 @@ class MyPublishTrackHandler : public quicr::PublishTrackHandler
     {
         auto track_alias_opt = GetTrackAlias();
         if (!track_alias_opt.has_value()) {
-            SPDLOG_WARN("StatusChanged called but track alias not available, status: {}", static_cast<int>(status));
+            QUICR_WARN("StatusChanged called but track alias not available, status: {}", static_cast<int>(status));
             return;
         }
         const auto alias = track_alias_opt.value();
         switch (status) {
             case Status::kOk: {
-                SPDLOG_INFO("Publish track alias: {0} is ready to send", alias);
+                QUICR_INFO("Publish track alias: {0} is ready to send", alias);
                 break;
             }
             case Status::kNoSubscribers: {
-                SPDLOG_INFO("Publish track alias: {0} has no subscribers", alias);
+                QUICR_INFO("Publish track alias: {0} has no subscribers", alias);
                 break;
             }
             case Status::kNewGroupRequested: {
-                SPDLOG_INFO("Publish track alias: {0} has new group request", alias);
+                QUICR_INFO("Publish track alias: {0} has new group request", alias);
                 break;
             }
             case Status::kSubscriptionUpdated: {
-                SPDLOG_INFO("Publish track alias: {0} has updated subscription", alias);
+                QUICR_INFO("Publish track alias: {0} has updated subscription", alias);
                 break;
             }
             case Status::kPaused: {
-                SPDLOG_INFO("Publish track alias: {0} is paused", alias);
+                QUICR_INFO("Publish track alias: {0} is paused", alias);
                 break;
             }
             case Status::kPendingPublishOk: {
-                SPDLOG_INFO("Publish track alias: {0} is pending publish ok", alias);
+                QUICR_INFO("Publish track alias: {0} is pending publish ok", alias);
                 break;
             }
 
             default:
-                SPDLOG_INFO("Publish track alias: {0} has status {1}", alias, static_cast<int>(status));
+                QUICR_INFO("Publish track alias: {0} has status {1}", alias, static_cast<int>(status));
                 break;
         }
     }
@@ -420,7 +419,7 @@ class MyFetchTrackHandler : public quicr::FetchTrackHandler
                         std::optional<quicr::messages::StreamHeaderProperties>) override
     {
         std::string msg(data.begin(), data.end());
-        SPDLOG_INFO(
+        QUICR_INFO(
           "Received fetched object group_id: {} object_id: {} value: {}", headers.group_id, headers.object_id, msg);
     }
 
@@ -429,21 +428,21 @@ class MyFetchTrackHandler : public quicr::FetchTrackHandler
         switch (status) {
             case Status::kOk: {
                 if (auto track_alias = GetTrackAlias(); track_alias.has_value()) {
-                    SPDLOG_INFO("Track alias: {0} is ready to read", track_alias.value());
+                    QUICR_INFO("Track alias: {0} is ready to read", track_alias.value());
                 }
             } break;
 
             case Status::kError: {
-                SPDLOG_INFO("Fetch failed");
+                QUICR_INFO("Fetch failed");
                 break;
             }
             case Status::kDoneByFin: {
-                SPDLOG_INFO("Fetch completed");
+                QUICR_INFO("Fetch completed");
                 break;
             }
 
             case Status::kDoneByReset: {
-                SPDLOG_INFO("Fetch failed");
+                QUICR_INFO("Fetch failed");
                 break;
             }
             default:
@@ -470,17 +469,17 @@ class MyClient : public quicr::Session::ClientCallbacks
     {
         switch (status) {
             case quicr::Session::Status::kReady:
-                SPDLOG_INFO("Connection ready");
+                QUICR_INFO("Connection ready");
                 moq_example::connected = true;
                 moq_example::cv.notify_all();
                 break;
             case quicr::Session::Status::kConnecting:
                 break;
             case quicr::Session::Status::kPendingServerSetup:
-                SPDLOG_INFO("Connection connected and now pending server setup");
+                QUICR_INFO("Connection connected and now pending server setup");
                 break;
             default:
-                SPDLOG_INFO("Connection failed {0}", static_cast<int>(status));
+                QUICR_INFO("Connection failed {0}", static_cast<int>(status));
                 moq_example::terminate = true;
                 moq_example::termination_reason = "Connection failed";
                 moq_example::cv.notify_all();
@@ -493,9 +492,9 @@ class MyClient : public quicr::Session::ClientCallbacks
     quicr::Reply<void, int> ServerSetupReceived([[maybe_unused]] const std::shared_ptr<quicr::Session>& session,
                                                 const quicr::ServerSetupAttributes& server_setup_attributes) override
     {
-        SPDLOG_INFO("Server setup received from '{}' (MOQT version: {})",
-                    server_setup_attributes.server_id,
-                    server_setup_attributes.moqt_version);
+        QUICR_INFO("Server setup received from '{}' (MOQT version: {})",
+                   server_setup_attributes.server_id,
+                   server_setup_attributes.moqt_version);
         return {};
     }
 
@@ -504,7 +503,7 @@ class MyClient : public quicr::Session::ClientCallbacks
       const quicr::FullTrackName& track_full_name,
       [[maybe_unused]] const quicr::SubscribeAttributes& subscribe_attributes) override
     {
-        SPDLOG_INFO("Received subscribe for a track that is not currently published: {}", track_full_name.NameStr());
+        QUICR_INFO("Received subscribe for a track that is not currently published: {}", track_full_name.NameStr());
         return {};
     }
 
@@ -514,7 +513,7 @@ class MyClient : public quicr::Session::ClientCallbacks
       [[maybe_unused]] const quicr::PublishNamespaceAttributes& publish_namespace_attributes) override
     {
         auto th = quicr::TrackHash({ track_namespace, {} });
-        SPDLOG_INFO("Received announce for namespace_hash: {}", th.track_namespace_hash);
+        QUICR_INFO("Received announce for namespace_hash: {}", th.track_namespace_hash);
         return {};
     }
 
@@ -525,7 +524,7 @@ class MyClient : public quicr::Session::ClientCallbacks
       std::weak_ptr<quicr::SubscribeNamespaceHandler> ns_handler) override
     {
         auto th = quicr::TrackHash(publish_attributes.track_full_name);
-        SPDLOG_INFO(
+        QUICR_INFO(
           "Received PUBLISH from relay for track namespace_hash: {} name_hash: {} track_hash: {} request_id: {} ns: {}",
           th.track_namespace_hash,
           th.track_name_hash,
@@ -584,7 +583,7 @@ class MyClient : public quicr::Session::ClientCallbacks
       [[maybe_unused]] const std::shared_ptr<quicr::Session>& session,
       std::uint64_t request_id) override
     {
-        SPDLOG_INFO("Fetch cancelled for request_id: {}", request_id);
+        QUICR_INFO("Fetch cancelled for request_id: {}", request_id);
         return {};
     }
 
@@ -594,7 +593,7 @@ class MyClient : public quicr::Session::ClientCallbacks
       const quicr::FullTrackName& track_full_name) override
     {
         const auto largest_location = GetLargestAvailable(track_full_name);
-        SPDLOG_INFO("Track status requested request_id: {} track: {}", request_id, track_full_name.NameStr());
+        QUICR_INFO("Track status requested request_id: {} track: {}", request_id, track_full_name.NameStr());
         return quicr::RequestResponse{ false, largest_location, quicr::messages::GroupOrder::kAscending };
     }
 
@@ -647,10 +646,10 @@ class MyClient : public quicr::Session::ClientCallbacks
                                                                           "No objects available for fetch");
         }
 
-        SPDLOG_INFO("Fetch received request id: {} largest group: {} object: {}",
-                    request_id,
-                    largest_location->group,
-                    largest_location->object);
+        QUICR_INFO("Fetch received request id: {} largest group: {} object: {}",
+                   request_id,
+                   largest_location->group,
+                   largest_location->object);
 
         if (start.group > end.group || largest_location->group < start.group) {
             return quicr::Unexpected<quicr::Error<quicr::FetchErrorCode>>(quicr::FetchErrorCode::kInvalidRange,
@@ -687,7 +686,7 @@ class MyClient : public quicr::Session::ClientCallbacks
                         return;
                     }
 
-                    SPDLOG_DEBUG(
+                    QUICR_DEBUG(
                       "Fetch sending group: {} object: {}", object.headers.group_id, object.headers.object_id);
 
                     pub_fetch_h->PublishObject(object.headers, object.data);
@@ -732,7 +731,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                    const std::shared_ptr<quicr::PublishTrackHandler> track_handler,
                    bool& stop)
 {
-    SPDLOG_INFO("Started publisher track");
+    QUICR_INFO("Started publisher track");
 
     const auto& full_track_name = track_handler->GetFullTrackName();
 
@@ -780,7 +779,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
 
     while (not stop) {
         if ((!published_track) && (session->GetStatus() == quicr::Session::Status::kReady)) {
-            SPDLOG_INFO("Publish track ");
+            QUICR_INFO("Publish track ");
             session->PublishTrack(track_handler);
             published_track = true;
         }
@@ -795,11 +794,11 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                     object_id = 0;
                     subgroup_id = 0;
                 }
-                SPDLOG_INFO("New Group Requested: Now using group {0}", group_id);
+                QUICR_INFO("New Group Requested: Now using group {0}", group_id);
 
                 break;
             case MyPublishTrackHandler::Status::kSubscriptionUpdated:
-                SPDLOG_INFO("subscribe updated");
+                QUICR_INFO("subscribe updated");
                 break;
             case MyPublishTrackHandler::Status::kNoSubscribers:
                 // Start a new group when a subscriber joins
@@ -816,15 +815,15 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
         }
 
         if (!sending) {
-            SPDLOG_INFO("--------------------------------------------------------------------------");
+            QUICR_INFO("--------------------------------------------------------------------------");
 
             if (qclient_vars::publish_clock) {
-                SPDLOG_INFO(" Publishing clock timestamp every second");
+                QUICR_INFO(" Publishing clock timestamp every second");
             } else {
-                SPDLOG_INFO(" Type message and press enter to send");
+                QUICR_INFO(" Type message and press enter to send");
             }
 
-            SPDLOG_INFO("--------------------------------------------------------------------------");
+            QUICR_INFO("--------------------------------------------------------------------------");
             sending = true;
         }
 
@@ -863,7 +862,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
 
                 std::ifstream file(watch_path, std::ios::binary);
                 if (!file) {
-                    SPDLOG_WARN("Failed to read watch file: {}", watch_path.string());
+                    QUICR_WARN("Failed to read watch file: {}", watch_path.string());
                     std::this_thread::sleep_for(poll_tick);
                     continue;
                 }
@@ -875,7 +874,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                 object_id = 0;
                 subgroup_id = 0;
 
-                SPDLOG_INFO("Publishing file {} ({} bytes) group_id: {}", watch_path.string(), data.size(), group_id);
+                QUICR_INFO("Publishing file {} ({} bytes) group_id: {}", watch_path.string(), data.size(), group_id);
 
                 quicr::ObjectHeaders obj_headers = {
                     group_id,         object_id,      subgroup_id,  data.size(),  quicr::ObjectStatus::kAvailable,
@@ -887,11 +886,11 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                         auto status = track_handler->PublishObject(
                           obj_headers, { reinterpret_cast<uint8_t*>(data.data()), data.size() });
                         if (status != decltype(status)::kOk) {
-                            SPDLOG_WARN("PublishObject returned status={}", static_cast<int>(status));
+                            QUICR_WARN("PublishObject returned status={}", static_cast<int>(status));
                         }
                     }
                 } catch (const std::exception& e) {
-                    SPDLOG_ERROR("Exception publishing watch file: {}", e.what());
+                    QUICR_ERROR("Exception publishing watch file: {}", e.what());
                 }
 
                 last_publish = now;
@@ -904,7 +903,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
             const auto [hdr, msg] = messages.front();
             messages.pop_front();
 
-            SPDLOG_INFO("Send message: {0}", std::string(msg.begin(), msg.end()));
+            QUICR_INFO("Send message: {0}", std::string(msg.begin(), msg.end()));
 
             try {
                 auto status = track_handler->PublishObject(hdr, msg);
@@ -913,7 +912,7 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                                              std::to_string(static_cast<int>(status)));
                 }
             } catch (const std::exception& e) {
-                SPDLOG_ERROR("Caught exception trying to publish. (error={})", e.what());
+                QUICR_ERROR("Caught exception trying to publish. (error={})", e.what());
             }
 
             std::this_thread::sleep_for(qclient_vars::playback_speed_ms);
@@ -944,12 +943,12 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
         if (qclient_vars::publish_clock) {
             std::this_thread::sleep_for(std::chrono::milliseconds(999));
             msg = quicr::example::GetTimeStr();
-            SPDLOG_INFO("Group:{0} Object:{1}, Msg:{2}", group_id, object_id, msg);
+            QUICR_INFO("Group:{0} Object:{1}, Msg:{2}", group_id, object_id, msg);
         } else { // stdin
             if (!getline(std::cin, msg)) {
                 break;
             }
-            SPDLOG_INFO("Send message: {0}", msg);
+            QUICR_INFO("Send message: {0}", msg);
         }
 
         quicr::ObjectHeaders obj_headers = {
@@ -963,20 +962,20 @@ PublishWithHandler(const std::shared_ptr<quicr::Session>& session,
                   track_handler->PublishObject(obj_headers, { reinterpret_cast<uint8_t*>(msg.data()), msg.size() });
 
                 if (status == decltype(status)::kPaused) {
-                    SPDLOG_INFO("Publish is paused");
+                    QUICR_INFO("Publish is paused");
                 } else if (status == decltype(status)::kNoSubscribers) {
-                    SPDLOG_INFO("Publish has no subscribers");
+                    QUICR_INFO("Publish has no subscribers");
                 } else if (status != decltype(status)::kOk) {
                     throw std::runtime_error("PublishObject returned status=" +
                                              std::to_string(static_cast<int>(status)));
                 }
             }
         } catch (const std::exception& e) {
-            SPDLOG_ERROR("Caught exception trying to publish. (error={})", e.what());
+            QUICR_ERROR("Caught exception trying to publish. (error={})", e.what());
         }
     }
 
-    SPDLOG_INFO("Publisher done track");
+    QUICR_INFO("Publisher done track");
 }
 
 void
@@ -1016,7 +1015,7 @@ DoPublisher(const std::string prefix_str,
     std::this_thread::sleep_for(1s);
 
     if (ns_handler->GetStatus() != MyPublisherNamespaceHandler::Status::kOk) {
-        SPDLOG_ERROR("Did not get Publish Namespace OK for prefix, exiting...");
+        QUICR_ERROR("Did not get Publish Namespace OK for prefix, exiting...");
         return;
     }
 
@@ -1062,14 +1061,14 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
         track_handler->SetTrackAlias(*qclient_vars::track_alias);
     }
 
-    SPDLOG_INFO("Started subgroup/stream test publisher");
+    QUICR_INFO("Started subgroup/stream test publisher");
 
     bool published_track{ false };
 
     // Wait for connection and publish track
     while (not stop) {
         if ((!published_track) && (session->GetStatus() == quicr::Session::Status::kReady)) {
-            SPDLOG_INFO("Publish track for subgroup test");
+            QUICR_INFO("Publish track for subgroup test");
             session->PublishTrack(track_handler);
             published_track = true;
             break;
@@ -1087,13 +1086,13 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 
-    SPDLOG_INFO("--------------------------------------------------------------------------");
-    SPDLOG_INFO(" Subgroup/Stream Test: {} groups, {} subgroups, {} messages/phase",
-                qclient_vars::subgroup_test_num_groups,
-                qclient_vars::subgroup_test_num_subgroups,
-                qclient_vars::subgroup_test_messages_per_phase);
-    SPDLOG_INFO(" Test will repeat until stopped (Ctrl+C)");
-    SPDLOG_INFO("--------------------------------------------------------------------------");
+    QUICR_INFO("--------------------------------------------------------------------------");
+    QUICR_INFO(" Subgroup/Stream Test: {} groups, {} subgroups, {} messages/phase",
+               qclient_vars::subgroup_test_num_groups,
+               qclient_vars::subgroup_test_num_subgroups,
+               qclient_vars::subgroup_test_messages_per_phase);
+    QUICR_INFO(" Test will repeat until stopped (Ctrl+C)");
+    QUICR_INFO("--------------------------------------------------------------------------");
 
     const std::size_t num_groups = qclient_vars::subgroup_test_num_groups;
     const std::size_t num_subgroups = qclient_vars::subgroup_test_num_subgroups;
@@ -1126,20 +1125,20 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
                   track_handler->PublishObject(headers, { reinterpret_cast<uint8_t*>(msg.data()), msg.size() });
 
                 if (status == decltype(status)::kOk) {
-                    SPDLOG_INFO("Published: group={} subgroup={} object={} end_subgroup={} end_group={}",
-                                group_id,
-                                subgroup_id,
-                                object_id,
-                                end_of_subgroup,
-                                end_of_group);
+                    QUICR_INFO("Published: group={} subgroup={} object={} end_subgroup={} end_group={}",
+                               group_id,
+                               subgroup_id,
+                               object_id,
+                               end_of_subgroup,
+                               end_of_group);
                 } else if (status == decltype(status)::kNoSubscribers) {
-                    SPDLOG_WARN("No subscribers for group={} subgroup={}", group_id, subgroup_id);
+                    QUICR_WARN("No subscribers for group={} subgroup={}", group_id, subgroup_id);
                 } else {
-                    SPDLOG_ERROR("Publish failed with status={}", static_cast<int>(status));
+                    QUICR_ERROR("Publish failed with status={}", static_cast<int>(status));
                 }
             }
         } catch (const std::exception& e) {
-            SPDLOG_ERROR("Exception publishing: {}", e.what());
+            QUICR_ERROR("Exception publishing: {}", e.what());
         }
     };
 
@@ -1149,7 +1148,7 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
     // Repeat the test until stopped
     while (!stop) {
         iteration++;
-        SPDLOG_INFO("========== Starting Test Iteration {} ==========", iteration);
+        QUICR_INFO("========== Starting Test Iteration {} ==========", iteration);
 
         // Track object IDs per group+subgroup (reset each iteration)
         std::map<std::pair<uint64_t, uint64_t>, uint64_t> next_object_id;
@@ -1179,8 +1178,8 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
             // TODO(tievens): See if this is needed or if it is a hangover from a previous iteration.
             [[maybe_unused]] bool is_last_subgroup = (phase == num_subgroups - 1);
 
-            SPDLOG_INFO("=== Iteration {} Phase {} ===", iteration, phase + 1);
-            SPDLOG_INFO(
+            QUICR_INFO("=== Iteration {} Phase {} ===", iteration, phase + 1);
+            QUICR_INFO(
               "Publishing {} messages to {} active subgroups per group", messages_per_phase, num_subgroups - phase);
 
             // Publish messages_per_phase messages to all active subgroups
@@ -1206,7 +1205,7 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
                 active_subgroups[group].erase(subgroup_to_close);
             }
 
-            SPDLOG_INFO(
+            QUICR_INFO(
               "Closed subgroup {} in all groups. {} subgroups remain.", subgroup_to_close, active_subgroups[0].size());
         }
 
@@ -1217,15 +1216,15 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
             total_messages += messages_for_subgroup * num_groups;
         }
 
-        SPDLOG_INFO("=== Iteration {} Complete ===", iteration);
-        SPDLOG_INFO("Messages published this iteration: {}", total_messages);
-        SPDLOG_INFO("Groups used: {} - {}", base_group_id, base_group_id + num_groups - 1);
+        QUICR_INFO("=== Iteration {} Complete ===", iteration);
+        QUICR_INFO("Messages published this iteration: {}", total_messages);
+        QUICR_INFO("Groups used: {} - {}", base_group_id, base_group_id + num_groups - 1);
 
         // Move to next set of group IDs for next iteration
         base_group_id += num_groups;
 
         // Brief pause between iterations
-        SPDLOG_INFO("Pausing before next iteration...");
+        QUICR_INFO("Pausing before next iteration...");
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
 
@@ -1235,7 +1234,7 @@ DoSubgroupTest(const quicr::FullTrackName& full_track_name,
     session->UnpublishTrack(track_handler);
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    SPDLOG_INFO("Subgroup test publisher done after {} iterations", iteration);
+    QUICR_INFO("Subgroup test publisher done after {} iterations", iteration);
     moq_example::terminate = true;
     moq_example::cv.notify_all();
 }
@@ -1258,13 +1257,13 @@ DoSubscriber(const quicr::FullTrackName& full_track_name,
     const auto track_handler = std::make_shared<MySubscribeTrackHandler>(full_track_name, joining_fetch);
     track_handler->SetPriority(128);
 
-    SPDLOG_INFO("Started subscriber");
+    QUICR_INFO("Started subscriber");
 
     bool subscribe_track{ false };
 
     while (not stop) {
         if ((!subscribe_track) && (session->GetStatus() == quicr::Session::Status::kReady)) {
-            SPDLOG_INFO("Subscribing to track");
+            QUICR_INFO("Subscribing to track");
             session->SubscribeTrack(track_handler);
             subscribe_track = true;
         }
@@ -1276,7 +1275,7 @@ DoSubscriber(const quicr::FullTrackName& full_track_name,
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    SPDLOG_INFO("Subscriber done track");
+    QUICR_INFO("Subscriber done track");
     moq_example::terminate = true;
 }
 
@@ -1293,17 +1292,17 @@ DoFetch(const quicr::FullTrackName& full_track_name,
 {
     auto track_handler = MyFetchTrackHandler::Create(full_track_name, start_location, end_location);
 
-    SPDLOG_INFO("Started fetch start: {}.{} end: {}.{}",
-                start_location.group,
-                start_location.object,
-                end_location.group,
-                end_location.object.has_value() ? std::to_string(end_location.object.value()) : "to_end");
+    QUICR_INFO("Started fetch start: {}.{} end: {}.{}",
+               start_location.group,
+               start_location.object,
+               end_location.group,
+               end_location.object.has_value() ? std::to_string(end_location.object.value()) : "to_end");
 
     bool fetch_track{ false };
 
     while (not stop) {
         if ((!fetch_track) && (session->GetStatus() == quicr::Session::Status::kReady)) {
-            SPDLOG_INFO("Fetching track");
+            QUICR_INFO("Fetching track");
             session->FetchTrack(track_handler);
             fetch_track = true;
         }
@@ -1311,7 +1310,7 @@ DoFetch(const quicr::FullTrackName& full_track_name,
         if (track_handler->GetStatus() == quicr::FetchTrackHandler::Status::kPendingResponse) {
             // do nothing...
         } else if (!fetch_track || (track_handler->GetStatus() != quicr::FetchTrackHandler::Status::kOk)) {
-            SPDLOG_DEBUG("GetStatus() != quicr::FetchTrackHandler::Status::kOk {}", (int)track_handler->GetStatus());
+            QUICR_DEBUG("GetStatus() != quicr::FetchTrackHandler::Status::kOk {}", (int)track_handler->GetStatus());
             moq_example::terminate = true;
             moq_example::cv.notify_all();
             break;
@@ -1342,12 +1341,12 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     }
 
     if (cli_opts.count("debug") && cli_opts["debug"].as<bool>() == true) {
-        SPDLOG_INFO("setting debug level");
-        spdlog::set_level(spdlog::level::debug);
+        QUICR_INFO("setting debug level");
+        quicr::Logger::GetDefault()->SetLevel(quicr::Logger::Level::Debug);
     }
 
     if (cli_opts.count("version") && cli_opts["version"].as<bool>() == true) {
-        SPDLOG_INFO("QuicR library version: {}", QUICR_VERSION);
+        QUICR_INFO("QuicR library version: {}", QUICR_VERSION);
         exit(0);
     }
 
@@ -1359,33 +1358,33 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
             name_str += name + ",";
         }
 
-        SPDLOG_INFO("Publisher enabled using track namespace: {0} name: {1}",
-                    cli_opts["pub_namespace"].as<std::string>(),
-                    name_str);
+        QUICR_INFO("Publisher enabled using track namespace: {0} name: {1}",
+                   cli_opts["pub_namespace"].as<std::string>(),
+                   name_str);
     }
 
     if (cli_opts.count("use_announce")) {
         use_announce = true;
-        SPDLOG_INFO("Publisher will use announce flow");
+        QUICR_INFO("Publisher will use announce flow");
     }
 
     if (cli_opts.count("clock") && cli_opts["clock"].as<bool>() == true) {
-        SPDLOG_INFO("Running in clock publish mode");
+        QUICR_INFO("Running in clock publish mode");
         qclient_vars::publish_clock = true;
     }
 
     if (cli_opts.count("sub_namespace") && cli_opts.count("sub_name")) {
         enable_sub = true;
-        SPDLOG_INFO("Subscriber enabled using track namespace: {0} name: {1}",
-                    cli_opts["sub_namespace"].as<std::string>(),
-                    cli_opts["sub_name"].as<std::string>());
+        QUICR_INFO("Subscriber enabled using track namespace: {0} name: {1}",
+                   cli_opts["sub_namespace"].as<std::string>(),
+                   cli_opts["sub_name"].as<std::string>());
     }
 
     if (cli_opts.count("fetch_namespace") && cli_opts.count("fetch_name")) {
         enable_fetch = true;
-        SPDLOG_INFO("Subscriber enabled using track namespace: {0} name: {1}",
-                    cli_opts["fetch_namespace"].as<std::string>(),
-                    cli_opts["fetch_name"].as<std::string>());
+        QUICR_INFO("Subscriber enabled using track namespace: {0} name: {1}",
+                   cli_opts["fetch_namespace"].as<std::string>(),
+                   cli_opts["fetch_name"].as<std::string>());
     }
 
     if (cli_opts.count("track_alias")) {
@@ -1393,7 +1392,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     }
 
     if (cli_opts.count("record")) {
-        SPDLOG_WARN("!!! RECORDING !!!");
+        QUICR_WARN("!!! RECORDING !!!");
         qclient_vars::record = true;
     }
 
@@ -1402,7 +1401,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     }
 
     if (cli_opts.count("gaps") && cli_opts["gaps"].as<bool>() == true) {
-        SPDLOG_INFO("Adding gaps to group and objects");
+        QUICR_INFO("Adding gaps to group and objects");
         qclient_vars::add_gaps = true;
     }
 
@@ -1417,7 +1416,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     if (cli_opts.count("subgroup_test")) {
         qclient_vars::subgroup_test = true;
         qclient_vars::publish_clock = true; // Enable clock mode for timing
-        SPDLOG_INFO("Subgroup/stream test mode enabled");
+        QUICR_INFO("Subgroup/stream test mode enabled");
     }
 
     if (cli_opts.count("subgroup_num_groups")) {
@@ -1447,7 +1446,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
 
     if (cli_opts.count("watch")) {
         qclient_vars::watch_path = cli_opts["watch"].as<std::string>();
-        SPDLOG_INFO("Watch mode enabled for file: {}", qclient_vars::watch_path->string());
+        QUICR_INFO("Watch mode enabled for file: {}", qclient_vars::watch_path->string());
     }
 
     if (cli_opts.count("watch_interval_ms")) {
@@ -1455,7 +1454,7 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
     }
 
     if (cli_opts.count("ssl_keylog") && cli_opts["ssl_keylog"].as<bool>() == true) {
-        SPDLOG_INFO("SSL Keylog enabled");
+        QUICR_INFO("SSL Keylog enabled");
     }
 
     if (cli_opts.count("mls_key")) {
@@ -1479,10 +1478,10 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
             size_t scheme_end = config.connect_uri.find("://");
             if (scheme_end != std::string::npos) {
                 config.connect_uri = "https://" + config.connect_uri.substr(scheme_end + 3);
-                SPDLOG_INFO("Using WebTransport with URL: {}", config.connect_uri);
+                QUICR_INFO("Using WebTransport with URL: {}", config.connect_uri);
             }
         } else if (!config.connect_uri.starts_with("https://")) {
-            SPDLOG_WARN("WebTransport requires https:// URL scheme");
+            QUICR_WARN("WebTransport requires https:// URL scheme");
         }
     } else if (transport_type == "quic") {
         // Convert URL scheme to moq:// for raw QUIC if needed
@@ -1490,11 +1489,11 @@ InitConfig(cxxopts::ParseResult& cli_opts, bool& enable_pub, bool& enable_sub, b
             size_t scheme_end = config.connect_uri.find("://");
             if (scheme_end != std::string::npos) {
                 config.connect_uri = "moq://" + config.connect_uri.substr(scheme_end + 3);
-                SPDLOG_INFO("Using raw QUIC with URL: {}", config.connect_uri);
+                QUICR_INFO("Using raw QUIC with URL: {}", config.connect_uri);
             }
         }
     } else {
-        SPDLOG_ERROR("Invalid transport type: {}. Valid options: quic, webtransport", transport_type);
+        QUICR_ERROR("Invalid transport type: {}. Valid options: quic, webtransport", transport_type);
         exit(-1);
     }
 
@@ -1603,13 +1602,13 @@ main(int argc, char* argv[])
         while (not stop_threads) {
             const auto status = session->GetStatus();
             if (status == quicr::Session::Status::kReady) {
-                SPDLOG_INFO("Connected to server");
+                QUICR_INFO("Connected to server");
                 break;
             }
 
             if (status == quicr::Session::Status::kFailedToConnect || status == quicr::Session::Status::kNotConnected ||
                 status == quicr::Session::Status::kInternalError || status == quicr::Session::Status::kInvalidParams) {
-                SPDLOG_ERROR("Connection failed with status {}", static_cast<int>(status));
+                QUICR_ERROR("Connection failed with status {}", static_cast<int>(status));
                 stop_threads = true;
                 moq_example::terminate = true;
                 moq_example::termination_reason = "Connection failed";
@@ -1629,9 +1628,9 @@ main(int argc, char* argv[])
 
             auto th = quicr::TrackHash(prefix_ns);
 
-            SPDLOG_INFO("Sending subscribe announces for prefix '{}' namespace_hash: {}",
-                        result["sub_announces"].as<std::string>(),
-                        th.track_namespace_hash);
+            QUICR_INFO("Sending subscribe announces for prefix '{}' namespace_hash: {}",
+                       result["sub_announces"].as<std::string>(),
+                       th.track_namespace_hash);
 
             session->SubscribeNamespace(MySubscribeNamespaceHandler::Create(
               prefix_ns.name_space, quicr::SubscribeNamespaceHandler::Mode::kTracks));
@@ -1688,7 +1687,7 @@ main(int argc, char* argv[])
         moq_example::cv.wait(lock, [&]() { return moq_example::terminate; });
 
         stop_threads = true;
-        SPDLOG_INFO("Stopping threads...");
+        QUICR_INFO("Stopping threads...");
 
         if (pub_thread.joinable()) {
             pub_thread.join();
@@ -1702,7 +1701,7 @@ main(int argc, char* argv[])
             fetch_thread.join();
         }
 
-        SPDLOG_INFO("Client done");
+        QUICR_INFO("Client done");
         std::this_thread::sleep_for(std::chrono::milliseconds(3000));
 
     } catch (const std::invalid_argument& e) {
@@ -1716,7 +1715,7 @@ main(int argc, char* argv[])
         result_code = EXIT_FAILURE;
     }
 
-    SPDLOG_INFO("Exit");
+    QUICR_INFO("Exit");
 
     return result_code;
 }

--- a/examples/qclient/client.cpp
+++ b/examples/qclient/client.cpp
@@ -37,7 +37,9 @@ class SpdlogLogger : public quicr::Logger
 
     virtual ~SpdlogLogger() = default;
 
-    void SetLevel(quicr::Logger::Level max_level) override { logger_->set_level(ConvertLevelType(max_level)); }
+    void SetLevel(Level max_level) override { logger_->set_level(ConvertLevelType(max_level)); }
+
+    bool ShouldLog(Level level) const noexcept override { return logger_->should_log(ConvertLevelType(level)); }
 
     void Log(quicr::Logger::Level level,
              std::string_view msg,
@@ -54,7 +56,7 @@ class SpdlogLogger : public quicr::Logger
     }
 
   private:
-    spdlog::level::level_enum ConvertLevelType(Logger::Level level)
+    spdlog::level::level_enum ConvertLevelType(Logger::Level level) const noexcept
     {
         switch (level) {
             case Logger::Level::Trace:
@@ -69,6 +71,8 @@ class SpdlogLogger : public quicr::Logger
                 return spdlog::level::err;
             case Logger::Level::Critical:
                 return spdlog::level::critical;
+            case Logger::Level::Off:
+                return spdlog::level::off;
         }
     }
 

--- a/include/quicr/log.h
+++ b/include/quicr/log.h
@@ -5,7 +5,7 @@
 #include <format>
 namespace std_or_fmt = std;
 #else
-#include <fmt/core.h>
+#include <fmt/format.h>
 namespace std_or_fmt = fmt;
 #endif
 #include <memory>

--- a/include/quicr/log.h
+++ b/include/quicr/log.h
@@ -68,6 +68,7 @@ namespace quicr {
 #define QUICR_LOG_WARN 3
 #define QUICR_LOG_ERROR 4
 #define QUICR_LOG_CRITICAL 5
+#define QUICR_LOG_OFF 6
 
 #ifndef QUICR_ACTIVE_LOG_LEVEL
 #ifdef NDEBUG

--- a/include/quicr/log.h
+++ b/include/quicr/log.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <version>
-#ifdef __cpp_lib_format
+#ifdef QUICR_HAVE_STD_FORMAT
 #include <format>
 namespace std_or_fmt = std;
 #else

--- a/include/quicr/log.h
+++ b/include/quicr/log.h
@@ -9,17 +9,26 @@
 
 namespace quicr {
 
+#define QUICR_LOG_TRACE 0
+#define QUICR_LOG_DEBUG 1
+#define QUICR_LOG_INFO 2
+#define QUICR_LOG_WARN 3
+#define QUICR_LOG_ERROR 4
+#define QUICR_LOG_CRITICAL 5
+#define QUICR_LOG_OFF 6
+
     class Logger
     {
       public:
         enum class Level
         {
-            Trace,
-            Debug,
-            Info,
-            Warn,
-            Error,
-            Critical,
+            Trace = QUICR_LOG_TRACE,
+            Debug = QUICR_LOG_DEBUG,
+            Info = QUICR_LOG_INFO,
+            Warn = QUICR_LOG_WARN,
+            Error = QUICR_LOG_ERROR,
+            Critical = QUICR_LOG_CRITICAL,
+            Off = QUICR_LOG_OFF,
         };
 
         virtual ~Logger() = default;
@@ -28,12 +37,18 @@ namespace quicr {
 
         virtual void Log(Level level, std::string_view msg, std::source_location = std::source_location::current()) = 0;
 
+        virtual bool ShouldLog(Level level) const noexcept;
+
         template<typename... Args>
         void Log(std::source_location location,
                  Level level,
                  std::conditional_t<sizeof...(Args) == 0, std::string_view, std_or_fmt::format_string<Args...>> msg,
                  Args&&... args)
         try {
+            if (!ShouldLog(level)) {
+                return;
+            }
+
             if constexpr (sizeof...(Args) == 0) {
                 Log(level, msg, location);
             } else {
@@ -50,14 +65,6 @@ namespace quicr {
             logger->Log(std::source_location::current(), level, msg __VA_OPT__(, ) __VA_ARGS__);                       \
         }                                                                                                              \
     } while (0)
-
-#define QUICR_LOG_TRACE 0
-#define QUICR_LOG_DEBUG 1
-#define QUICR_LOG_INFO 2
-#define QUICR_LOG_WARN 3
-#define QUICR_LOG_ERROR 4
-#define QUICR_LOG_CRITICAL 5
-#define QUICR_LOG_OFF 6
 
 #ifndef QUICR_ACTIVE_LOG_LEVEL
 #ifdef NDEBUG

--- a/include/quicr/log.h
+++ b/include/quicr/log.h
@@ -38,9 +38,18 @@ namespace quicr {
         void Log(Level level, std::string_view msg, std::source_location = std::source_location::current());
 
         template<typename... Args>
-        void Log(std::source_location location, Level level, std::string_view msg, Args&&... args)
-        {
-            Log(level, std_or_fmt::vformat(msg, std_or_fmt::make_format_args(args...)), location);
+        void Log(std::source_location location,
+                 Level level,
+                 std::conditional_t<sizeof...(Args) == 0, std::string_view, std_or_fmt::format_string<Args...>> msg,
+                 Args&&... args)
+        try {
+            if constexpr (sizeof...(Args) == 0) {
+                Log(level, msg, location);
+            } else {
+                Log(level, std_or_fmt::vformat(msg.get(), std_or_fmt::make_format_args(args...)), location);
+            }
+        } catch (const std::exception& e) {
+            Log(Level::Error, std_or_fmt::format("log failed to format (error={})", e.what()), location);
         }
 
       private:

--- a/include/quicr/log.h
+++ b/include/quicr/log.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <version>
+#ifdef __cpp_lib_format
+#include <format>
+namespace std_or_fmt = std;
+#else
+#include <fmt/core.h>
+namespace std_or_fmt = fmt;
+#endif
+#include <memory>
+#include <source_location>
+#include <string_view>
+
+namespace quicr {
+
+    class Logger
+    {
+        Logger(std::string_view name);
+
+      public:
+        enum class Level
+        {
+            Trace,
+            Debug,
+            Info,
+            Warn,
+            Error,
+            Critical,
+        };
+
+        static std::shared_ptr<Logger> Create(std::string_view name);
+
+        static std::shared_ptr<Logger> GetDefault();
+
+        void SetLevel(Level max_level);
+
+        void Log(Level level, std::string_view msg, std::source_location = std::source_location::current());
+
+        template<typename... Args>
+        void Log(std::source_location location, Level level, std::string_view msg, Args&&... args)
+        {
+            Log(level, std_or_fmt::vformat(msg, std_or_fmt::make_format_args(args...)), location);
+        }
+
+      private:
+        class Impl;
+        std::unique_ptr<Impl> impl_;
+    };
+
+#define QUICR_LOGGER_LOG(logger, level, msg, ...)                                                                      \
+    logger->Log(std::source_location::current(), level, msg __VA_OPT__(, ) __VA_ARGS__)
+
+#define QUICR_LOG(level, msg, ...) QUICR_LOGGER_LOG(quicr::Logger::GetDefault(), level, msg __VA_OPT__(, ) __VA_ARGS__)
+
+#define QUICR_LOG_TRACE 0
+#define QUICR_LOG_DEBUG 1
+#define QUICR_LOG_INFO 2
+#define QUICR_LOG_WARN 3
+#define QUICR_LOG_ERROR 4
+#define QUICR_LOG_CRITICAL 5
+
+#ifndef QUICR_ACTIVE_LOG_LEVEL
+#ifdef NDEBUG
+#define QUICR_ACTIVE_LOG_LEVEL QUICR_LOG_INFO
+#else
+#define QUICR_ACTIVE_LOG_LEVEL QUICR_LOG_DEBUG
+#endif
+#endif
+
+#if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_TRACE
+#define QUICR_LOGGER_TRACE(logger, msg, ...)                                                                           \
+    QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Trace, msg __VA_OPT__(, ) __VA_ARGS__)
+#define QUICR_TRACE(msg, ...) QUICR_LOG(quicr::Logger::Level::Trace, msg __VA_OPT__(, ) __VA_ARGS__)
+#else
+#define QUICR_LOGGER_TRACE(logger, msg, ...)
+#define QUICR_TRACE(msg, ...)
+#endif
+#if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_DEBUG
+#define QUICR_LOGGER_DEBUG(logger, msg, ...)                                                                           \
+    QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Debug, msg __VA_OPT__(, ) __VA_ARGS__)
+#define QUICR_DEBUG(msg, ...) QUICR_LOG(quicr::Logger::Level::Debug, msg __VA_OPT__(, ) __VA_ARGS__)
+#else
+#define QUICR_LOGGER_DEBUG(logger, msg, ...)
+#define QUICR_DEBUG(msg, ...)
+#endif
+#if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_INFO
+#define QUICR_LOGGER_INFO(logger, msg, ...)                                                                            \
+    QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Info, msg __VA_OPT__(, ) __VA_ARGS__)
+#define QUICR_INFO(msg, ...) QUICR_LOG(quicr::Logger::Level::Info, msg __VA_OPT__(, ) __VA_ARGS__)
+#else
+#define QUICR_LOGGER_INFO(logger, msg, ...)
+#define QUICR_INFO(msg, ...)
+#endif
+#if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_WARN
+#define QUICR_LOGGER_WARN(logger, msg, ...)                                                                            \
+    QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Warn, msg __VA_OPT__(, ) __VA_ARGS__)
+#define QUICR_WARN(msg, ...) QUICR_LOG(quicr::Logger::Level::Warn, msg __VA_OPT__(, ) __VA_ARGS__)
+#else
+#define QUICR_LOGGER_WARN(logger, msg, ...)
+#define QUICR_WARN(msg, ...)
+#endif
+#if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_ERROR
+#define QUICR_LOGGER_ERROR(logger, msg, ...)                                                                           \
+    QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Error, msg __VA_OPT__(, ) __VA_ARGS__)
+#define QUICR_ERROR(msg, ...) QUICR_LOG(quicr::Logger::Level::Error, msg __VA_OPT__(, ) __VA_ARGS__)
+#else
+#define QUICR_LOGGER_ERROR(logger, msg, ...)
+#define QUICR_ERROR(msg, ...)
+#endif
+#if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_CRITICAL
+#define QUICR_LOGGER_CRITICAL(logger, msg, ...)                                                                        \
+    QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Critical, msg __VA_OPT__(, ) __VA_ARGS__)
+#define QUICR_CRITICAL(msg, ...) QUICR_LOG(quicr::Logger::Level::Critical, msg __VA_OPT__(, ) __VA_ARGS__)
+#else
+#define QUICR_LOGGER_CRITICAL(logger, msg, ...)
+#define QUICR_CRITICAL(msg, ...)
+#endif
+
+}

--- a/include/quicr/log.h
+++ b/include/quicr/log.h
@@ -1,23 +1,16 @@
 #pragma once
 
-#include <version>
-#ifdef QUICR_HAVE_STD_FORMAT
-#include <format>
-namespace std_or_fmt = std;
-#else
-#include <fmt/format.h>
-namespace std_or_fmt = fmt;
-#endif
+#include "quicr/utilities/format.h"
+
 #include <memory>
 #include <source_location>
 #include <string_view>
+#include <version>
 
 namespace quicr {
 
     class Logger
     {
-        Logger(std::string_view name);
-
       public:
         enum class Level
         {
@@ -29,13 +22,11 @@ namespace quicr {
             Critical,
         };
 
-        static std::shared_ptr<Logger> Create(std::string_view name);
+        virtual ~Logger() = default;
 
-        static std::shared_ptr<Logger> GetDefault();
+        virtual void SetLevel(Level max_level) = 0;
 
-        void SetLevel(Level max_level);
-
-        void Log(Level level, std::string_view msg, std::source_location = std::source_location::current());
+        virtual void Log(Level level, std::string_view msg, std::source_location = std::source_location::current()) = 0;
 
         template<typename... Args>
         void Log(std::source_location location,
@@ -51,16 +42,14 @@ namespace quicr {
         } catch (const std::exception& e) {
             Log(Level::Error, std_or_fmt::format("log failed to format (error={})", e.what()), location);
         }
-
-      private:
-        class Impl;
-        std::unique_ptr<Impl> impl_;
     };
 
 #define QUICR_LOGGER_LOG(logger, level, msg, ...)                                                                      \
-    logger->Log(std::source_location::current(), level, msg __VA_OPT__(, ) __VA_ARGS__)
-
-#define QUICR_LOG(level, msg, ...) QUICR_LOGGER_LOG(quicr::Logger::GetDefault(), level, msg __VA_OPT__(, ) __VA_ARGS__)
+    do {                                                                                                               \
+        if (logger) {                                                                                                  \
+            logger->Log(std::source_location::current(), level, msg __VA_OPT__(, ) __VA_ARGS__);                       \
+        }                                                                                                              \
+    } while (0)
 
 #define QUICR_LOG_TRACE 0
 #define QUICR_LOG_DEBUG 1
@@ -81,50 +70,38 @@ namespace quicr {
 #if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_TRACE
 #define QUICR_LOGGER_TRACE(logger, msg, ...)                                                                           \
     QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Trace, msg __VA_OPT__(, ) __VA_ARGS__)
-#define QUICR_TRACE(msg, ...) QUICR_LOG(quicr::Logger::Level::Trace, msg __VA_OPT__(, ) __VA_ARGS__)
 #else
 #define QUICR_LOGGER_TRACE(logger, msg, ...)
-#define QUICR_TRACE(msg, ...)
 #endif
 #if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_DEBUG
 #define QUICR_LOGGER_DEBUG(logger, msg, ...)                                                                           \
     QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Debug, msg __VA_OPT__(, ) __VA_ARGS__)
-#define QUICR_DEBUG(msg, ...) QUICR_LOG(quicr::Logger::Level::Debug, msg __VA_OPT__(, ) __VA_ARGS__)
 #else
 #define QUICR_LOGGER_DEBUG(logger, msg, ...)
-#define QUICR_DEBUG(msg, ...)
 #endif
 #if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_INFO
 #define QUICR_LOGGER_INFO(logger, msg, ...)                                                                            \
     QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Info, msg __VA_OPT__(, ) __VA_ARGS__)
-#define QUICR_INFO(msg, ...) QUICR_LOG(quicr::Logger::Level::Info, msg __VA_OPT__(, ) __VA_ARGS__)
 #else
 #define QUICR_LOGGER_INFO(logger, msg, ...)
-#define QUICR_INFO(msg, ...)
 #endif
 #if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_WARN
 #define QUICR_LOGGER_WARN(logger, msg, ...)                                                                            \
     QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Warn, msg __VA_OPT__(, ) __VA_ARGS__)
-#define QUICR_WARN(msg, ...) QUICR_LOG(quicr::Logger::Level::Warn, msg __VA_OPT__(, ) __VA_ARGS__)
 #else
 #define QUICR_LOGGER_WARN(logger, msg, ...)
-#define QUICR_WARN(msg, ...)
 #endif
 #if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_ERROR
 #define QUICR_LOGGER_ERROR(logger, msg, ...)                                                                           \
     QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Error, msg __VA_OPT__(, ) __VA_ARGS__)
-#define QUICR_ERROR(msg, ...) QUICR_LOG(quicr::Logger::Level::Error, msg __VA_OPT__(, ) __VA_ARGS__)
 #else
 #define QUICR_LOGGER_ERROR(logger, msg, ...)
-#define QUICR_ERROR(msg, ...)
 #endif
 #if QUICR_ACTIVE_LOG_LEVEL <= QUICR_LOG_CRITICAL
 #define QUICR_LOGGER_CRITICAL(logger, msg, ...)                                                                        \
     QUICR_LOGGER_LOG(logger, quicr::Logger::Level::Critical, msg __VA_OPT__(, ) __VA_ARGS__)
-#define QUICR_CRITICAL(msg, ...) QUICR_LOG(quicr::Logger::Level::Critical, msg __VA_OPT__(, ) __VA_ARGS__)
 #else
 #define QUICR_LOGGER_CRITICAL(logger, msg, ...)
-#define QUICR_CRITICAL(msg, ...)
 #endif
 
 }

--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -162,10 +162,15 @@ namespace quicr {
                                                std::shared_ptr<Transport> transport,
                                                std::shared_ptr<Connection> connection,
                                                std::shared_ptr<ClientCallbacks> callbacks,
-                                               std::shared_ptr<timeq::tick_service> tick_service)
+                                               std::shared_ptr<timeq::tick_service> tick_service,
+                                               std::shared_ptr<Logger> logger = nullptr)
         {
-            return std::shared_ptr<Session>(new Session(
-              cfg, std::move(transport), std::move(connection), std::move(callbacks), std::move(tick_service)));
+            return std::shared_ptr<Session>(new Session(cfg,
+                                                        std::move(transport),
+                                                        std::move(connection),
+                                                        std::move(callbacks),
+                                                        std::move(tick_service),
+                                                        std::move(logger)));
         }
 
         /**
@@ -177,10 +182,15 @@ namespace quicr {
                                                std::shared_ptr<Transport> transport,
                                                std::shared_ptr<Connection> connection,
                                                std::shared_ptr<ServerCallbacks> callbacks,
-                                               std::shared_ptr<timeq::tick_service> tick_service)
+                                               std::shared_ptr<timeq::tick_service> tick_service,
+                                               std::shared_ptr<Logger> logger = nullptr)
         {
-            return std::shared_ptr<Session>(new Session(
-              cfg, std::move(transport), std::move(connection), std::move(callbacks), std::move(tick_service)));
+            return std::shared_ptr<Session>(new Session(cfg,
+                                                        std::move(transport),
+                                                        std::move(connection),
+                                                        std::move(callbacks),
+                                                        std::move(tick_service),
+                                                        std::move(logger)));
         }
 
         virtual ~Session();
@@ -188,6 +198,8 @@ namespace quicr {
         const std::shared_ptr<Connection>& GetConnection() const noexcept { return current_connection_; }
 
         const std::shared_ptr<timeq::tick_service>& GetTickService() const noexcept { return tick_service_; }
+
+        const std::shared_ptr<Logger>& GetLogger() const noexcept { return logger_; }
 
         Status GetStatus() const noexcept { return status_; }
 
@@ -437,14 +449,18 @@ namespace quicr {
          * @param cfg MoQ Client Configuration
          */
         Session(const ClientConfig& cfg,
+
                 std::shared_ptr<Transport> transport,
+
                 std::shared_ptr<Connection> connection,
-                std::shared_ptr<ClientCallbacks> callbacks)
+                std::shared_ptr<ClientCallbacks> callbacks,
+                std::shared_ptr<Logger> logger)
           : Session(cfg,
                     std::move(transport),
                     std::move(connection),
                     std::move(callbacks),
-                    std::make_shared<timeq::threaded_tick_service>(cfg.tick_service_sleep_delay_us))
+                    std::make_shared<timeq::threaded_tick_service>(cfg.tick_service_sleep_delay_us),
+                    std::move(logger))
         {
         }
 
@@ -454,14 +470,18 @@ namespace quicr {
          * @param cfg MoQ Server Configuration
          */
         Session(const ServerConfig& cfg,
+
                 std::shared_ptr<Transport> transport,
+
                 std::shared_ptr<Connection> connection,
-                std::shared_ptr<ServerCallbacks> callbacks)
+                std::shared_ptr<ServerCallbacks> callbacks,
+                std::shared_ptr<Logger> logger)
           : Session(cfg,
                     std::move(transport),
                     std::move(connection),
                     std::move(callbacks),
-                    std::make_shared<timeq::threaded_tick_service>(cfg.tick_service_sleep_delay_us))
+                    std::make_shared<timeq::threaded_tick_service>(cfg.tick_service_sleep_delay_us),
+                    std::move(logger))
         {
         }
 
@@ -475,7 +495,8 @@ namespace quicr {
                 std::shared_ptr<Transport> transport,
                 std::shared_ptr<Connection> connection,
                 std::shared_ptr<ClientCallbacks> callbacks,
-                std::shared_ptr<timeq::tick_service> tick_service);
+                std::shared_ptr<timeq::tick_service> tick_service,
+                std::shared_ptr<Logger> logger);
 
         /**
          * @brief Server mode constructor with explicit tick service
@@ -487,7 +508,8 @@ namespace quicr {
                 std::shared_ptr<Transport> transport,
                 std::shared_ptr<Connection> connection,
                 std::shared_ptr<ServerCallbacks> callbacks,
-                std::shared_ptr<timeq::tick_service> tick_service);
+                std::shared_ptr<timeq::tick_service> tick_service,
+                std::shared_ptr<Logger> logger);
 
         void OnStreamClosed(std::uint64_t stream_id,
                             std::shared_ptr<StreamRxContext> rx_ctx,

--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -27,11 +27,9 @@
 #include <string>
 #include <string_view>
 
-namespace spdlog {
-    class logger;
-}
-
 namespace quicr {
+
+    class Logger;
 
     /**
      * @brief Response to a received subscribe or track status request
@@ -759,7 +757,7 @@ namespace quicr {
 
         const bool client_mode_;
 
-        std::shared_ptr<spdlog::logger> logger_;
+        std::shared_ptr<Logger> logger_;
 
         bool stop_{ false };
 

--- a/include/quicr/session_manager.h
+++ b/include/quicr/session_manager.h
@@ -36,13 +36,15 @@ namespace quicr {
         };
 
       public:
-        SessionManager();
+        SessionManager(std::shared_ptr<Logger> logger = nullptr);
 
-        SessionManager(std::shared_ptr<Callbacks> callbacks);
+        SessionManager(std::shared_ptr<Callbacks> callbacks, std::shared_ptr<Logger> logger = nullptr);
 
-        SessionManager(std::shared_ptr<timeq::tick_service> tick_service);
+        SessionManager(std::shared_ptr<timeq::tick_service> tick_service, std::shared_ptr<Logger> logger = nullptr);
 
-        SessionManager(std::shared_ptr<Callbacks> callbacks, std::shared_ptr<timeq::tick_service> tick_service);
+        SessionManager(std::shared_ptr<Callbacks> callbacks,
+                       std::shared_ptr<timeq::tick_service> tick_service,
+                       std::shared_ptr<Logger> logger = nullptr);
 
         ~SessionManager();
 

--- a/include/quicr/session_manager.h
+++ b/include/quicr/session_manager.h
@@ -16,15 +16,12 @@ namespace timeq {
     struct tick_service;
 }
 
-namespace spdlog {
-    class logger;
-}
-
 namespace quicr {
 
     class Connection;
     class Transport;
     class TrackHandler;
+    class Logger;
 
     class SessionManager
     {
@@ -63,7 +60,7 @@ namespace quicr {
 
         std::shared_ptr<timeq::tick_service> tick_service_;
 
-        std::shared_ptr<spdlog::logger> logger_;
+        std::shared_ptr<Logger> logger_;
 
         std::mutex mutex_;
 

--- a/include/quicr/transport.h
+++ b/include/quicr/transport.h
@@ -24,13 +24,10 @@
 #include <sys/socket.h>
 #include <vector>
 
-namespace spdlog {
-    class logger;
-}
-
 namespace quicr {
 
     class Connection;
+    class Logger;
 
     /**
      * Close Connection App Reasons
@@ -182,7 +179,7 @@ namespace quicr {
         static std::shared_ptr<Transport> MakeClientTransport(const TransportRemote& server,
                                                               const TransportConfig& tcfg,
                                                               std::shared_ptr<timeq::tick_service> tick_service,
-                                                              std::shared_ptr<spdlog::logger> logger);
+                                                              std::shared_ptr<Logger> logger);
 
         /**
          * @brief Create a new server transport based on the remote (server) ip and port
@@ -202,7 +199,7 @@ namespace quicr {
         static std::shared_ptr<Transport> MakeServerTransport(const TransportRemote& server,
                                                               const TransportConfig& tcfg,
                                                               std::shared_ptr<timeq::tick_service> tick_service,
-                                                              std::shared_ptr<spdlog::logger> logger);
+                                                              std::shared_ptr<Logger> logger);
 
       public:
         virtual ~Transport() = default;

--- a/include/quicr/utilities/format.h
+++ b/include/quicr/utilities/format.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifdef QUICR_HAVE_STD_FORMAT
+#include <format>
+namespace std_or_fmt = std;
+#else
+#include <fmt/format.h>
+namespace std_or_fmt = fmt;
+#endif
+
+namespace quicr {
+
+    template<typename... Args>
+    std::string format(std_or_fmt::format_string<Args...> msg, Args&&... args)
+    {
+        return std_or_fmt::format(msg, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    std::string vformat(
+      std::conditional_t<sizeof...(Args) == 0, std::string_view, std_or_fmt::format_string<Args...>> msg,
+      Args&&... args)
+    {
+        return std_or_fmt::vformat(msg, std_or_fmt::make_format_args(args...));
+    }
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,8 +55,8 @@ target_link_libraries(quicr PRIVATE
     picohttp-core
 )
 
-if (NOT HAVE_STD_FORMAT)
-    target_link_libraries(quicr PUBLIC fmt::fmt-header-only)
+if (NOT HAS_STD_VFORMAT)
+    target_link_libraries(quicr PUBLIC fmt::fmt)
 endif()
 
 target_include_directories(quicr PUBLIC ${CMAKE_BINARY_DIR}/include ${PROJECT_SOURCE_DIR}/include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(quicr PRIVATE
     ctrl_message_types.cpp
     fetch_track_handler.cpp
     joining_fetch_handler.cpp
+    log.cpp
     messages.cpp
     publish_fetch_handler.cpp
     publish_namespace_handler.cpp
@@ -44,14 +45,20 @@ target_sources(quicr PRIVATE
 )
 
 target_link_libraries(quicr PUBLIC
-    spdlog::spdlog
     timeq
+)
+
+target_link_libraries(quicr PRIVATE
+    spdlog::spdlog
     picoquic-core
     picoquic-log
     picohttp-core
 )
 
-target_compile_definitions(quicr PRIVATE SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
+if (NOT HAVE_STD_FORMAT)
+    target_link_libraries(quicr PUBLIC fmt::fmt-header-only)
+endif()
+
 target_include_directories(quicr PUBLIC ${CMAKE_BINARY_DIR}/include ${PROJECT_SOURCE_DIR}/include)
 
 if(LINT)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,6 @@ target_link_libraries(quicr PUBLIC
 )
 
 target_link_libraries(quicr PRIVATE
-    spdlog::spdlog
     picoquic-core
     picoquic-log
     picohttp-core

--- a/src/fetch_track_handler.cpp
+++ b/src/fetch_track_handler.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "quicr/handlers/fetch_track_handler.h"
-#include "quicr/log.h"
+#include "quicr/utilities/format.h"
 
 namespace quicr {
     void FetchTrackHandler::TryParseStreamBufferData(StreamContext& stream)
@@ -34,31 +34,21 @@ namespace quicr {
                 continue;
             }
 
-            const auto resolved = serialization_state_.Decode(std::move(obj));
-            if (!resolved.has_value()) {
-                // TODO: We're being told this object doesn't exist, should we notify?
-                stream.buffer.ResetAnyB();
-                continue;
-            }
-
-            QUICR_TRACE("Received fetch_object priority: {} "
-                        "group_id: {} subgroup_id: {} object_id: {} data size: {}",
-                        *resolved->headers.priority,
-                        resolved->headers.group_id,
-                        resolved->headers.subgroup_id,
-                        resolved->headers.object_id,
-                        resolved->payload.size());
-
             subscribe_track_metrics_.objects_received++;
             subscribe_track_metrics_.bytes_received += resolved->payload.size();
 
+            std::exception_ptr error;
             try {
                 ObjectReceived(resolved->headers, resolved->payload);
             } catch (const std::exception& e) {
-                QUICR_ERROR("Caught exception trying to receive Fetch object. (error={})", e.what());
+                error = std::make_exception_ptr(e);
             }
 
             stream.buffer.ResetAnyB();
+
+            if (error) {
+                std::rethrow_exception(error);
+            }
         }
     }
 }

--- a/src/fetch_track_handler.cpp
+++ b/src/fetch_track_handler.cpp
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "quicr/handlers/fetch_track_handler.h"
-
-#include <spdlog/spdlog.h>
+#include "quicr/log.h"
 
 namespace quicr {
     void FetchTrackHandler::TryParseStreamBufferData(StreamContext& stream)
@@ -35,14 +34,14 @@ namespace quicr {
                 continue;
             }
 
-            SPDLOG_TRACE("Received fetch_object subscribe_id: {} priority: {} "
-                         "group_id: {} subgroup_id: {} object_id: {} data size: {}",
-                         *GetSubscribeId(),
-                         *resolved->headers.priority,
-                         resolved->headers.group_id,
-                         resolved->headers.subgroup_id,
-                         resolved->headers.object_id,
-                         resolved->payload.size());
+            QUICR_TRACE("Received fetch_object subscribe_id: {} priority: {} "
+                        "group_id: {} subgroup_id: {} object_id: {} data size: {}",
+                        *GetSubscribeId(),
+                        *resolved->headers.priority,
+                        resolved->headers.group_id,
+                        resolved->headers.subgroup_id,
+                        resolved->headers.object_id,
+                        resolved->payload.size());
 
             subscribe_track_metrics_.objects_received++;
             subscribe_track_metrics_.bytes_received += resolved->payload.size();
@@ -50,7 +49,7 @@ namespace quicr {
             try {
                 ObjectReceived(resolved->headers, resolved->payload);
             } catch (const std::exception& e) {
-                SPDLOG_ERROR("Caught exception trying to receive Fetch object. (error={})", e.what());
+                QUICR_ERROR("Caught exception trying to receive Fetch object. (error={})", e.what());
             }
 
             stream.buffer.ResetAnyB();

--- a/src/fetch_track_handler.cpp
+++ b/src/fetch_track_handler.cpp
@@ -34,9 +34,15 @@ namespace quicr {
                 continue;
             }
 
-            QUICR_TRACE("Received fetch_object subscribe_id: {} priority: {} "
+            const auto resolved = serialization_state_.Decode(std::move(obj));
+            if (!resolved.has_value()) {
+                // TODO: We're being told this object doesn't exist, should we notify?
+                stream.buffer.ResetAnyB();
+                continue;
+            }
+
+            QUICR_TRACE("Received fetch_object priority: {} "
                         "group_id: {} subgroup_id: {} object_id: {} data size: {}",
-                        *GetSubscribeId(),
                         *resolved->headers.priority,
                         resolved->headers.group_id,
                         resolved->headers.subgroup_id,

--- a/src/joining_fetch_handler.cpp
+++ b/src/joining_fetch_handler.cpp
@@ -33,9 +33,14 @@ namespace quicr {
                 continue;
             }
 
-            QUICR_TRACE("Received fetch_object subscribe_id: {} priority: {} "
+            const auto resolved = serialization_state_.Decode(std::move(obj));
+            if (!resolved.has_value()) {
+                stream.buffer.ResetAnyB();
+                continue;
+            }
+
+            QUICR_TRACE("Received fetch_object priority: {} "
                         "group_id: {} subgroup_id: {} object_id: {} data size: {}",
-                        *GetSubscribeId(),
                         *resolved->headers.priority,
                         resolved->headers.group_id,
                         resolved->headers.subgroup_id,

--- a/src/joining_fetch_handler.cpp
+++ b/src/joining_fetch_handler.cpp
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "quicr/handlers/joining_fetch_handler.h"
-
-#include <spdlog/spdlog.h>
+#include "quicr/log.h"
 
 namespace quicr {
     void JoiningFetchHandler::TryParseStreamBufferData(StreamContext& stream)
@@ -34,18 +33,18 @@ namespace quicr {
                 continue;
             }
 
-            SPDLOG_TRACE("Received fetch_object subscribe_id: {} priority: {} "
-                         "group_id: {} subgroup_id: {} object_id: {} data size: {}",
-                         *GetSubscribeId(),
-                         *resolved->headers.priority,
-                         resolved->headers.group_id,
-                         resolved->headers.subgroup_id,
-                         resolved->headers.object_id,
-                         resolved->payload.size());
+            QUICR_TRACE("Received fetch_object subscribe_id: {} priority: {} "
+                        "group_id: {} subgroup_id: {} object_id: {} data size: {}",
+                        *GetSubscribeId(),
+                        *resolved->headers.priority,
+                        resolved->headers.group_id,
+                        resolved->headers.subgroup_id,
+                        resolved->headers.object_id,
+                        resolved->payload.size());
             try {
                 joining_subscribe_->ObjectReceived(resolved->headers, resolved->payload);
             } catch (const std::exception& e) {
-                SPDLOG_ERROR("Caught exception trying to receive Joining Fetch object. (error={})", e.what());
+                QUICR_ERROR("Caught exception trying to receive Joining Fetch object. (error={})", e.what());
             }
 
             stream.buffer.ResetAnyB();

--- a/src/joining_fetch_handler.cpp
+++ b/src/joining_fetch_handler.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "quicr/handlers/joining_fetch_handler.h"
-#include "quicr/log.h"
+#include "quicr/utilities/format.h"
 
 namespace quicr {
     void JoiningFetchHandler::TryParseStreamBufferData(StreamContext& stream)
@@ -33,26 +33,18 @@ namespace quicr {
                 continue;
             }
 
-            const auto resolved = serialization_state_.Decode(std::move(obj));
-            if (!resolved.has_value()) {
-                stream.buffer.ResetAnyB();
-                continue;
-            }
-
-            QUICR_TRACE("Received fetch_object priority: {} "
-                        "group_id: {} subgroup_id: {} object_id: {} data size: {}",
-                        *resolved->headers.priority,
-                        resolved->headers.group_id,
-                        resolved->headers.subgroup_id,
-                        resolved->headers.object_id,
-                        resolved->payload.size());
+            std::exception_ptr error;
             try {
                 joining_subscribe_->ObjectReceived(resolved->headers, resolved->payload);
             } catch (const std::exception& e) {
-                QUICR_ERROR("Caught exception trying to receive Joining Fetch object. (error={})", e.what());
+                error = std::make_exception_ptr(e);
             }
 
             stream.buffer.ResetAnyB();
+
+            if (error) {
+                std::rethrow_exception(error);
+            }
         }
     }
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -19,10 +19,15 @@ namespace quicr {
         void SetLevel(Logger::Level max_level) { logger_->set_level(ConvertLevelType(max_level)); }
 
         void Log(Logger::Level level, std::string_view msg, std::source_location location)
-        {
+        try {
             logger_->log(spdlog::source_loc(location.file_name(), location.line(), location.function_name()),
                          ConvertLevelType(level),
                          msg);
+        } catch (const std::exception& e) {
+            logger_->log(spdlog::source_loc(location.file_name(), location.line(), location.function_name()),
+                         spdlog::level::err,
+                         "log failed to format (error={})",
+                         e.what());
         }
 
       private:

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,82 +1,8 @@
 #include "quicr/log.h"
 
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
-
 #include <memory>
 #include <string_view>
 
 namespace quicr {
-
-    class Logger::Impl
-    {
-      public:
-        Impl(const std::string& name)
-          : logger_(spdlog::get(name) ? spdlog::get(name) : spdlog::stderr_color_mt(name))
-        {
-        }
-
-        void SetLevel(Logger::Level max_level) { logger_->set_level(ConvertLevelType(max_level)); }
-
-        void Log(Logger::Level level, std::string_view msg, std::source_location location)
-        try {
-            logger_->log(spdlog::source_loc(location.file_name(), location.line(), location.function_name()),
-                         ConvertLevelType(level),
-                         msg);
-        } catch (const std::exception& e) {
-            logger_->log(spdlog::source_loc(location.file_name(), location.line(), location.function_name()),
-                         spdlog::level::err,
-                         "log failed to format (error={})",
-                         e.what());
-        }
-
-      private:
-        spdlog::level::level_enum ConvertLevelType(Logger::Level level)
-        {
-            switch (level) {
-                case Logger::Level::Trace:
-                    return spdlog::level::trace;
-                case Logger::Level::Debug:
-                    return spdlog::level::debug;
-                case Logger::Level::Info:
-                    return spdlog::level::info;
-                case Logger::Level::Warn:
-                    return spdlog::level::warn;
-                case Logger::Level::Error:
-                    return spdlog::level::err;
-                case Logger::Level::Critical:
-                    return spdlog::level::critical;
-            }
-        }
-
-      private:
-        std::shared_ptr<spdlog::logger> logger_;
-    };
-
-    Logger::Logger(std::string_view name)
-      : impl_(std::make_unique<Impl>(std::string(name)))
-    {
-    }
-
-    std::shared_ptr<Logger> Logger::Create(std::string_view name)
-    {
-        return std::shared_ptr<Logger>(new Logger(name));
-    }
-
-    std::shared_ptr<Logger> Logger::GetDefault()
-    {
-        static auto default_logger = Logger::Create("");
-        return default_logger;
-    }
-
-    void Logger::SetLevel(Level max_level)
-    {
-        impl_->SetLevel(max_level);
-    }
-
-    void Logger::Log(Level level, std::string_view msg, std::source_location location)
-    {
-        impl_->Log(level, msg, location);
-    }
 
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,0 +1,77 @@
+#include "quicr/log.h"
+
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+#include <memory>
+#include <string_view>
+
+namespace quicr {
+
+    class Logger::Impl
+    {
+      public:
+        Impl(const std::string& name)
+          : logger_(spdlog::get(name) ? spdlog::get(name) : spdlog::stderr_color_mt(name))
+        {
+        }
+
+        void SetLevel(Logger::Level max_level) { logger_->set_level(ConvertLevelType(max_level)); }
+
+        void Log(Logger::Level level, std::string_view msg, std::source_location location)
+        {
+            logger_->log(spdlog::source_loc(location.file_name(), location.line(), location.function_name()),
+                         ConvertLevelType(level),
+                         msg);
+        }
+
+      private:
+        spdlog::level::level_enum ConvertLevelType(Logger::Level level)
+        {
+            switch (level) {
+                case Logger::Level::Trace:
+                    return spdlog::level::trace;
+                case Logger::Level::Debug:
+                    return spdlog::level::debug;
+                case Logger::Level::Info:
+                    return spdlog::level::info;
+                case Logger::Level::Warn:
+                    return spdlog::level::warn;
+                case Logger::Level::Error:
+                    return spdlog::level::err;
+                case Logger::Level::Critical:
+                    return spdlog::level::critical;
+            }
+        }
+
+      private:
+        std::shared_ptr<spdlog::logger> logger_;
+    };
+
+    Logger::Logger(std::string_view name)
+      : impl_(std::make_unique<Impl>(std::string(name)))
+    {
+    }
+
+    std::shared_ptr<Logger> Logger::Create(std::string_view name)
+    {
+        return std::shared_ptr<Logger>(new Logger(name));
+    }
+
+    std::shared_ptr<Logger> Logger::GetDefault()
+    {
+        static auto default_logger = Logger::Create("");
+        return default_logger;
+    }
+
+    void Logger::SetLevel(Level max_level)
+    {
+        impl_->SetLevel(max_level);
+    }
+
+    void Logger::Log(Level level, std::string_view msg, std::source_location location)
+    {
+        impl_->Log(level, msg, location);
+    }
+
+}

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -4,5 +4,12 @@
 #include <string_view>
 
 namespace quicr {
-
+    bool Logger::ShouldLog(Level level) const noexcept
+    {
+#ifdef QUICR_ACTIVE_LOG_LEVEL
+        return static_cast<int>(level) >= QUICR_ACTIVE_LOG_LEVEL;
+#else
+        return true;
+#endif
+    }
 }

--- a/src/publish_namespace_handler.cpp
+++ b/src/publish_namespace_handler.cpp
@@ -26,44 +26,8 @@ quicr::PublishNamespaceHandler::~PublishNamespaceHandler()
 }
 
 void
-quicr::PublishNamespaceHandler::StatusChanged(Status status)
+quicr::PublishNamespaceHandler::StatusChanged(Status)
 {
-
-    auto th = quicr::TrackHash({ GetPrefix(), {} });
-
-    switch (status) {
-        case Status::kOk:
-            QUICR_INFO("Publication to namespace with hash: {} status changed to OK", th.track_namespace_hash);
-            break;
-        case Status::kNotConnected:
-            QUICR_WARN("Publication to namespace with hash: {} status changed to NOT_CONNECTED",
-                       th.track_namespace_hash);
-            break;
-        case Status::kNotPublished:
-            QUICR_WARN("Publication to namespace with hash: {} status changed to NOT_PUBLISHED",
-                       th.track_namespace_hash);
-            break;
-        case Status::kPendingResponse:
-            QUICR_INFO("Publication to namespace with hash: {} status changed to PENDING_RESPONSE",
-                       th.track_namespace_hash);
-            break;
-        case Status::kPublishNotAuthorized:
-            QUICR_ERROR("Publication to namespace with hash: {} status changed to PUBLISH_NOT_AUTHORIZED",
-                        th.track_namespace_hash);
-            break;
-        case Status::kSendingDone:
-            QUICR_INFO("Publication to namespace with hash: {} status changed to SENDING_DONE",
-                       th.track_namespace_hash);
-        case Status::kError:
-            if (error_ != std::nullopt) {
-                QUICR_ERROR("Publication to namespace with hash: {} status changed to ERROR: {}",
-                            th.track_namespace_hash,
-                            std::string(error_->second.begin(), error_->second.end()));
-            } else {
-                QUICR_ERROR("Publication to namespace with hash: {} status changed to unknown ERROR");
-            }
-            break;
-    }
 }
 
 void

--- a/src/publish_namespace_handler.cpp
+++ b/src/publish_namespace_handler.cpp
@@ -1,8 +1,7 @@
 #include "quicr/handlers/publish_namespace_handler.h"
+#include "quicr/log.h"
 #include "quicr/messages/parameters.h"
 #include "quicr/session.h"
-
-#include <spdlog/spdlog.h>
 
 #include <ranges>
 
@@ -34,34 +33,34 @@ quicr::PublishNamespaceHandler::StatusChanged(Status status)
 
     switch (status) {
         case Status::kOk:
-            SPDLOG_INFO("Publication to namespace with hash: {} status changed to OK", th.track_namespace_hash);
+            QUICR_INFO("Publication to namespace with hash: {} status changed to OK", th.track_namespace_hash);
             break;
         case Status::kNotConnected:
-            SPDLOG_WARN("Publication to namespace with hash: {} status changed to NOT_CONNECTED",
-                        th.track_namespace_hash);
+            QUICR_WARN("Publication to namespace with hash: {} status changed to NOT_CONNECTED",
+                       th.track_namespace_hash);
             break;
         case Status::kNotPublished:
-            SPDLOG_WARN("Publication to namespace with hash: {} status changed to NOT_PUBLISHED",
-                        th.track_namespace_hash);
+            QUICR_WARN("Publication to namespace with hash: {} status changed to NOT_PUBLISHED",
+                       th.track_namespace_hash);
             break;
         case Status::kPendingResponse:
-            SPDLOG_INFO("Publication to namespace with hash: {} status changed to PENDING_RESPONSE",
-                        th.track_namespace_hash);
+            QUICR_INFO("Publication to namespace with hash: {} status changed to PENDING_RESPONSE",
+                       th.track_namespace_hash);
             break;
         case Status::kPublishNotAuthorized:
-            SPDLOG_ERROR("Publication to namespace with hash: {} status changed to PUBLISH_NOT_AUTHORIZED",
-                         th.track_namespace_hash);
+            QUICR_ERROR("Publication to namespace with hash: {} status changed to PUBLISH_NOT_AUTHORIZED",
+                        th.track_namespace_hash);
             break;
         case Status::kSendingDone:
-            SPDLOG_INFO("Publication to namespace with hash: {} status changed to SENDING_DONE",
-                        th.track_namespace_hash);
+            QUICR_INFO("Publication to namespace with hash: {} status changed to SENDING_DONE",
+                       th.track_namespace_hash);
         case Status::kError:
             if (error_ != std::nullopt) {
-                SPDLOG_ERROR("Publication to namespace with hash: {} status changed to ERROR: {}",
-                             th.track_namespace_hash,
-                             std::string(error_->second.begin(), error_->second.end()));
+                QUICR_ERROR("Publication to namespace with hash: {} status changed to ERROR: {}",
+                            th.track_namespace_hash,
+                            std::string(error_->second.begin(), error_->second.end()));
             } else {
-                SPDLOG_ERROR("Publication to namespace with hash: {} status changed to unknown ERROR");
+                QUICR_ERROR("Publication to namespace with hash: {} status changed to unknown ERROR");
             }
             break;
     }

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -3,11 +3,10 @@
 
 #include "quicr/handlers/publish_track_handler.h"
 
+#include "quicr/log.h"
 #include "quicr/messages/messages.h"
 #include "quicr/messages/parameters.h"
 #include "quicr/session.h"
-
-#include <spdlog/spdlog.h>
 
 namespace quicr {
     PublishTrackHandler::PublishTrackHandler(const FullTrackName& full_track_name,
@@ -347,12 +346,12 @@ namespace quicr {
             }
         }
 
-        SPDLOG_TRACE("Published conn_id: {} object stream_id: {} group: {} subgroup: {} object: {}",
+        QUICR_TRACE("Published conn_id: {} object stream_id: {} group: {} subgroup: {} object: {}",
 
-                     subgroup_it->second.stream_id,
-                     object_headers.group_id,
-                     object_headers.subgroup_id,
-                     object_headers.object_id);
+                    subgroup_it->second.stream_id,
+                    object_headers.group_id,
+                    object_headers.subgroup_id,
+                    object_headers.object_id);
         auto result = transport->Enqueue(
 
           publish_data_ctx_id_,

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -3,7 +3,6 @@
 
 #include "quicr/handlers/publish_track_handler.h"
 
-#include "quicr/log.h"
 #include "quicr/messages/messages.h"
 #include "quicr/messages/parameters.h"
 #include "quicr/session.h"
@@ -346,12 +345,6 @@ namespace quicr {
             }
         }
 
-        QUICR_TRACE("Published conn_id: {} object stream_id: {} group: {} subgroup: {} object: {}",
-                    session->GetConnection()->GetID(),
-                    stream_id,
-                    object_headers.group_id,
-                    object_headers.subgroup_id,
-                    object_headers.object_id);
         auto result = session->Enqueue(
 
           publish_data_ctx_id_,

--- a/src/publish_track_handler.cpp
+++ b/src/publish_track_handler.cpp
@@ -47,10 +47,10 @@ namespace quicr {
       uint64_t subgroup_id,
       std::shared_ptr<const std::vector<uint8_t>> data)
     {
-        auto transport = GetSession().lock();
+        auto session = GetSession().lock();
         uint64_t stream_id{ 0 };
 
-        if (!transport) {
+        if (!session) {
             return PublishObjectStatus::kInternalError;
         }
 
@@ -127,7 +127,7 @@ namespace quicr {
                     // first object parsed
 #if 0
                     auto stream_id =
-                      transport->CreateStream(publish_data_ctx_id_, GetDefaultPriority());
+                      session->CreateStream(publish_data_ctx_id_, GetDefaultPriority());
                     stream_info_by_group_[group_id][subgroup_id] = { stream_id, group_id, subgroup_id };
 #endif
 
@@ -150,7 +150,7 @@ namespace quicr {
         }
 
         auto result =
-          transport->Enqueue(publish_data_ctx_id_, stream_id, data, default_priority_, default_ttl_, 0, eflags);
+          session->Enqueue(publish_data_ctx_id_, stream_id, data, default_priority_, default_ttl_, 0, eflags);
 
         if (result != TransportError::kNone) {
             throw TransportException(result);
@@ -164,9 +164,9 @@ namespace quicr {
       BytesSpan data,
       std::optional<messages::StreamHeaderProperties> stream_mode)
     {
-        auto transport = GetSession().lock();
+        auto session = GetSession().lock();
 
-        if (!transport) {
+        if (!session) {
             return PublishObjectStatus::kInternalError;
         }
 
@@ -255,7 +255,7 @@ namespace quicr {
             subgroup_it = group_it->second.find(object_headers.subgroup_id);
             if (subgroup_it == group_it->second.end()) {
                 is_stream_header_needed = true;
-                stream_id = transport->CreateStream(publish_data_ctx_id_, priority);
+                stream_id = session->CreateStream(publish_data_ctx_id_, priority);
 
                 auto& subgroup_map = stream_info_by_group_[object_headers.group_id];
                 auto [it, _] =
@@ -347,12 +347,12 @@ namespace quicr {
         }
 
         QUICR_TRACE("Published conn_id: {} object stream_id: {} group: {} subgroup: {} object: {}",
-
-                    subgroup_it->second.stream_id,
+                    session->GetConnection()->GetID(),
+                    stream_id,
                     object_headers.group_id,
                     object_headers.subgroup_id,
                     object_headers.object_id);
-        auto result = transport->Enqueue(
+        auto result = session->Enqueue(
 
           publish_data_ctx_id_,
           stream_id,
@@ -371,9 +371,9 @@ namespace quicr {
 
     void PublishTrackHandler::EndSubgroup(uint64_t group_id, uint64_t subgroup_id, bool completed)
     {
-        auto transport = GetSession().lock();
+        auto session = GetSession().lock();
 
-        if (!transport) {
+        if (!session) {
             return;
         }
 
@@ -394,7 +394,7 @@ namespace quicr {
         eflags.close_stream = true;
         eflags.use_reset = !completed;
 
-        transport->Enqueue(
+        session->Enqueue(
           publish_data_ctx_id_, subgroup_it->second.stream_id, {}, default_priority_, default_ttl_, 0, eflags);
 
         group_it->second.erase(subgroup_it);
@@ -459,8 +459,8 @@ namespace quicr {
             SetStatus(Status::kNewGroupRequested);
         }
 
-        if (const auto transport = GetSession().lock()) {
-            transport->ResolveRequestUpdate(*GetRequestId(), { .error = std::nullopt, .params = {} });
+        if (const auto session = GetSession().lock()) {
+            session->ResolveRequestUpdate(*GetRequestId(), { .error = std::nullopt, .params = {} });
         }
     }
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1923,7 +1923,12 @@ namespace quicr {
 
         rx_ctx.is_new = false;
         rx_ctx.caller_any = std::make_any<std::weak_ptr<SubscribeTrackHandler>>(sub_it->second);
-        sub_it->second->StreamDataRecv(stream_id, std::move(initial_buffer));
+        try {
+            sub_it->second->StreamDataRecv(stream_id, std::move(initial_buffer));
+        } catch (const std::exception& e) {
+            QUICR_LOGGER_ERROR(
+              logger_, "Encountered an error while receiving stream data (stream={}, error={})", stream_id, e.what());
+        }
         return true;
     }
 
@@ -1952,7 +1957,14 @@ namespace quicr {
 
             rx_ctx.is_new = false;
             rx_ctx.caller_any = std::make_any<std::weak_ptr<SubscribeTrackHandler>>(h);
-            h->StreamDataRecv(stream_id, std::move(initial_buffer));
+            try {
+                h->StreamDataRecv(stream_id, std::move(initial_buffer));
+            } catch (const std::exception& e) {
+                QUICR_LOGGER_ERROR(logger_,
+                                   "Encountered an error while receiving stream data (stream={}, error={})",
+                                   stream_id,
+                                   e.what());
+            }
             return true;
         }
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -211,13 +211,14 @@ namespace quicr {
                      std::shared_ptr<Transport> transport,
                      std::shared_ptr<Connection> connection,
                      std::shared_ptr<ClientCallbacks> callbacks,
-                     std::shared_ptr<timeq::tick_service> tick_service)
+                     std::shared_ptr<timeq::tick_service> tick_service,
+                     std::shared_ptr<Logger> logger)
       : std::enable_shared_from_this<Session>()
       , current_connection_(std::move(connection))
       , callbacks_(std::move(callbacks))
       , next_request_id_(0)
       , client_mode_(true)
-      , logger_(Logger::Create("QUICR_CLIENT"))
+      , logger_(std::move(logger))
       , server_config_({})
       , client_config_(cfg)
       , tick_service_(std::move(tick_service))
@@ -231,13 +232,14 @@ namespace quicr {
                      std::shared_ptr<Transport> transport,
                      std::shared_ptr<Connection> connection,
                      std::shared_ptr<ServerCallbacks> callbacks,
-                     std::shared_ptr<timeq::tick_service> tick_service)
+                     std::shared_ptr<timeq::tick_service> tick_service,
+                     std::shared_ptr<Logger> logger)
       : std::enable_shared_from_this<Session>()
       , current_connection_(std::move(connection))
       , callbacks_(std::move(callbacks))
       , next_request_id_(1)
       , client_mode_(false)
-      , logger_(Logger::Create("QUICR_SERVER"))
+      , logger_(std::move(logger))
       , server_config_(cfg)
       , client_config_({})
       , tick_service_(std::move(tick_service))
@@ -259,13 +261,17 @@ namespace quicr {
             // client init items
 
             if (client_config_.transport_config.debug) {
-                logger_->SetLevel(Logger::Level::Debug);
+                if (logger_) {
+                    logger_->SetLevel(Logger::Level::Debug);
+                }
             }
         } else {
             // Server init items
 
             if (server_config_.transport_config.debug) {
-                logger_->SetLevel(Logger::Level::Debug);
+                if (logger_) {
+                    logger_->SetLevel(Logger::Level::Debug);
+                }
             }
         }
 
@@ -1067,13 +1073,13 @@ namespace quicr {
                       }
 
                       const auto& [code, reason] = result.error();
-                      SPDLOG_LOGGER_ERROR(self->logger_,
-                                          "Publish namespace done failed conn_id: {} request_id: {} code: {} "
-                                          "reason: {}",
-                                          self->current_connection_->GetID(),
-                                          request_id,
-                                          static_cast<std::uint64_t>(code),
-                                          reason.value_or("unknown"));
+                      QUICR_LOGGER_ERROR(self->logger_,
+                                         "Publish namespace done failed conn_id: {} request_id: {} code: {} "
+                                         "reason: {}",
+                                         self->current_connection_->GetID(),
+                                         request_id,
+                                         static_cast<std::uint64_t>(code),
+                                         reason.value_or("unknown"));
                   });
             }
             return;
@@ -1123,13 +1129,13 @@ namespace quicr {
                       }
 
                       const auto& [code, reason] = result.error();
-                      SPDLOG_LOGGER_ERROR(self->logger_,
-                                          "Unsubscribe of subscribe track failed conn_id: {} request_id: {} code: {} "
-                                          "reason: {}",
-                                          self->current_connection_->GetID(),
-                                          request_id,
-                                          code,
-                                          reason.value_or("unknown"));
+                      QUICR_LOGGER_ERROR(self->logger_,
+                                         "Unsubscribe of subscribe track failed conn_id: {} request_id: {} code: {} "
+                                         "reason: {}",
+                                         self->current_connection_->GetID(),
+                                         request_id,
+                                         code,
+                                         reason.value_or("unknown"));
                   });
             }
 
@@ -1150,13 +1156,13 @@ namespace quicr {
                       }
 
                       const auto& [code, reason] = result.error();
-                      SPDLOG_LOGGER_ERROR(self->logger_,
-                                          "Unsubscribe of publish track failed conn_id: {} request_id: {} code: {} "
-                                          "reason: {}",
-                                          self->current_connection_->GetID(),
-                                          request_id,
-                                          code,
-                                          reason.value_or("unknown"));
+                      QUICR_LOGGER_ERROR(self->logger_,
+                                         "Unsubscribe of publish track failed conn_id: {} request_id: {} code: {} "
+                                         "reason: {}",
+                                         self->current_connection_->GetID(),
+                                         request_id,
+                                         code,
+                                         reason.value_or("unknown"));
                   });
             }
 
@@ -1909,7 +1915,7 @@ namespace quicr {
 
         const auto stream_it = stream_buffers.find(stream_id);
         if (stream_it == stream_buffers.end()) {
-            SPDLOG_LOGGER_ERROR(logger_, "Missing expected pending stream buffer");
+            QUICR_LOGGER_ERROR(logger_, "Missing expected pending stream buffer");
             return false;
         }
         auto initial_buffer = std::move(stream_it->second);
@@ -1938,7 +1944,7 @@ namespace quicr {
         if (auto h = fetch_it->second->Get<SubscribeTrackHandler>()) {
             const auto stream_it = stream_buffers.find(stream_id);
             if (stream_it == stream_buffers.end()) {
-                SPDLOG_LOGGER_ERROR(logger_, "Missing expected pending stream buffer");
+                QUICR_LOGGER_ERROR(logger_, "Missing expected pending stream buffer");
                 return false;
             }
             auto initial_buffer = std::move(stream_it->second);
@@ -2008,7 +2014,11 @@ namespace quicr {
 
                 auto handler = static_cast<SubscribeTrackHandler*>(sub_it->second.get());
 
-                handler->DgramDataRecv(data);
+                try {
+                    handler->DgramDataRecv(data);
+                } catch (const std::exception& e) {
+                    QUICR_LOGGER_ERROR(logger_, "Caught exception in ObjectStatusReceived. (error={})", e.what());
+                }
             } else if (data) {
                 current_connection_->metrics.rx_dgram_decode_failed++;
 
@@ -2115,10 +2125,10 @@ namespace quicr {
     {
         const auto request_it = recv_req_id.find(request_id);
         if (request_it == recv_req_id.end() || request_it->second.data_ctx_id == 0) {
-            SPDLOG_LOGGER_ERROR(logger_,
-                                "Cannot resolve FETCH without its request stream conn_id: {} request_id: {}",
-                                current_connection_->GetID(),
-                                request_id);
+            QUICR_LOGGER_ERROR(logger_,
+                               "Cannot resolve FETCH without its request stream conn_id: {} request_id: {}",
+                               current_connection_->GetID(),
+                               request_id);
             return;
         }
         const auto data_ctx_id = request_it->second.data_ctx_id;
@@ -2338,11 +2348,11 @@ namespace quicr {
                               }
 
                               const auto& [code, reason] = result.error();
-                              SPDLOG_LOGGER_ERROR(self->logger_,
-                                                  "Server setup rejected conn_id: {} code: {} reason: {}",
-                                                  self->current_connection_->GetID(),
-                                                  code,
-                                                  reason.value_or("unknown"));
+                              QUICR_LOGGER_ERROR(self->logger_,
+                                                 "Server setup rejected conn_id: {} code: {} reason: {}",
+                                                 self->current_connection_->GetID(),
+                                                 code,
+                                                 reason.value_or("unknown"));
                           });
                     }
                 } else {
@@ -2351,12 +2361,12 @@ namespace quicr {
                           .Resolve([self = GetSharedPtr()](const auto& result) {
                               if (!result) {
                                   const auto& [code, reason] = result.error();
-                                  SPDLOG_LOGGER_ERROR(self->logger_,
-                                                      "Client setup rejected, not sending SETUP conn_id: {} code: {} "
-                                                      "reason: {}",
-                                                      self->current_connection_->GetID(),
-                                                      code,
-                                                      reason.value_or("unknown"));
+                                  QUICR_LOGGER_ERROR(self->logger_,
+                                                     "Client setup rejected, not sending SETUP conn_id: {} code: {} "
+                                                     "reason: {}",
+                                                     self->current_connection_->GetID(),
+                                                     code,
+                                                     reason.value_or("unknown"));
                                   return;
                               }
 
@@ -2496,12 +2506,12 @@ namespace quicr {
                               // Save the latest state for joining fetch.
                               auto req_it = self->recv_req_id.find(request_id);
                               if (req_it == self->recv_req_id.end()) {
-                                  SPDLOG_LOGGER_WARN(self->logger_,
-                                                     "Resolve subscribe has no request_id: {} conn_id: {} "
-                                                     "track_alias: {}",
-                                                     request_id,
-                                                     self->current_connection_->GetID(),
-                                                     th.track_fullname_hash);
+                                  QUICR_LOGGER_WARN(self->logger_,
+                                                    "Resolve subscribe has no request_id: {} conn_id: {} "
+                                                    "track_alias: {}",
+                                                    request_id,
+                                                    self->current_connection_->GetID(),
+                                                    th.track_fullname_hash);
                                   return;
                               }
 
@@ -2528,13 +2538,13 @@ namespace quicr {
                                 }
 
                                 const auto& [code, reason] = new_group_result.error();
-                                SPDLOG_LOGGER_ERROR(self->logger_,
-                                                    "New group request on subscribe failed request_id: {} group_id: {} "
-                                                    "code: {} reason: {}",
-                                                    request_id,
-                                                    *new_group_request_id,
-                                                    code,
-                                                    reason.value_or("unknown"));
+                                QUICR_LOGGER_ERROR(self->logger_,
+                                                   "New group request on subscribe failed request_id: {} group_id: {} "
+                                                   "code: {} reason: {}",
+                                                   request_id,
+                                                   *new_group_request_id,
+                                                   code,
+                                                   reason.value_or("unknown"));
                             });
                       });
                 }
@@ -2544,10 +2554,10 @@ namespace quicr {
             case messages::ControlMessageType::kSubscribeOk: {
                 const auto request_it = request_id_by_data_ctx.find(data_ctx_id);
                 if (request_it == request_id_by_data_ctx.end()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received SUBSCRIBE_OK for unknown request conn_id: {} data_ctx_id: {}, ignored",
-                                       current_connection_->GetID(),
-                                       data_ctx_id);
+                    QUICR_LOGGER_WARN(logger_,
+                                      "Received SUBSCRIBE_OK for unknown request conn_id: {} data_ctx_id: {}, ignored",
+                                      current_connection_->GetID(),
+                                      data_ctx_id);
                     return true;
                 }
                 const auto request_id = request_it->second;
@@ -2741,10 +2751,9 @@ namespace quicr {
 
                           const auto sub_data_ctx_id = self->FindSubscribeNamespaceDataContext(track_namespace);
                           if (!sub_data_ctx_id.has_value()) {
-                              SPDLOG_LOGGER_WARN(
-                                self->logger_,
-                                "No subscribe namespace data context for publish namespace conn_id: {}",
-                                self->current_connection_->GetID());
+                              QUICR_LOGGER_WARN(self->logger_,
+                                                "No subscribe namespace data context for publish namespace conn_id: {}",
+                                                self->current_connection_->GetID());
                               return;
                           }
 
@@ -2813,7 +2822,7 @@ namespace quicr {
                         for (const auto& name_space : result.value()) {
                             const auto match = track_namespace_prefix.IsPrefixOf(name_space);
                             if (match == std::partial_ordering::unordered || match == std::partial_ordering::less) {
-                                SPDLOG_LOGGER_WARN(self->logger_, "Dropping non prefix match");
+                                QUICR_LOGGER_WARN(self->logger_, "Dropping non prefix match");
                                 continue;
                             }
 
@@ -2841,11 +2850,11 @@ namespace quicr {
                           }
 
                           const auto& [code, reason] = result.error();
-                          SPDLOG_LOGGER_ERROR(self->logger_,
-                                              "Unsubscribe namespace failed conn_id: {} code: {} reason: {}",
-                                              self->current_connection_->GetID(),
-                                              code,
-                                              reason.value_or("unknown"));
+                          QUICR_LOGGER_ERROR(self->logger_,
+                                             "Unsubscribe namespace failed conn_id: {} code: {} reason: {}",
+                                             self->current_connection_->GetID(),
+                                             code,
+                                             reason.value_or("unknown"));
                       });
                 }
                 return true;
@@ -2895,12 +2904,12 @@ namespace quicr {
                               }
 
                               const auto& [code, reason] = result.error();
-                              SPDLOG_LOGGER_ERROR(self->logger_,
-                                                  "Publish done failed conn_id: {} request_id: {} code: {} reason: {}",
-                                                  self->current_connection_->GetID(),
-                                                  request_id,
-                                                  code,
-                                                  reason.value_or("unknown"));
+                              QUICR_LOGGER_ERROR(self->logger_,
+                                                 "Publish done failed conn_id: {} request_id: {} code: {} reason: {}",
+                                                 self->current_connection_->GetID(),
+                                                 request_id,
+                                                 code,
+                                                 reason.value_or("unknown"));
                           });
                     }
                 }
@@ -2923,10 +2932,10 @@ namespace quicr {
 
                 const auto request_it = request_id_by_data_ctx.find(data_ctx_id);
                 if (request_it == request_id_by_data_ctx.end()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received FETCH_OK for unknown request conn_id: {} data_ctx_id: {}, ignored",
-                                       current_connection_->GetID(),
-                                       data_ctx_id);
+                    QUICR_LOGGER_WARN(logger_,
+                                      "Received FETCH_OK for unknown request conn_id: {} data_ctx_id: {}, ignored",
+                                      current_connection_->GetID(),
+                                      data_ctx_id);
                     return true;
                 }
                 const auto request_id = request_it->second;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -5,6 +5,7 @@
 #include "quicr/connection.h"
 #include "quicr/handlers/joining_fetch_handler.h"
 #include "quicr/handlers/subscribe_namespace_handler.h"
+#include "quicr/log.h"
 #include "quicr/messages/ctrl_message_types.h"
 #include "quicr/messages/message.h"
 #include "quicr/messages/messages.h"
@@ -12,9 +13,6 @@
 #include "quicr/session_callbacks.h"
 #include "track_properties.h"
 #include "transport_picoquic.h"
-
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
 
 #include <iomanip>
 #include <memory>
@@ -30,14 +28,6 @@ namespace quicr {
     constexpr int kReadLoopMaxPerStream = 100; ///< Support packet/frame bursts, but do not allow starving other streams
 
     namespace {
-        std::shared_ptr<spdlog::logger> SafeLoggerGet(const std::string& name)
-        {
-            if (auto logger = spdlog::get(name)) {
-                return logger;
-            }
-
-            return spdlog::stderr_color_mt(name);
-        }
 
         /**
          * @brief Try to decode a uintvar from the front of a span, advancing past it on success.
@@ -227,13 +217,13 @@ namespace quicr {
       , callbacks_(std::move(callbacks))
       , next_request_id_(0)
       , client_mode_(true)
-      , logger_(SafeLoggerGet("QUICR_CLIENT"))
+      , logger_(Logger::Create("QUICR_CLIENT"))
       , server_config_({})
       , client_config_(cfg)
       , tick_service_(std::move(tick_service))
       , quic_transport_(std::move(transport))
     {
-        SPDLOG_LOGGER_TRACE(logger_, "Created MoQ Session in client mode connected to {}", cfg.connect_uri);
+        QUICR_LOGGER_TRACE(logger_, "Created MoQ Session in client mode connected to {}", cfg.connect_uri);
         Init();
     }
 
@@ -247,7 +237,7 @@ namespace quicr {
       , callbacks_(std::move(callbacks))
       , next_request_id_(1)
       , client_mode_(false)
-      , logger_(SafeLoggerGet("QUICR_SERVER"))
+      , logger_(Logger::Create("QUICR_SERVER"))
       , server_config_(cfg)
       , client_config_({})
       , tick_service_(std::move(tick_service))
@@ -256,15 +246,12 @@ namespace quicr {
         tx_ctrl_data_ctx_id_ = quic_transport_->CreateDataContext(current_connection_, true, 0, false);
         tx_ctrl_stream_id_ = quic_transport_->CreateStream(current_connection_, tx_ctrl_data_ctx_id_.value(), 0);
 
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger_, "Created MoQ Session in server mode listening on {}:{}", cfg.server_bind_ip, cfg.server_port);
         Init();
     }
 
-    Session::~Session()
-    {
-        spdlog::drop(logger_->name());
-    }
+    Session::~Session() {}
 
     void Session::Init()
     {
@@ -272,13 +259,13 @@ namespace quicr {
             // client init items
 
             if (client_config_.transport_config.debug) {
-                logger_->set_level(spdlog::level::debug);
+                logger_->SetLevel(Logger::Level::Debug);
             }
         } else {
             // Server init items
 
             if (server_config_.transport_config.debug) {
-                logger_->set_level(spdlog::level::debug);
+                logger_->SetLevel(Logger::Level::Debug);
             }
         }
 
@@ -327,7 +314,7 @@ namespace quicr {
 
     void Session::SendSetup()
     try {
-        SPDLOG_LOGGER_DEBUG(logger_, "Sending SETUP to conn_id: {}", current_connection_->GetID());
+        QUICR_LOGGER_DEBUG(logger_, "Sending SETUP to conn_id: {}", current_connection_->GetID());
 
         KeyValuePairs setup_options;
 
@@ -348,7 +335,7 @@ namespace quicr {
         }
         SendCtrlMsg(tx_ctrl_data_ctx_id_.value(), ControlMessageType::kSetup, setup_options);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Setup (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending Setup (error={})", e.what());
         throw e;
     }
 
@@ -379,14 +366,14 @@ namespace quicr {
                                 const messages::Parameters& params,
                                 const TrackExtensions& track_properties)
     try {
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending REQUEST_OK to conn_id: {} request_id: {}",
-                            current_connection_->GetID(),
-                            request_id_by_data_ctx.at(data_ctx_id));
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Sending REQUEST_OK to conn_id: {} request_id: {}",
+                           current_connection_->GetID(),
+                           request_id_by_data_ctx.at(data_ctx_id));
 
         SendCtrlMsg(data_ctx_id, ControlMessageType::kRequestOk, params, track_properties);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending REQUEST_OK (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending REQUEST_OK (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -401,19 +388,19 @@ namespace quicr {
                         .Add(ParameterType::kForward, forward)
                         .AddOptional(ParameterType::kNewGroupRequest, end_group_id);
 
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending REQUEST_UPDATE to conn_id: {} request_id: {} track namespace hash: {} name "
-                            "hash: {} forward: {} ngr: {}",
-                            current_connection_->GetID(),
-                            GetNextRequestID(),
-                            th.track_namespace_hash,
-                            th.track_name_hash,
-                            forward,
-                            end_group_id.has_value());
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Sending REQUEST_UPDATE to conn_id: {} request_id: {} track namespace hash: {} name "
+                           "hash: {} forward: {} ngr: {}",
+                           current_connection_->GetID(),
+                           GetNextRequestID(),
+                           th.track_namespace_hash,
+                           th.track_name_hash,
+                           forward,
+                           end_group_id.has_value());
 
         SendCtrlMsg(data_ctx_id, ControlMessageType::kRequestUpdate, UintVar(GetNextRequestID()), params);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending REQUEST_UPDATE (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending REQUEST_UPDATE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -423,17 +410,17 @@ namespace quicr {
                                    std::chrono::milliseconds retry_interval,
                                    const std::string& reason)
     try {
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending REQUEST_ERROR to conn_id: {} request_id: {} error code: {} reason: {}",
-                            current_connection_->GetID(),
-                            request_id,
-                            static_cast<int>(error),
-                            reason);
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Sending REQUEST_ERROR to conn_id: {} request_id: {} error code: {} reason: {}",
+                           current_connection_->GetID(),
+                           request_id,
+                           static_cast<int>(error),
+                           reason);
 
         SendCtrlMsg(
           data_ctx_id, ControlMessageType::kRequestError, error, UintVar(retry_interval.count()), AsOwnedBytes(reason));
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending REQUEST_ERROR (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending REQUEST_ERROR (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -441,22 +428,22 @@ namespace quicr {
                                        std::uint64_t request_id,
                                        const TrackNamespace& track_namespace)
     try {
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending PublishNamespace to conn_id: {} request_id: {} namespace_hash: {}",
-                            current_connection_->GetID(),
-                            request_id,
-                            TrackHash({ track_namespace, {} }).track_namespace_hash);
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Sending PublishNamespace to conn_id: {} request_id: {} namespace_hash: {}",
+                           current_connection_->GetID(),
+                           request_id,
+                           TrackHash({ track_namespace, {} }).track_namespace_hash);
 
         SendCtrlMsg(
           data_ctx_id, ControlMessageType::kPublishNamespace, UintVar(request_id), track_namespace, Parameters{});
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending PublishNamespace (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending PublishNamespace (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
     void Session::SendTrackStatus(std::uint64_t request_id, const FullTrackName& tfn)
     try {
-        SPDLOG_LOGGER_DEBUG(
+        QUICR_LOGGER_DEBUG(
           logger_, "Sending TRACK_STATUS to conn_id: {} request_id: {}", current_connection_->GetID(), request_id);
 
         SendCtrlMsg(tx_ctrl_data_ctx_id_.value(),
@@ -465,7 +452,7 @@ namespace quicr {
                     tfn.name_space,
                     tfn.name);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Trac (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending Trac (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -499,16 +486,16 @@ namespace quicr {
             params.Add(filter_type, filter);
         }
 
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending SUBSCRIBE to conn_id: {} request_id: {} track namespace hash: {} name hash: {}",
-                            current_connection_->GetID(),
-                            request_id,
-                            th.track_namespace_hash,
-                            th.track_name_hash);
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Sending SUBSCRIBE to conn_id: {} request_id: {} track namespace hash: {} name hash: {}",
+                           current_connection_->GetID(),
+                           request_id,
+                           th.track_namespace_hash,
+                           th.track_name_hash);
 
         SendCtrlMsg(data_ctx_id, ControlMessageType::kSubscribe, UintVar(request_id), tfn.name_space, tfn.name, params);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Subscribe (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending Subscribe (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -532,11 +519,11 @@ namespace quicr {
                             .Add(ExtensionType::kDefaultPublisherPriority, publish.default_publisher_priority)
                             .Add(ExtensionType::kDynamicGroups, publish.dynamic_groups);
 
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending PUBLISH to conn_id: {} request_id: {} track alias: {}",
-                            current_connection_->GetID(),
-                            request_id,
-                            publish.track_alias);
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Sending PUBLISH to conn_id: {} request_id: {} track alias: {}",
+                           current_connection_->GetID(),
+                           request_id,
+                           publish.track_alias);
 
         SendCtrlMsg(data_ctx_id,
                     ControlMessageType::kPublish,
@@ -547,7 +534,7 @@ namespace quicr {
                     params,
                     extensions);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Publish (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending Publish (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -577,7 +564,7 @@ namespace quicr {
 
         SendRequestOk(data_ctx_id, params);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Publish Ok (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending Publish Ok (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -599,12 +586,12 @@ namespace quicr {
                             .Add(ExtensionType::kDefaultPublisherPriority, 1)
                             .Add(ExtensionType::kDynamicGroups, true);
 
-        SPDLOG_LOGGER_DEBUG(
+        QUICR_LOGGER_DEBUG(
           logger_, "Sending SUBSCRIBE OK to conn_id: {} request_id: {}", current_connection_->GetID(), request_id);
 
         SendCtrlMsg(data_ctx_id, ControlMessageType::kSubscribeOk, UintVar(track_alias), params, extensions);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending SubscribeOk (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending SubscribeOk (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -613,16 +600,16 @@ namespace quicr {
                                   messages::PublishDoneStatusCode status,
                                   const std::string& reason)
     try {
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending PUBLISH_DONE to conn_id: {} request_id: {} status: {}",
-                            current_connection_->GetID(),
-                            request_id,
-                            static_cast<uint64_t>(status));
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Sending PUBLISH_DONE to conn_id: {} request_id: {} status: {}",
+                           current_connection_->GetID(),
+                           request_id,
+                           static_cast<uint64_t>(status));
 
         SendCtrlMsg(
           data_ctx_id, ControlMessageType::kPublishDone, UintVar(request_id), status, UintVar(0), AsOwnedBytes(reason));
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending PUBLISH_DONE (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending PUBLISH_DONE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -642,16 +629,16 @@ namespace quicr {
 
         [[maybe_unused]] auto th = TrackHash({ prefix, {} });
 
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending {} to conn_id: {} request_id: {} prefix_hash: {}",
-                            log_name,
-                            current_connection_->GetID(),
-                            request_id,
-                            th.track_namespace_hash);
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Sending {} to conn_id: {} request_id: {} prefix_hash: {}",
+                           log_name,
+                           current_connection_->GetID(),
+                           request_id,
+                           th.track_namespace_hash);
 
         SendCtrlMsg(data_ctx_id, type, UintVar(request_id), prefix, params);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending subscribe namespace (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending subscribe namespace (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -659,14 +646,14 @@ namespace quicr {
     try {
         [[maybe_unused]] auto th = TrackHash({ prefix, {} });
 
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Sending UNSUBSCRIBE_NAMESPACE to conn_id: {} prefix_hash: {}",
-                            current_connection_->GetID(),
-                            th.track_namespace_hash);
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Sending UNSUBSCRIBE_NAMESPACE to conn_id: {} prefix_hash: {}",
+                           current_connection_->GetID(),
+                           th.track_namespace_hash);
 
         SendCtrlMsg(data_ctx_id, ControlMessageType::kNamespaceDone, prefix);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending UNSUBSCRIBE_NAMESPACE (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending UNSUBSCRIBE_NAMESPACE (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -677,12 +664,11 @@ namespace quicr {
 
         [[maybe_unused]] auto th = TrackHash({ prefix, {} });
 
-        SPDLOG_LOGGER_INFO(logger_,
-                           "Subscribe namespace conn_id: {} prefix_hash: {} mode: {}",
-                           current_connection_->GetID(),
-                           th.track_namespace_hash,
-                           handler->GetMode() == SubscribeNamespaceHandler::Mode::kNamespaces ? "namespaces"
-                                                                                              : "tracks");
+        QUICR_LOGGER_INFO(logger_,
+                          "Subscribe namespace conn_id: {} prefix_hash: {} mode: {}",
+                          current_connection_->GetID(),
+                          th.track_namespace_hash,
+                          handler->GetMode() == SubscribeNamespaceHandler::Mode::kNamespaces ? "namespaces" : "tracks");
 
         std::lock_guard<std::mutex> lock(state_mutex_);
 
@@ -690,7 +676,7 @@ namespace quicr {
         handler->SetTransport(GetSharedPtr());
 
         if (auto [_, is_new] = request_handlers.try_emplace(handler->GetRequestId().value(), handler); !is_new) {
-            SPDLOG_LOGGER_WARN(logger_, "Namespace already subscribed to (prefix_hash={})", th.track_namespace_hash);
+            QUICR_LOGGER_WARN(logger_, "Namespace already subscribed to (prefix_hash={})", th.track_namespace_hash);
             return;
         }
 
@@ -715,10 +701,10 @@ namespace quicr {
         const auto& prefix = handler->GetPrefix();
         [[maybe_unused]] auto th = TrackHash({ prefix, {} });
 
-        SPDLOG_LOGGER_INFO(logger_,
-                           "Unsubscribe namespace conn_id: {} prefix_hash: {}",
-                           current_connection_->GetID(),
-                           th.track_namespace_hash);
+        QUICR_LOGGER_INFO(logger_,
+                          "Unsubscribe namespace conn_id: {} prefix_hash: {}",
+                          current_connection_->GetID(),
+                          th.track_namespace_hash);
 
         std::lock_guard<std::mutex> lock(state_mutex_);
 
@@ -757,7 +743,7 @@ namespace quicr {
                     wire_end_location,
                     params);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending Fetch (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending Fetch (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -786,7 +772,7 @@ namespace quicr {
                     joining_start,
                     params);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending JoiningFetch (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending JoiningFetch (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -807,7 +793,7 @@ namespace quicr {
 
         SendCtrlMsg(data_ctx_id, ControlMessageType::kFetchOk, end_of_track, largest_location, params, extensions);
     } catch (const std::exception& e) {
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception sending FetchOk (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception sending FetchOk (error={})", e.what());
         // TODO: add error handling in libquicr in calling function
     }
 
@@ -826,7 +812,7 @@ namespace quicr {
             th.track_fullname_hash = proposed_track_alias.value();
         }
 
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger_, "Subscribe track conn_id: {} track_alias: {}", current_connection_->GetID(), th.track_fullname_hash);
 
         std::lock_guard<std::mutex> _(state_mutex_);
@@ -862,10 +848,10 @@ namespace quicr {
         if (!track_handler->IsPublisherInitiated()) {
             if (auto [_, is_new] = request_handlers.try_emplace(*track_handler->GetRequestId(), track_handler);
                 !is_new) {
-                SPDLOG_LOGGER_WARN(logger_,
-                                   "Track already subscribed conn_id: {} track_alias: {}",
-                                   current_connection_->GetID(),
-                                   th.track_fullname_hash);
+                QUICR_LOGGER_WARN(logger_,
+                                  "Track already subscribed conn_id: {} track_alias: {}",
+                                  current_connection_->GetID(),
+                                  th.track_fullname_hash);
                 return;
             }
 
@@ -891,13 +877,13 @@ namespace quicr {
                 const auto joining_fetch_handler = std::make_shared<JoiningFetchHandler>(
                   track_handler, info.group_order.value_or(messages::GroupOrder::kAscending));
                 const auto fetch_rid = GetNextRequestID();
-                SPDLOG_LOGGER_INFO(logger_,
-                                   "Subscribe with joining fetch conn_id: {} track_alias: {} subscribe id: {} "
-                                   "joining subscribe id: {}",
-                                   current_connection_->GetID(),
-                                   th.track_fullname_hash,
-                                   fetch_rid,
-                                   *track_handler->GetRequestId());
+                QUICR_LOGGER_INFO(logger_,
+                                  "Subscribe with joining fetch conn_id: {} track_alias: {} subscribe id: {} "
+                                  "joining subscribe id: {}",
+                                  current_connection_->GetID(),
+                                  th.track_fullname_hash,
+                                  fetch_rid,
+                                  *track_handler->GetRequestId());
                 joining_fetch_handler->SetRequestId(fetch_rid);
                 joining_fetch_handler->SetConnectionId(current_connection_->GetID());
                 joining_fetch_handler->SetTransport(GetSharedPtr());
@@ -925,10 +911,10 @@ namespace quicr {
         const auto& tfn = track_handler->GetFullTrackName();
         auto th = TrackHash(tfn);
 
-        SPDLOG_LOGGER_INFO(logger_,
-                           "Unsubscribe track conn_id: {} track_alias: {}",
-                           current_connection_->GetID(),
-                           th.track_fullname_hash);
+        QUICR_LOGGER_INFO(logger_,
+                          "Unsubscribe track conn_id: {} track_alias: {}",
+                          current_connection_->GetID(),
+                          th.track_fullname_hash);
 
         std::lock_guard<std::mutex> lock(state_mutex_);
 
@@ -940,7 +926,7 @@ namespace quicr {
         const auto& tfn = track_handler->GetFullTrackName();
         auto th = TrackHash(tfn);
 
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger_, "Subscribe track conn_id: {} hash: {}", current_connection_->GetID(), th.track_fullname_hash);
 
         std::lock_guard<std::mutex> _(state_mutex_);
@@ -951,7 +937,7 @@ namespace quicr {
 
         auto priority = track_handler->GetPriority();
         if (!track_handler->GetDataContextId().has_value()) {
-            SPDLOG_LOGGER_ERROR(
+            QUICR_LOGGER_ERROR(
               logger_, "Subscribe track update missing data context conn_id: {}", current_connection_->GetID());
             return;
         }
@@ -979,7 +965,7 @@ namespace quicr {
                         }
                     }
                 } catch (const std::exception& e) {
-                    SPDLOG_LOGGER_ERROR(logger_, "Failed to send unsubscribe: {}", e.what());
+                    QUICR_LOGGER_ERROR(logger_, "Failed to send unsubscribe: {}", e.what());
                 }
 
                 handler.SetStatus(SubscribeTrackHandler::Status::kNotSubscribed);
@@ -1011,7 +997,7 @@ namespace quicr {
                         SendUnsubscribeNamespace(handler.GetDataContextId().value(), handler.GetPrefix());
                     }
                 } catch (const std::exception& e) {
-                    SPDLOG_LOGGER_ERROR(logger_, "Failed to send unsubscribe namespace: {}", e.what());
+                    QUICR_LOGGER_ERROR(logger_, "Failed to send unsubscribe namespace: {}", e.what());
                 }
 
                 handler.SetStatus(SubscribeNamespaceHandler::Status::kNotSubscribed);
@@ -1095,10 +1081,10 @@ namespace quicr {
 
         const auto handler_it = request_handlers.find(request_id);
         if (handler_it == request_handlers.end()) {
-            SPDLOG_LOGGER_DEBUG(logger_,
-                                "Stream closed for unknown request_id conn_id: {} request_id: {}",
-                                current_connection_->GetID(),
-                                request_id);
+            QUICR_LOGGER_DEBUG(logger_,
+                               "Stream closed for unknown request_id conn_id: {} request_id: {}",
+                               current_connection_->GetID(),
+                               request_id);
             recv_req_id.erase(request_id);
             return;
         }
@@ -1109,12 +1095,12 @@ namespace quicr {
             request_id_by_data_ctx.erase(*data_ctx_id);
         }
 
-        SPDLOG_LOGGER_INFO(logger_,
-                           "Closing request handler conn_id: {} request_id: {} stream_id: {} reset: {}",
-                           current_connection_->GetID(),
-                           request_id,
-                           stream_id,
-                           is_reset);
+        QUICR_LOGGER_INFO(logger_,
+                          "Closing request handler conn_id: {} request_id: {} stream_id: {} reset: {}",
+                          current_connection_->GetID(),
+                          request_id,
+                          stream_id,
+                          is_reset);
 
         if (auto sub_handler = handler_it->second->Get<SubscribeTrackHandler>()) {
             sub_handler->SetStatus(is_reset ? SubscribeTrackHandler::Status::kDoneByReset
@@ -1209,7 +1195,7 @@ namespace quicr {
         auto tfn = track_handler->GetFullTrackName();
         auto th = TrackHash(tfn);
 
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger_, "Unpublish track conn_id: {} hash: {}", current_connection_->GetID(), th.track_fullname_hash);
 
         std::unique_lock<std::mutex> lock(state_mutex_);
@@ -1234,23 +1220,22 @@ namespace quicr {
                 // Send subscribe done if track has subscriber and is sending
                 if (pub_n_it->second->GetStatus() == PublishTrackHandler::Status::kOk &&
                     pub_n_it->second->GetRequestId().has_value() && pub_n_it->second->GetDataContextId().has_value()) {
-                    SPDLOG_LOGGER_INFO(
-                      logger_,
-                      "Unpublish track namespace hash: {} track_name_hash: {} track_alias: {}, sending "
-                      "publish_done",
-                      th.track_namespace_hash,
-                      th.track_name_hash,
-                      th.track_fullname_hash);
+                    QUICR_LOGGER_INFO(logger_,
+                                      "Unpublish track namespace hash: {} track_name_hash: {} track_alias: {}, sending "
+                                      "publish_done",
+                                      th.track_namespace_hash,
+                                      th.track_name_hash,
+                                      th.track_fullname_hash);
                     SendPublishDone(*pub_n_it->second->GetDataContextId(),
                                     *pub_n_it->second->GetRequestId(),
                                     PublishDoneStatusCode::kSubscribtionEnded,
                                     "Unpublish track");
                 } else {
-                    SPDLOG_LOGGER_INFO(logger_,
-                                       "Unpublish track namespace hash: {} track_name_hash: {} track_alias: {}",
-                                       th.track_namespace_hash,
-                                       th.track_name_hash,
-                                       th.track_fullname_hash);
+                    QUICR_LOGGER_INFO(logger_,
+                                      "Unpublish track namespace hash: {} track_name_hash: {} track_alias: {}",
+                                      th.track_namespace_hash,
+                                      th.track_name_hash,
+                                      th.track_fullname_hash);
                 }
 
                 pub_n_it->second->publish_data_ctx_id_ = 0;
@@ -1273,12 +1258,12 @@ namespace quicr {
     {
         const auto tfn = track_handler->GetFullTrackName();
         auto th = TrackHash(tfn);
-        SPDLOG_LOGGER_INFO(logger_,
-                           "Publish track conn_id: {} hash: {} tfn: {} ({})",
-                           current_connection_->GetID(),
-                           th.track_fullname_hash,
-                           tfn.NamespaceStr(),
-                           tfn.NameStr());
+        QUICR_LOGGER_INFO(logger_,
+                          "Publish track conn_id: {} hash: {} tfn: {} ({})",
+                          current_connection_->GetID(),
+                          th.track_fullname_hash,
+                          tfn.NamespaceStr(),
+                          tfn.NameStr());
 
         std::unique_lock<std::mutex> lock(state_mutex_);
 
@@ -1315,11 +1300,11 @@ namespace quicr {
         SendPublish(track_handler->GetDataContextId().value(), *track_handler->GetRequestId(), publish);
 
         track_handler->connection_id_ = current_connection_->GetID();
-        SPDLOG_LOGGER_INFO(logger_,
-                           "Publish track creating new data context connId {}, track namespace hash: {}, name hash: {}",
-                           current_connection_->GetID(),
-                           th.track_namespace_hash,
-                           th.track_name_hash);
+        QUICR_LOGGER_INFO(logger_,
+                          "Publish track creating new data context connId {}, track namespace hash: {}, name hash: {}",
+                          current_connection_->GetID(),
+                          th.track_namespace_hash,
+                          th.track_name_hash);
         track_handler->publish_data_ctx_id_ =
           quic_transport_->CreateDataContext(current_connection_,
                                              track_handler->default_track_mode_ == TrackMode::kDatagram ? false : true,
@@ -1340,7 +1325,7 @@ namespace quicr {
     void Session::PublishNamespace(std::shared_ptr<PublishNamespaceHandler> ns_handler, bool passive)
     {
         auto prefix_hash = hash(ns_handler->GetPrefix());
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger_, "Publish namespace conn_id: {0} hash: {1}", current_connection_->GetID(), prefix_hash);
 
         std::unique_lock<std::mutex> lock(state_mutex_);
@@ -1348,7 +1333,7 @@ namespace quicr {
         if (!passive) {
             ns_handler->SetRequestId(GetNextRequestID());
 
-            SPDLOG_LOGGER_INFO(logger_, "Publishing to namespace hash: {0} sending ANNOUNCE message", prefix_hash);
+            QUICR_LOGGER_INFO(logger_, "Publishing to namespace hash: {0} sending ANNOUNCE message", prefix_hash);
 
             lock.unlock();
 
@@ -1379,7 +1364,7 @@ namespace quicr {
         const auto& prefix = track_handler->GetPrefix();
         const auto prefix_hash = hash(prefix);
 
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger_, "PublishNamespaceDone (conn_id={}, prefix_hash={})", current_connection_->GetID(), prefix_hash);
 
         std::lock_guard<std::mutex> lock(state_mutex_);
@@ -1387,10 +1372,10 @@ namespace quicr {
         const auto data_ctx_id = track_handler->GetDataContextId();
         const auto request_stream_id = track_handler->GetRequestStreamId();
         if (!data_ctx_id.has_value() || !request_stream_id.has_value()) {
-            SPDLOG_LOGGER_ERROR(logger_,
-                                "PublishNamespaceDone missing request context conn_id: {} prefix_hash: {}",
-                                current_connection_->GetID(),
-                                prefix_hash);
+            QUICR_LOGGER_ERROR(logger_,
+                               "PublishNamespaceDone missing request context conn_id: {} prefix_hash: {}",
+                               current_connection_->GetID(),
+                               prefix_hash);
             return;
         }
 
@@ -1405,7 +1390,7 @@ namespace quicr {
 
         track_handler->SetTrackAlias(th.track_fullname_hash);
 
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger_, "Fetch track conn_id: {} hash: {}", current_connection_->GetID(), th.track_fullname_hash);
 
         std::lock_guard<std::mutex> _(state_mutex_);
@@ -1414,7 +1399,7 @@ namespace quicr {
         track_handler->SetConnectionId(current_connection_->GetID());
         track_handler->SetTransport(GetSharedPtr());
 
-        SPDLOG_LOGGER_DEBUG(logger_, "subscribe id (from fetch) to add to memory: {}", *track_handler->GetRequestId());
+        QUICR_LOGGER_DEBUG(logger_, "subscribe id (from fetch) to add to memory: {}", *track_handler->GetRequestId());
 
         auto priority = track_handler->GetPriority();
         auto group_order = track_handler->GetGroupOrder();
@@ -1502,14 +1487,14 @@ namespace quicr {
 
     void Session::OnConnectionStatus(Connection::Status status)
     {
-        SPDLOG_LOGGER_DEBUG(
+        QUICR_LOGGER_DEBUG(
           logger_, "Connection status conn_id: {} status: {}", current_connection_->GetID(), static_cast<int>(status));
         bool remove_connection = false;
 
         switch (status) {
             case Connection::Status::kReady: {
                 if (client_mode_) {
-                    SPDLOG_LOGGER_INFO(logger_, "Connection established, creating bi-dir stream and sending SETUP");
+                    QUICR_LOGGER_INFO(logger_, "Connection established, creating bi-dir stream and sending SETUP");
 
                     tx_ctrl_data_ctx_id_ = quic_transport_->CreateDataContext(current_connection_, true, 0, false);
                     tx_ctrl_stream_id_ =
@@ -1612,7 +1597,7 @@ namespace quicr {
                 initial_cursor = initial_buffer.buffer.Data();
                 initial_stream_type = TryDecodeUintV(initial_cursor);
                 if (!initial_stream_type.has_value()) {
-                    SPDLOG_LOGGER_DEBUG(
+                    QUICR_LOGGER_DEBUG(
                       logger_,
                       "New stream {} bidir: {} does not have enough bytes to process start of stream yet",
                       stream_id,
@@ -1620,13 +1605,13 @@ namespace quicr {
                     continue;
                 }
 
-                SPDLOG_LOGGER_DEBUG(logger_,
-                                    "New stream conn_id: {} stream_id: {} bidir: {} data size: {} msg_type: {}",
-                                    current_connection_->GetID(),
-                                    stream_id,
-                                    is_bidir,
-                                    initial_buffer.buffer.Size(),
-                                    *initial_stream_type);
+                QUICR_LOGGER_DEBUG(logger_,
+                                   "New stream conn_id: {} stream_id: {} bidir: {} data size: {} msg_type: {}",
+                                   current_connection_->GetID(),
+                                   stream_id,
+                                   is_bidir,
+                                   initial_buffer.buffer.Size(),
+                                   *initial_stream_type);
 
                 // This might be incoming control stream arriving.
                 if (static_cast<ControlMessageType>(*initial_stream_type) == ControlMessageType::kSetup) {
@@ -1648,11 +1633,11 @@ namespace quicr {
 
                 auto& stream_buffer = stream_buffers.at(stream_id).buffer;
 
-                SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Transport:ControlMessageReceived conn_id: {} stream_id: {} data size: {}",
-                                    current_connection_->GetID(),
-                                    stream_id,
-                                    stream_buffer.Size());
+                QUICR_LOGGER_DEBUG(logger_,
+                                   "Transport:ControlMessageReceived conn_id: {} stream_id: {} data size: {}",
+                                   current_connection_->GetID(),
+                                   stream_id,
+                                   stream_buffer.Size());
 
                 // Parse control messages out of this stream data.
                 while (!stream_buffer.Empty()) {
@@ -1697,13 +1682,13 @@ namespace quicr {
                             processed = ProcessRequestMessage(*data_ctx_id, msg_type, payload);
                         }
                     } catch (const std::exception& e) {
-                        SPDLOG_LOGGER_ERROR(logger_,
-                                            "Caught exception trying to process control message. (type={}, error={})",
-                                            static_cast<int>(msg_type),
-                                            e.what());
+                        QUICR_LOGGER_ERROR(logger_,
+                                           "Caught exception trying to process control message. (type={}, error={})",
+                                           static_cast<int>(msg_type),
+                                           e.what());
                         throw ProtocolViolationException(e.what());
                     } catch (...) {
-                        SPDLOG_LOGGER_ERROR(logger_, "Unable to parse control message");
+                        QUICR_LOGGER_ERROR(logger_, "Unable to parse control message");
                         throw ProtocolViolationException("Control message cannot be parsed");
                     }
 
@@ -1717,7 +1702,7 @@ namespace quicr {
 
             // DATA OBJECT
             if (rx_ctx->is_new) {
-                SPDLOG_LOGGER_TRACE(
+                QUICR_LOGGER_TRACE(
                   logger_, "Received stream message type: 0x{:02x} ({})", *initial_stream_type, *initial_stream_type);
 
                 bool parsed_header = false;
@@ -1741,9 +1726,9 @@ namespace quicr {
                         break;
                     }
                     default:
-                        SPDLOG_LOGGER_WARN(logger_,
-                                           "Received start of stream with invalid header type {}, dropping",
-                                           *initial_stream_type);
+                        QUICR_LOGGER_WARN(logger_,
+                                          "Received start of stream with invalid header type {}, dropping",
+                                          *initial_stream_type);
                         current_connection_->metrics.rx_stream_invalid_type++;
 
                         // TODO(tievens): Need to reset this stream as this is invalid.
@@ -1759,7 +1744,7 @@ namespace quicr {
                           std::chrono::duration_cast<std::chrono::milliseconds>(tick_service_->get()).count());
                         rx_ctx->unknown_expiry_tick_ms += age_ms;
 
-                        SPDLOG_LOGGER_INFO(
+                        QUICR_LOGGER_INFO(
                           logger_,
                           "Setting stream_id: {} unknown expiry to {}ms (current time is {}ms)",
                           stream_id,
@@ -1781,14 +1766,14 @@ namespace quicr {
                     try {
                         sub_handler->StreamDataRecv(stream_id, *data_opt);
                     } catch (const ProtocolViolationException& e) {
-                        SPDLOG_LOGGER_ERROR(logger_, "Protocol violation on stream data recv: {}", e.reason);
+                        QUICR_LOGGER_ERROR(logger_, "Protocol violation on stream data recv: {}", e.reason);
                         throw ProtocolViolationException(e.reason);
                     } catch (std::exception& e) {
-                        SPDLOG_LOGGER_ERROR(logger_, "Caught exception on stream data recv: {}", e.what());
+                        QUICR_LOGGER_ERROR(logger_, "Caught exception on stream data recv: {}", e.what());
                         throw e;
                     }
                 } else {
-                    SPDLOG_LOGGER_ERROR(
+                    QUICR_LOGGER_ERROR(
                       logger_,
                       "Received data on existing stream_id: {} with no handler anymore, resetting stream",
                       stream_id);
@@ -1800,7 +1785,7 @@ namespace quicr {
             }
         } // end of for loop rx data queue
     } catch (const TransportException& e) {
-        SPDLOG_LOGGER_INFO(logger_, "OnRecvStream: connection or stream no longer exists (error={})", e.what());
+        QUICR_LOGGER_INFO(logger_, "OnRecvStream: connection or stream no longer exists (error={})", e.what());
     } catch (const std::exception& e) {
         // NOTE: Whatever message was being processed when this was thrown (e.g. a control message) was not
         // removed from its buffer, so the connection cannot make forward progress on that stream if left
@@ -1809,7 +1794,7 @@ namespace quicr {
         // instead of surfacing an error. Rather than letting that exception disappear into the transport's
         // callback notifier (which only logs and ignores it), close the connection so the failure is visible
         // and the peer is not left waiting indefinitely.
-        SPDLOG_LOGGER_ERROR(logger_, "Caught exception on receiving stream, closing connection. (error={})", e.what());
+        QUICR_LOGGER_ERROR(logger_, "Caught exception on receiving stream, closing connection. (error={})", e.what());
         current_connection_->metrics.invalid_ctrl_stream_msg++;
         Disconnect();
 
@@ -1821,7 +1806,7 @@ namespace quicr {
                                  std::optional<uint64_t> data_ctx_id,
                                  StreamClosedFlag flag)
     {
-        SPDLOG_LOGGER_DEBUG(logger_, "Stream {} closed", stream_id);
+        QUICR_LOGGER_DEBUG(logger_, "Stream {} closed", stream_id);
 
         if (auto callbacks = std::dynamic_pointer_cast<ServerCallbacks>(callbacks_)) {
             callbacks->OnStreamClosed(stream_id, flag);
@@ -1848,7 +1833,7 @@ namespace quicr {
                 }
 
             } catch (const std::exception& e) {
-                SPDLOG_LOGGER_ERROR(logger_, "Caught exception on stream closed: {}", e.what());
+                QUICR_LOGGER_ERROR(logger_, "Caught exception on stream closed: {}", e.what());
             }
             return;
         }
@@ -1896,15 +1881,15 @@ namespace quicr {
                         }
                     }
                 } catch (const ProtocolViolationException& e) {
-                    SPDLOG_LOGGER_ERROR(logger_, "Protocol violation on stream data recv: {}", e.reason);
+                    QUICR_LOGGER_ERROR(logger_, "Protocol violation on stream data recv: {}", e.reason);
                     throw ProtocolViolationException(e.reason);
                 } catch (const std::exception& e) {
-                    SPDLOG_LOGGER_ERROR(logger_, "Caught exception on stream data recv: {}", e.what());
+                    QUICR_LOGGER_ERROR(logger_, "Caught exception on stream data recv: {}", e.what());
                     throw std::runtime_error("Internal error");
                 }
             }
         } catch (const std::bad_any_cast&) {
-            SPDLOG_LOGGER_WARN(logger_, "Received stream closed for unknown handler");
+            QUICR_LOGGER_WARN(logger_, "Received stream closed for unknown handler");
         }
     }
 
@@ -1913,7 +1898,7 @@ namespace quicr {
         auto sub_it = sub_by_recv_track_alias.find(track_alias);
         if ((sub_it == sub_by_recv_track_alias.end() || sub_it->second == nullptr)) {
             current_connection_->metrics.rx_stream_unknown_track_alias++;
-            SPDLOG_LOGGER_WARN(
+            QUICR_LOGGER_WARN(
               logger_,
               "Received stream_header_subgroup to unknown subscribe track track_alias: {} stream: {}, ignored",
               track_alias,
@@ -1941,10 +1926,10 @@ namespace quicr {
         const auto fetch_it = request_handlers.find(request_id);
         if (fetch_it == request_handlers.end()) {
             // TODO: Metrics.
-            SPDLOG_LOGGER_WARN(logger_,
-                               "Received fetch_header to unknown fetch track request_id: {} stream: {}, ignored",
-                               request_id,
-                               stream_id);
+            QUICR_LOGGER_WARN(logger_,
+                              "Received fetch_header to unknown fetch track request_id: {} stream: {}, ignored",
+                              request_id,
+                              stream_id);
 
             // TODO(tievens): Should close/reset stream in this case but draft leaves this case hanging
             return false;
@@ -1982,7 +1967,7 @@ namespace quicr {
 
                 // Message type needs to be either datagram header types or status types.
                 if (!DatagramHeaderProperties::IsValid(msg_type)) {
-                    SPDLOG_LOGGER_DEBUG(
+                    QUICR_LOGGER_DEBUG(
                       logger_, "Received datagram that is not a supported datagram type, dropping: {}", msg_type);
                     current_connection_->metrics.rx_dgram_invalid_type++;
                     continue;
@@ -2005,7 +1990,7 @@ namespace quicr {
                 if (sub_it == sub_by_recv_track_alias.end()) {
                     current_connection_->metrics.rx_dgram_unknown_track_alias++;
 
-                    SPDLOG_LOGGER_DEBUG(
+                    QUICR_LOGGER_DEBUG(
                       logger_, "Received datagram to unknown subscribe track track alias: {}, ignored", track_alias);
 
                     // TODO(tievens): Should close/reset stream in this case but draft leaves this case hanging
@@ -2013,14 +1998,13 @@ namespace quicr {
                     continue;
                 }
 
-                SPDLOG_LOGGER_TRACE(logger_,
-                                    "Received object datagram conn_id: {} data_ctx_id: {} subscriber_id: {} "
-                                    "track_alias: {} group_id: {4} object_id: {5} data size: {6}",
-                                    current_connection_->GetID(),
-                                    (data_ctx_id ? *data_ctx_id : 0),
-                                    sub_id,
-                                    track_alias,
-                                    data.value()->size());
+                QUICR_LOGGER_TRACE(logger_,
+                                   "Received object datagram conn_id: {} data_ctx_id: {} "
+                                   "track_alias: {} group_id: {4} object_id: {5} data size: {6}",
+                                   current_connection_->GetID(),
+                                   (data_ctx_id ? *data_ctx_id : 0),
+                                   track_alias,
+                                   data->size());
 
                 auto handler = static_cast<SubscribeTrackHandler*>(sub_it->second.get());
 
@@ -2028,11 +2012,11 @@ namespace quicr {
             } else if (data) {
                 current_connection_->metrics.rx_dgram_decode_failed++;
 
-                SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Failed to decode datagram conn_id: {} data_ctx_id: {} size: {}",
-                                    current_connection_->GetID(),
-                                    (data_ctx_id ? *data_ctx_id : 0),
-                                    data->size());
+                QUICR_LOGGER_DEBUG(logger_,
+                                   "Failed to decode datagram conn_id: {} data_ctx_id: {} size: {}",
+                                   current_connection_->GetID(),
+                                   (data_ctx_id ? *data_ctx_id : 0),
+                                   data->size());
             }
         }
     }
@@ -2146,18 +2130,18 @@ namespace quicr {
     {
         auto track_it = request_handlers.find(request_id);
         if (track_it == request_handlers.end()) {
-            SPDLOG_LOGGER_ERROR(logger_, "Resolve REQUEST_UPDATE for request {} had no handler", request_id);
+            QUICR_LOGGER_ERROR(logger_, "Resolve REQUEST_UPDATE for request {} had no handler", request_id);
             return;
         }
 
-        SPDLOG_LOGGER_DEBUG(logger_, "Request Updated resolve req_id: {}", request_id);
+        QUICR_LOGGER_DEBUG(logger_, "Request Updated resolve req_id: {}", request_id);
 
         const auto data_ctx_id = track_it->second->GetDataContextId();
         if (!data_ctx_id.has_value()) {
-            SPDLOG_LOGGER_WARN(logger_,
-                               "ResolveRequestUpdate missing handler data context conn_id: {} request_id: {}",
-                               current_connection_->GetID(),
-                               request_id);
+            QUICR_LOGGER_WARN(logger_,
+                              "ResolveRequestUpdate missing handler data context conn_id: {} request_id: {}",
+                              current_connection_->GetID(),
+                              request_id);
             return;
         }
 
@@ -2261,7 +2245,7 @@ namespace quicr {
         std::lock_guard lock(state_mutex_);
 
         auto th = TrackHash(track_handler->GetFullTrackName());
-        SPDLOG_LOGGER_DEBUG(
+        QUICR_LOGGER_DEBUG(
           logger_,
           "Server publish track conn_id: {} full_name_hash: {} namespace_hash: {} name_hash: {} unbind",
           current_connection_->GetID(),
@@ -2278,11 +2262,11 @@ namespace quicr {
         }
 
         if (pub_tracks_by_name.count(th.track_namespace_hash) == 0) {
-            SPDLOG_LOGGER_DEBUG(logger_,
-                                "Server publish track conn_id: {} full_name_hash: {} namespace_hash: {} unbind",
-                                current_connection_->GetID(),
-                                th.track_fullname_hash,
-                                th.track_namespace_hash);
+            QUICR_LOGGER_DEBUG(logger_,
+                               "Server publish track conn_id: {} full_name_hash: {} namespace_hash: {} unbind",
+                               current_connection_->GetID(),
+                               th.track_fullname_hash,
+                               th.track_namespace_hash);
 
             pub_tracks_by_name.erase(th.track_namespace_hash);
         }
@@ -2302,7 +2286,7 @@ namespace quicr {
     void Session::BindFetchTrack(std::shared_ptr<PublishFetchHandler> track_handler)
     {
         const std::uint64_t request_id = *track_handler->GetRequestId();
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger_, "Publish fetch track conn_id: {} subscribe: {}", current_connection_->GetID(), request_id);
 
         std::lock_guard lock(state_mutex_);
@@ -2323,10 +2307,10 @@ namespace quicr {
         std::lock_guard lock(state_mutex_);
 
         auto request_id = *track_handler->GetRequestId();
-        SPDLOG_LOGGER_DEBUG(logger_,
-                            "Server publish fetch track conn_id: {} subscribe id: {} unbind",
-                            current_connection_->GetID(),
-                            request_id);
+        QUICR_LOGGER_DEBUG(logger_,
+                           "Server publish fetch track conn_id: {} subscribe id: {} unbind",
+                           current_connection_->GetID(),
+                           request_id);
 
         pub_fetch_tracks_by_request_id.erase(request_id);
         quic_transport_->DeleteDataContext(current_connection_, track_handler->publish_data_ctx_id_, true);
@@ -2383,7 +2367,7 @@ namespace quicr {
 
                 SetStatus(Status::kReady);
 
-                SPDLOG_LOGGER_INFO(
+                QUICR_LOGGER_INFO(
                   logger_, "Setup received conn_id: {} from: {}", current_connection_->GetID(), endpoint_id);
 
                 return true;
@@ -2392,11 +2376,11 @@ namespace quicr {
                 // Session GOAWAY.
                 const auto new_session_uri = messages::Message::ParseField<Bytes>(msg_bytes);
                 std::string new_sess_uri(new_session_uri.begin(), new_session_uri.end());
-                SPDLOG_LOGGER_INFO(logger_, "Received session goaway new session uri: {}", new_sess_uri);
+                QUICR_LOGGER_INFO(logger_, "Received session goaway new session uri: {}", new_sess_uri);
                 return true;
             }
             default: {
-                SPDLOG_LOGGER_ERROR(
+                QUICR_LOGGER_ERROR(
                   logger_, "Unsupported session control message, type: {}", static_cast<std::uint64_t>(msg_type));
                 throw ProtocolViolationException("Unsupported session control message");
             }
@@ -2422,13 +2406,13 @@ namespace quicr {
                 if (client_mode_) {
                     auto ptd = GetPubTrackHandler(th);
                     if (ptd == nullptr) {
-                        SPDLOG_LOGGER_WARN(logger_,
-                                           "Received subscribe unknown publish track conn_id: {} namespace hash: {} "
-                                           "name hash: {} request_id: {}",
-                                           current_connection_->GetID(),
-                                           th.track_namespace_hash,
-                                           th.track_name_hash,
-                                           request_id);
+                        QUICR_LOGGER_WARN(logger_,
+                                          "Received subscribe unknown publish track conn_id: {} namespace hash: {} "
+                                          "name hash: {} request_id: {}",
+                                          current_connection_->GetID(),
+                                          th.track_namespace_hash,
+                                          th.track_name_hash,
+                                          request_id);
 
                         SendRequestError(data_ctx_id,
                                          request_id,
@@ -2574,7 +2558,7 @@ namespace quicr {
 
                 auto sub_it = request_handlers.find(request_id);
                 if (sub_it == request_handlers.end()) {
-                    SPDLOG_LOGGER_WARN(
+                    QUICR_LOGGER_WARN(
                       logger_,
                       "Received subscribe ok to unknown subscribe track conn_id: {} request_id: {}, ignored",
                       current_connection_->GetID(),
@@ -2608,10 +2592,10 @@ namespace quicr {
                 // What request is this for?
                 const auto req_it = request_id_by_data_ctx.find(data_ctx_id);
                 if (req_it == request_id_by_data_ctx.end()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received REQUEST_OK for unknown request conn_id: {} data_ctx_ic: {}, ignored",
-                                       current_connection_->GetID(),
-                                       data_ctx_id);
+                    QUICR_LOGGER_WARN(logger_,
+                                      "Received REQUEST_OK for unknown request conn_id: {} data_ctx_ic: {}, ignored",
+                                      current_connection_->GetID(),
+                                      data_ctx_id);
                     return true;
                 }
                 const auto request_id = req_it->second;
@@ -2623,10 +2607,10 @@ namespace quicr {
 
                 auto track_it = request_handlers.find(request_id);
                 if (track_it == request_handlers.end()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received REQUEST_OK to unknown track conn_id: {} request_id: {}, ignored",
-                                       current_connection_->GetID(),
-                                       request_id);
+                    QUICR_LOGGER_WARN(logger_,
+                                      "Received REQUEST_OK to unknown track conn_id: {} request_id: {}, ignored",
+                                      current_connection_->GetID(),
+                                      request_id);
                     return true;
                 }
 
@@ -2636,11 +2620,10 @@ namespace quicr {
             case messages::ControlMessageType::kRequestError: {
                 const auto request_it = request_id_by_data_ctx.find(data_ctx_id);
                 if (request_it == request_id_by_data_ctx.end()) {
-                    SPDLOG_LOGGER_WARN(
-                      logger_,
-                      "Received REQUEST_ERROR for unknown request conn_id: {} data_ctx_id: {}, ignored",
-                      current_connection_->GetID(),
-                      data_ctx_id);
+                    QUICR_LOGGER_WARN(logger_,
+                                      "Received REQUEST_ERROR for unknown request conn_id: {} data_ctx_id: {}, ignored",
+                                      current_connection_->GetID(),
+                                      data_ctx_id);
                     return true;
                 }
                 const auto request_id = request_it->second;
@@ -2653,11 +2636,10 @@ namespace quicr {
                 if (client_mode_) {
                     auto track_it = request_handlers.find(request_id);
                     if (track_it == request_handlers.end()) {
-                        SPDLOG_LOGGER_WARN(
-                          logger_,
-                          "Received REQUEST_ERROR to unknown track conn_id: {} request_id: {}, ignored",
-                          current_connection_->GetID(),
-                          request_id);
+                        QUICR_LOGGER_WARN(logger_,
+                                          "Received REQUEST_ERROR to unknown track conn_id: {} request_id: {}, ignored",
+                                          current_connection_->GetID(),
+                                          request_id);
                         return true;
                     }
 
@@ -2665,11 +2647,11 @@ namespace quicr {
                     return true;
                 }
 
-                SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Received track status error request_id: {} error code: {} reason: {}",
-                                    request_id,
-                                    static_cast<std::uint64_t>(error_code),
-                                    reason_str);
+                QUICR_LOGGER_DEBUG(logger_,
+                                   "Received track status error request_id: {} error code: {} reason: {}",
+                                   request_id,
+                                   static_cast<std::uint64_t>(error_code),
+                                   reason_str);
                 return true;
             }
             case messages::ControlMessageType::kTrackStatus: {
@@ -2680,10 +2662,10 @@ namespace quicr {
                 auto tfn = FullTrackName{ track_namespace, track_name };
 
                 auto th = TrackHash(tfn);
-                SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Received track status request_id: {} for full name hash: {}",
-                                    request_id,
-                                    th.track_fullname_hash);
+                QUICR_LOGGER_DEBUG(logger_,
+                                   "Received track status request_id: {} for full name hash: {}",
+                                   request_id,
+                                   th.track_fullname_hash);
 
                 request_id_by_data_ctx[data_ctx_id] = request_id;
 
@@ -2776,7 +2758,7 @@ namespace quicr {
                 [[fallthrough]];
             case messages::ControlMessageType::kSubscribeNamespace: {
                 if (client_mode_) {
-                    SPDLOG_LOGGER_ERROR(
+                    QUICR_LOGGER_ERROR(
                       logger_, "Unsupported MOQT message type: {}, bad stream", static_cast<uint64_t>(msg_type));
                     return false;
                 }
@@ -2845,7 +2827,7 @@ namespace quicr {
             }
             case messages::ControlMessageType::kNamespaceDone: {
                 if (client_mode_) {
-                    SPDLOG_LOGGER_ERROR(
+                    QUICR_LOGGER_ERROR(
                       logger_, "Unsupported MOQT message type: {}, bad stream", static_cast<uint64_t>(msg_type));
                     return false;
                 }
@@ -2877,10 +2859,10 @@ namespace quicr {
 
                 auto sub_it = request_handlers.find(request_id);
                 if (sub_it == request_handlers.end()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received publish done to unknown request_id conn_id: {} request_id: {}",
-                                       current_connection_->GetID(),
-                                       request_id);
+                    QUICR_LOGGER_WARN(logger_,
+                                      "Received publish done to unknown request_id conn_id: {} request_id: {}",
+                                      current_connection_->GetID(),
+                                      request_id);
                     return true;
                 }
 
@@ -2894,14 +2876,14 @@ namespace quicr {
                 auto tfn = sub_it->second->GetFullTrackName();
                 auto th = TrackHash(tfn);
 
-                SPDLOG_LOGGER_INFO(logger_,
-                                   "Received publish done conn_id: {} request_id: {} track namespace hash: {} "
-                                   "name hash: {} track alias: {}",
-                                   current_connection_->GetID(),
-                                   request_id,
-                                   th.track_namespace_hash,
-                                   th.track_name_hash,
-                                   th.track_fullname_hash);
+                QUICR_LOGGER_INFO(logger_,
+                                  "Received publish done conn_id: {} request_id: {} track namespace hash: {} "
+                                  "name hash: {} track alias: {}",
+                                  current_connection_->GetID(),
+                                  request_id,
+                                  th.track_namespace_hash,
+                                  th.track_name_hash,
+                                  th.track_fullname_hash);
 
                 if (auto h = sub_it->second->Get<SubscribeTrackHandler>()) {
                     h->SetStatus(SubscribeTrackHandler::Status::kNotSubscribed);
@@ -2930,7 +2912,7 @@ namespace quicr {
                 // Request GOAWAY.
                 const auto new_session_uri = messages::Message::ParseField<Bytes>(msg_bytes);
                 std::string new_sess_uri(new_session_uri.begin(), new_session_uri.end());
-                SPDLOG_LOGGER_INFO(logger_, "Received request goaway new session uri: {}", new_sess_uri);
+                QUICR_LOGGER_INFO(logger_, "Received request goaway new session uri: {}", new_sess_uri);
                 return true;
             }
             case messages::ControlMessageType::kFetchOk: {
@@ -2951,10 +2933,10 @@ namespace quicr {
 
                 auto fetch_it = request_handlers.find(request_id);
                 if (fetch_it == request_handlers.end()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received fetch ok for unknown fetch track conn_id: {} request_id: {}, ignored",
-                                       current_connection_->GetID(),
-                                       request_id);
+                    QUICR_LOGGER_WARN(logger_,
+                                      "Received fetch ok for unknown fetch track conn_id: {} request_id: {}, ignored",
+                                      current_connection_->GetID(),
+                                      request_id);
                     return true;
                 }
 
@@ -3229,12 +3211,12 @@ namespace quicr {
                 const auto update_request_id = messages::Message::ParseField<std::uint64_t>(msg_bytes);
                 const auto request_it = request_id_by_data_ctx.find(data_ctx_id);
                 if (request_it == request_id_by_data_ctx.end()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received REQUEST_UPDATE on unknown request stream conn_id: {} data_ctx_id: {} "
-                                       "update_request_id: {}, ignored",
-                                       current_connection_->GetID(),
-                                       data_ctx_id,
-                                       update_request_id);
+                    QUICR_LOGGER_WARN(logger_,
+                                      "Received REQUEST_UPDATE on unknown request stream conn_id: {} data_ctx_id: {} "
+                                      "update_request_id: {}, ignored",
+                                      current_connection_->GetID(),
+                                      data_ctx_id,
+                                      update_request_id);
                     return true;
                 }
                 const auto request_id = request_it->second;
@@ -3243,11 +3225,11 @@ namespace quicr {
                 if (client_mode_) {
                     auto track_it = request_handlers.find(request_id);
                     if (track_it == request_handlers.end()) {
-                        SPDLOG_LOGGER_WARN(logger_,
-                                           "Received REQUEST_UPDATE to unknown track conn_id: {} request_id: {}, "
-                                           "ignored",
-                                           current_connection_->GetID(),
-                                           request_id);
+                        QUICR_LOGGER_WARN(logger_,
+                                          "Received REQUEST_UPDATE to unknown track conn_id: {} request_id: {}, "
+                                          "ignored",
+                                          current_connection_->GetID(),
+                                          request_id);
                         return true;
                     }
 
@@ -3257,10 +3239,10 @@ namespace quicr {
 
                 auto sub_ctx_it = recv_req_id.find(request_id);
                 if (sub_ctx_it == recv_req_id.end()) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "Received subscribe_update for unknown subscription conn_id: {} request_id: {}",
-                                       current_connection_->GetID(),
-                                       request_id);
+                    QUICR_LOGGER_WARN(logger_,
+                                      "Received subscribe_update for unknown subscription conn_id: {} request_id: {}",
+                                      current_connection_->GetID(),
+                                      request_id);
 
                     SendRequestError(
                       data_ctx_id, request_id, messages::ErrorCode::kDoesNotExist, 0ms, "Subscription not found");
@@ -3284,22 +3266,22 @@ namespace quicr {
                                 }
 
                                 const auto& [code, reason] = result.error();
-                                SPDLOG_LOGGER_ERROR(self->logger_,
-                                                    "New group request on update failed request_id: {} group_id: {} "
-                                                    "code: {} reason: {}",
-                                                    request_id,
-                                                    group_id,
-                                                    code,
-                                                    reason.value_or("unknown"));
+                                QUICR_LOGGER_ERROR(self->logger_,
+                                                   "New group request on update failed request_id: {} group_id: {} "
+                                                   "code: {} reason: {}",
+                                                   request_id,
+                                                   group_id,
+                                                   code,
+                                                   reason.value_or("unknown"));
                             });
                     }
                 }
 
-                SPDLOG_LOGGER_DEBUG(logger_,
-                                    "Received subscribe_update to recv request_id: {} forward: {} ngr: {}",
-                                    request_id,
-                                    forward,
-                                    new_group_request_id.has_value());
+                QUICR_LOGGER_DEBUG(logger_,
+                                   "Received subscribe_update to recv request_id: {} forward: {} ngr: {}",
+                                   request_id,
+                                   forward,
+                                   new_group_request_id.has_value());
 
                 for (const auto& pub : pub_tracks_by_track_alias[sub_ctx_it->second.track_hash.track_fullname_hash]) {
                     if (not forward) {
@@ -3313,7 +3295,7 @@ namespace quicr {
                 return true;
             }
             default: {
-                SPDLOG_LOGGER_ERROR(
+                QUICR_LOGGER_ERROR(
                   logger_, "Unsupported MOQT message type: {}, bad stream", static_cast<uint64_t>(msg_type));
                 return false;
             }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -2000,7 +2000,7 @@ namespace quicr {
 
                 QUICR_LOGGER_TRACE(logger_,
                                    "Received object datagram conn_id: {} data_ctx_id: {} "
-                                   "track_alias: {} group_id: {4} object_id: {5} data size: {6}",
+                                   "track_alias: {} data size: {}",
                                    current_connection_->GetID(),
                                    (data_ctx_id ? *data_ctx_id : 0),
                                    track_alias,

--- a/src/session_manager.cpp
+++ b/src/session_manager.cpp
@@ -102,26 +102,29 @@ namespace quicr {
 
     void SessionManager::Callbacks::OnSessionRemoved(const std::shared_ptr<Session>& session) {}
 
-    SessionManager::SessionManager()
-      : SessionManager(std::make_shared<Callbacks>(), std::make_shared<timeq::threaded_tick_service>())
+    SessionManager::SessionManager(std::shared_ptr<Logger> logger)
+      : SessionManager(std::make_shared<Callbacks>(),
+                       std::make_shared<timeq::threaded_tick_service>(),
+                       std::move(logger))
     {
     }
 
-    SessionManager::SessionManager(std::shared_ptr<Callbacks> callbacks)
-      : SessionManager(std::move(callbacks), std::make_shared<timeq::threaded_tick_service>())
+    SessionManager::SessionManager(std::shared_ptr<Callbacks> callbacks, std::shared_ptr<Logger> logger)
+      : SessionManager(std::move(callbacks), std::make_shared<timeq::threaded_tick_service>(), std::move(logger))
     {
     }
 
-    SessionManager::SessionManager(std::shared_ptr<timeq::tick_service> tick_service)
-      : SessionManager(std::make_shared<Callbacks>(), std::move(tick_service))
+    SessionManager::SessionManager(std::shared_ptr<timeq::tick_service> tick_service, std::shared_ptr<Logger> logger)
+      : SessionManager(std::make_shared<Callbacks>(), std::move(tick_service), std::move(logger))
     {
     }
 
     SessionManager::SessionManager(std::shared_ptr<Callbacks> callbacks,
-                                   std::shared_ptr<timeq::tick_service> tick_service)
+                                   std::shared_ptr<timeq::tick_service> tick_service,
+                                   std::shared_ptr<Logger> logger)
       : callbacks_(std::move(callbacks))
       , tick_service_(std::move(tick_service))
-      , logger_(Logger::Create("QUICR"))
+      , logger_(std::move(logger))
     {
         on_connection_closed_ = [this](const auto& connection) {
             connection->SetDelegate(nullptr);
@@ -181,7 +184,7 @@ namespace quicr {
             return {};
         }
 
-        auto session = Session::Create(config, transport, connection, std::move(callbacks), tick_service_);
+        auto session = Session::Create(config, transport, connection, std::move(callbacks), tick_service_, logger_);
 
         connection->SetDelegate(session);
 
@@ -207,7 +210,7 @@ namespace quicr {
         transport->OnNewConnection =
           [=, this, wtransport = std::weak_ptr(transport), callbacks = std::move(callbacks)](const auto& connection) {
               auto transport = wtransport.lock();
-              auto session = Session::Create(config, transport, connection, callbacks, tick_service_);
+              auto session = Session::Create(config, transport, connection, callbacks, tick_service_, logger_);
               connection->SetDelegate(session);
 
               {

--- a/src/session_manager.cpp
+++ b/src/session_manager.cpp
@@ -6,25 +6,15 @@
 #include "quicr/handlers/publish_track_handler.h"
 #include "quicr/handlers/subscribe_namespace_handler.h"
 #include "quicr/handlers/subscribe_track_handler.h"
+#include "quicr/log.h"
 #include "quicr/session.h"
 #include "quicr/transport.h"
 
-#include <spdlog/sinks/stdout_color_sinks.h>
-#include <spdlog/spdlog.h>
 #include <timeq/tick_service.h>
 
 namespace quicr {
 
     namespace {
-        std::shared_ptr<spdlog::logger> SafeLoggerGet(const std::string& name)
-        {
-            if (auto logger = spdlog::get(name)) {
-                return logger;
-            }
-
-            return spdlog::stderr_color_mt(name);
-        }
-
         static std::optional<std::tuple<std::string, uint16_t, TransportProtocol, std::string>> ParseConnectUri(
           const std::string& connect_uri)
         {
@@ -131,7 +121,7 @@ namespace quicr {
                                    std::shared_ptr<timeq::tick_service> tick_service)
       : callbacks_(std::move(callbacks))
       , tick_service_(std::move(tick_service))
-      , logger_(SafeLoggerGet("QUICR"))
+      , logger_(Logger::Create("QUICR"))
     {
         on_connection_closed_ = [this](const auto& connection) {
             connection->SetDelegate(nullptr);
@@ -140,9 +130,9 @@ namespace quicr {
 
             auto it = sessions_.find(connection->GetID());
             if (it == sessions_.end()) {
-                SPDLOG_LOGGER_ERROR(logger_,
-                                    "Received Close for connection that has no associated session (conn_id={})",
-                                    connection->GetID());
+                QUICR_LOGGER_ERROR(logger_,
+                                   "Received Close for connection that has no associated session (conn_id={})",
+                                   connection->GetID());
                 return;
             }
 
@@ -157,8 +147,6 @@ namespace quicr {
         for (const auto& [_, transport] : transports_) {
             transport->Shutdown();
         }
-
-        spdlog::drop(logger_->name());
     }
 
     std::weak_ptr<Session> SessionManager::AddTransport(const ClientConfig& config,

--- a/src/subscribe_namespace_handler.cpp
+++ b/src/subscribe_namespace_handler.cpp
@@ -36,28 +36,6 @@ quicr::SubscribeNamespaceHandler::~SubscribeNamespaceHandler()
 void
 quicr::SubscribeNamespaceHandler::StatusChanged(Status status)
 {
-    auto th = quicr::TrackHash({ GetPrefix(), {} });
-
-    switch (status) {
-        case Status::kOk:
-            QUICR_TRACE("Subscription to namespace with hash: {} status changed to OK", th.track_namespace_hash);
-            break;
-        case Status::kNotSubscribed:
-            QUICR_TRACE("Subscription to namespace with hash: {} status changed to NOT_SUBSCRIBED",
-                        th.track_namespace_hash);
-            break;
-        case Status::kError:
-            if (error_ != std::nullopt) {
-                QUICR_ERROR("Subscription to namespace with hash: {} status changed to ERROR: {}",
-                            th.track_namespace_hash,
-                            std::string(error_->second.begin(), error_->second.end()));
-            } else {
-                QUICR_ERROR("Subscription to namespace with hash: {} status changed to unknown ERROR");
-            }
-            break;
-        default:
-            break;
-    }
 }
 
 void

--- a/src/subscribe_namespace_handler.cpp
+++ b/src/subscribe_namespace_handler.cpp
@@ -1,10 +1,9 @@
 #include "quicr/handlers/subscribe_namespace_handler.h"
 #include "quicr/handlers/subscribe_track_handler.h"
+#include "quicr/log.h"
 #include "quicr/messages/messages.h"
 #include "quicr/messages/parameters.h"
 #include "quicr/session.h"
-
-#include <spdlog/spdlog.h>
 
 quicr::SubscribeNamespaceHandler::SubscribeNamespaceHandler(const TrackNamespace& prefix,
                                                             const Mode mode,
@@ -41,19 +40,19 @@ quicr::SubscribeNamespaceHandler::StatusChanged(Status status)
 
     switch (status) {
         case Status::kOk:
-            SPDLOG_TRACE("Subscription to namespace with hash: {} status changed to OK", th.track_namespace_hash);
+            QUICR_TRACE("Subscription to namespace with hash: {} status changed to OK", th.track_namespace_hash);
             break;
         case Status::kNotSubscribed:
-            SPDLOG_TRACE("Subscription to namespace with hash: {} status changed to NOT_SUBSCRIBED",
-                         th.track_namespace_hash);
+            QUICR_TRACE("Subscription to namespace with hash: {} status changed to NOT_SUBSCRIBED",
+                        th.track_namespace_hash);
             break;
         case Status::kError:
             if (error_ != std::nullopt) {
-                SPDLOG_ERROR("Subscription to namespace with hash: {} status changed to ERROR: {}",
-                             th.track_namespace_hash,
-                             std::string(error_->second.begin(), error_->second.end()));
+                QUICR_ERROR("Subscription to namespace with hash: {} status changed to ERROR: {}",
+                            th.track_namespace_hash,
+                            std::string(error_->second.begin(), error_->second.end()));
             } else {
-                SPDLOG_ERROR("Subscription to namespace with hash: {} status changed to unknown ERROR");
+                QUICR_ERROR("Subscription to namespace with hash: {} status changed to unknown ERROR");
             }
             break;
         default:

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -8,6 +8,7 @@
 #include "quicr/messages/messages.h"
 #include "quicr/messages/parameters.h"
 #include "quicr/session.h"
+#include "quicr/utilities/format.h"
 
 namespace quicr {
 
@@ -28,8 +29,8 @@ namespace quicr {
         auto [it, inserted] =
           streams_.try_emplace(stream_id, StreamContext{ .buffer = std::move(initial_buffer.buffer) });
         if (!inserted) {
-            SPDLOG_ERROR("StreamDataRecv got new stream for existing Stream ID {}", stream_id);
-            return;
+            throw std::runtime_error(
+              quicr::format("StreamDataRecv got new stream for existing Stream ID {}", stream_id));
         }
         TryParseStreamBufferData(it->second);
     }
@@ -38,8 +39,8 @@ namespace quicr {
     {
         const auto it = streams_.find(stream_id);
         if (it == streams_.end()) {
-            SPDLOG_ERROR("StreamDataRecv had no stream for expected Stream ID {}", stream_id);
-            return;
+            throw std::runtime_error(
+              quicr::format("StreamDataRecv had no stream for expected Stream ID {}", stream_id));
         }
         it->second.buffer.Push(*data);
         TryParseStreamBufferData(it->second);
@@ -77,16 +78,6 @@ namespace quicr {
                 stream_properties.emplace(*s_hdr.properties);
             }
 
-            QUICR_TRACE("Received stream_subgroup_object priority: {} track_alias: {} "
-                        "group: {} subgroup: {} object: {} data size: {} type: {}",
-                        s_hdr.priority.value_or(-1),
-                        s_hdr.track_alias,
-                        s_hdr.group_id,
-                        s_hdr.subgroup_id.value_or(-1),
-                        obj.object_delta,
-                        obj.payload.size(),
-                        static_cast<int>(obj.object_status));
-
             if (stream.next_object_id.has_value()) {
                 if (stream.current_group_id != s_hdr.group_id || stream.current_subgroup_id != s_hdr.subgroup_id) {
                     stream.next_object_id = obj.object_delta;
@@ -110,6 +101,7 @@ namespace quicr {
 
             subscribe_track_metrics_.objects_received++;
 
+            std::exception_ptr error;
             try {
                 ObjectReceived(
                   {
@@ -129,10 +121,14 @@ namespace quicr {
 
                 *stream.next_object_id += 1;
             } catch (const std::exception& e) {
-                QUICR_ERROR("Caught exception trying to receive Subscribe object. (error={})", e.what());
+                error = std::make_exception_ptr(e);
             }
 
             stream.buffer.ResetAnyB();
+
+            if (error) {
+                std::rethrow_exception(error);
+            }
         }
     }
 
@@ -146,25 +142,15 @@ namespace quicr {
         if (properties.status) {
             messages::ObjectDatagramStatus status_msg;
             if (dgram_buffer_ >> status_msg) {
-                QUICR_TRACE("Received object datagram status track_alias: {} group_id: {} object_id: {} status: {}",
-                            status_msg.track_alias,
-                            status_msg.group_id,
-                            status_msg.object_id,
-                            static_cast<uint8_t>(status_msg.status));
-
                 subscribe_track_metrics_.objects_received++;
 
-                try {
-                    ObjectStatusReceived(
-                      status_msg.group_id,
-                      status_msg.object_id,
-                      status_msg.priority.value_or(priority_), // TODO: This should be publisher priority.
-                      status_msg.status,
-                      std::move(status_msg.extensions),
-                      std::move(status_msg.immutable_extensions));
-                } catch (const std::exception& e) {
-                    QUICR_ERROR("Caught exception in ObjectStatusReceived. (error={})", e.what());
-                }
+                ObjectStatusReceived(
+                  status_msg.group_id,
+                  status_msg.object_id,
+                  status_msg.priority.value_or(priority_), // TODO: This should be publisher priority.
+                  status_msg.status,
+                  std::move(status_msg.extensions),
+                  std::move(status_msg.immutable_extensions));
             }
             return;
         }
@@ -172,33 +158,24 @@ namespace quicr {
         // Data.
         messages::ObjectDatagram msg;
         if (dgram_buffer_ >> msg) {
-            QUICR_TRACE("Received object datagram (track_alias={}, group_id={}, object_id={}, data size={})",
-                        msg.track_alias,
-                        msg.group_id,
-                        msg.object_id,
-                        msg.payload.size());
 
             subscribe_track_metrics_.objects_received++;
             subscribe_track_metrics_.bytes_received += msg.payload.size();
 
-            try {
-                ObjectReceived(
-                  {
-                    msg.group_id,
-                    msg.object_id,
-                    0, // datagrams don't have subgroups
-                    msg.payload.size(),
-                    ObjectStatus::kAvailable,
-                    msg.priority,
-                    std::nullopt,
-                    TrackMode::kDatagram,
-                    std::move(msg.extensions),
-                    std::move(msg.immutable_extensions),
-                  },
-                  std::move(msg.payload));
-            } catch (const std::exception& e) {
-                QUICR_ERROR("Caught exception trying to receive Subscribe object. (error={})", e.what());
-            }
+            ObjectReceived(
+              {
+                msg.group_id,
+                msg.object_id,
+                0, // datagrams don't have subgroups
+                msg.payload.size(),
+                ObjectStatus::kAvailable,
+                msg.priority,
+                std::nullopt,
+                TrackMode::kDatagram,
+                std::move(msg.extensions),
+                std::move(msg.immutable_extensions),
+              },
+              std::move(msg.payload));
         }
     }
 

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -4,11 +4,10 @@
 #include "quicr/handlers/subscribe_track_handler.h"
 
 #include "quicr/containers/stream_buffer.h"
+#include "quicr/log.h"
 #include "quicr/messages/messages.h"
 #include "quicr/messages/parameters.h"
 #include "quicr/session.h"
-
-#include <spdlog/spdlog.h>
 
 namespace quicr {
 
@@ -78,15 +77,15 @@ namespace quicr {
                 stream_properties.emplace(*s_hdr.properties);
             }
 
-            SPDLOG_TRACE("Received stream_subgroup_object priority: {} track_alias: {} "
-                         "group: {} subgroup: {} object: {} data size: {} type: {}",
-                         s_hdr.priority,
-                         s_hdr.track_alias,
-                         s_hdr.group_id,
-                         s_hdr.subgroup_id.has_value() ? *s_hdr.subgroup_id : -1,
-                         obj.object_delta,
-                         obj.payload.size(),
-                         static_cast<int>(obj.object_status));
+            QUICR_TRACE("Received stream_subgroup_object priority: {} track_alias: {} "
+                        "group: {} subgroup: {} object: {} data size: {} type: {}",
+                        s_hdr.priority,
+                        s_hdr.track_alias,
+                        s_hdr.group_id,
+                        s_hdr.subgroup_id.has_value() ? *s_hdr.subgroup_id : -1,
+                        obj.object_delta,
+                        obj.payload.size(),
+                        static_cast<int>(obj.object_status));
 
             if (stream.next_object_id.has_value()) {
                 if (stream.current_group_id != s_hdr.group_id || stream.current_subgroup_id != s_hdr.subgroup_id) {
@@ -130,7 +129,7 @@ namespace quicr {
 
                 *stream.next_object_id += 1;
             } catch (const std::exception& e) {
-                SPDLOG_ERROR("Caught exception trying to receive Subscribe object. (error={})", e.what());
+                QUICR_ERROR("Caught exception trying to receive Subscribe object. (error={})", e.what());
             }
 
             stream.buffer.ResetAnyB();
@@ -147,11 +146,11 @@ namespace quicr {
         if (properties.status) {
             messages::ObjectDatagramStatus status_msg;
             if (dgram_buffer_ >> status_msg) {
-                SPDLOG_TRACE("Received object datagram status track_alias: {} group_id: {} object_id: {} status: {}",
-                             status_msg.track_alias,
-                             status_msg.group_id,
-                             status_msg.object_id,
-                             static_cast<uint8_t>(status_msg.status));
+                QUICR_TRACE("Received object datagram status track_alias: {} group_id: {} object_id: {} status: {}",
+                            status_msg.track_alias,
+                            status_msg.group_id,
+                            status_msg.object_id,
+                            static_cast<uint8_t>(status_msg.status));
 
                 subscribe_track_metrics_.objects_received++;
 
@@ -164,7 +163,7 @@ namespace quicr {
                       std::move(status_msg.extensions),
                       std::move(status_msg.immutable_extensions));
                 } catch (const std::exception& e) {
-                    SPDLOG_ERROR("Caught exception in ObjectStatusReceived. (error={})", e.what());
+                    QUICR_ERROR("Caught exception in ObjectStatusReceived. (error={})", e.what());
                 }
             }
             return;
@@ -173,15 +172,15 @@ namespace quicr {
         // Data.
         messages::ObjectDatagram msg;
         if (dgram_buffer_ >> msg) {
-            SPDLOG_TRACE("Received object datagram conn_id: {0} data_ctx_id: {1} subscriber_id: {2} "
-                         "track_alias: {3} group_id: {4} object_id: {5} data size: {6}",
-                         conn_id,
-                         (data_ctx_id ? *data_ctx_id : 0),
-                         msg.subscribe_id,
-                         msg.track_alias,
-                         msg.group_id,
-                         msg.object_id,
-                         msg.payload.size());
+            QUICR_TRACE("Received object datagram conn_id: {0} data_ctx_id: {1} subscriber_id: {2} "
+                        "track_alias: {3} group_id: {4} object_id: {5} data size: {6}",
+                        conn_id,
+                        (data_ctx_id ? *data_ctx_id : 0),
+                        msg.subscribe_id,
+                        msg.track_alias,
+                        msg.group_id,
+                        msg.object_id,
+                        msg.payload.size());
 
             subscribe_track_metrics_.objects_received++;
             subscribe_track_metrics_.bytes_received += msg.payload.size();
@@ -202,7 +201,7 @@ namespace quicr {
                   },
                   std::move(msg.payload));
             } catch (const std::exception& e) {
-                SPDLOG_ERROR("Caught exception trying to receive Subscribe object. (error={})", e.what());
+                QUICR_ERROR("Caught exception trying to receive Subscribe object. (error={})", e.what());
             }
         }
     }

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -79,10 +79,10 @@ namespace quicr {
 
             QUICR_TRACE("Received stream_subgroup_object priority: {} track_alias: {} "
                         "group: {} subgroup: {} object: {} data size: {} type: {}",
-                        s_hdr.priority,
+                        s_hdr.priority.value_or(-1),
                         s_hdr.track_alias,
                         s_hdr.group_id,
-                        s_hdr.subgroup_id.has_value() ? *s_hdr.subgroup_id : -1,
+                        s_hdr.subgroup_id.value_or(-1),
                         obj.object_delta,
                         obj.payload.size(),
                         static_cast<int>(obj.object_status));
@@ -172,11 +172,7 @@ namespace quicr {
         // Data.
         messages::ObjectDatagram msg;
         if (dgram_buffer_ >> msg) {
-            QUICR_TRACE("Received object datagram conn_id: {0} data_ctx_id: {1} subscriber_id: {2} "
-                        "track_alias: {3} group_id: {4} object_id: {5} data size: {6}",
-                        conn_id,
-                        (data_ctx_id ? *data_ctx_id : 0),
-                        msg.subscribe_id,
+            QUICR_TRACE("Received object datagram (track_alias={}, group_id={}, object_id={}, data size={})",
                         msg.track_alias,
                         msg.group_id,
                         msg.object_id,

--- a/src/transport.cpp
+++ b/src/transport.cpp
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include "quicr/transport.h"
+#include "quicr/log.h"
 #include "transport_picoquic.h"
-
-#include <spdlog/logger.h>
 
 #include <memory>
 #include <stdexcept>
@@ -17,7 +16,7 @@ namespace quicr {
     std::shared_ptr<Transport> Transport::MakeClientTransport(const TransportRemote& server,
                                                               const TransportConfig& tcfg,
                                                               std::shared_ptr<timeq::tick_service> tick_service,
-                                                              std::shared_ptr<spdlog::logger> logger)
+                                                              std::shared_ptr<Logger> logger)
     {
         switch (server.proto) {
             case TransportProtocol::kQuic:
@@ -37,7 +36,7 @@ namespace quicr {
     std::shared_ptr<Transport> Transport::MakeServerTransport(const TransportRemote& server,
                                                               const TransportConfig& tcfg,
                                                               std::shared_ptr<timeq::tick_service> tick_service,
-                                                              std::shared_ptr<spdlog::logger> logger)
+                                                              std::shared_ptr<Logger> logger)
     {
         // Server mode supports BOTH raw QUIC (moq-00) and WebTransport (h3) simultaneously.
         //

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -151,7 +151,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
 
             if (data_ctx == NULL) {
                 // picoquic calls this again even after reset/fin, here we ignore it
-                QUICR_LOGGER_INFO(transport->logger, "conn_id: {} stream_id: {} context is null", conn_id, stream_id);
+                QUICR_LOGGER_INFO(transport->logger_, "conn_id: {} stream_id: {} context is null", conn_id, stream_id);
                 break;
             }
 
@@ -192,7 +192,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
                 transport->OnRecvStreamBytes(connection, data_ctx, stream_id, is_fin, std::span{ bytes, length });
 
                 if (is_fin) {
-                    QUICR_LOGGER_DEBUG(transport->logger, "Received FIN for stream {}", stream_id);
+                    QUICR_LOGGER_DEBUG(transport->logger_, "Received FIN for stream {}", stream_id);
 
                     picoquic_reset_stream_ctx(pq_cnx, stream_id);
 
@@ -217,13 +217,13 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
         case picoquic_callback_stop_sending:
             // Stop sending is basically a reset initiated by the other side. MOQT suggests to RESET on this
             QUICR_LOGGER_DEBUG(
-              transport->logger, "Received STOP_SENDING stream conn_id: {} stream_id: {}", conn_id, stream_id);
+              transport->logger_, "Received STOP_SENDING stream conn_id: {} stream_id: {}", conn_id, stream_id);
             picoquic_reset_stream(pq_cnx, stream_id, 0);
             [[fallthrough]];
 
         case picoquic_callback_stream_reset: {
             QUICR_LOGGER_DEBUG(
-              transport->logger, "Received RESET stream conn_id: {} stream_id: {}", conn_id, stream_id);
+              transport->logger_, "Received RESET stream conn_id: {} stream_id: {}", conn_id, stream_id);
 
             picoquic_reset_stream_ctx(pq_cnx, stream_id);
 
@@ -237,7 +237,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
 
                 if (data_ctx != nullptr) {
                     QUICR_LOGGER_DEBUG(
-                      transport->logger,
+                      transport->logger_,
                       "Received RESET stream with data context; conn_id: {} data_ctx_id: {} stream_id: {}",
                       data_ctx->conn_id,
                       data_ctx->data_ctx_id,
@@ -277,7 +277,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
             picoquic_get_path_quality(pq_cnx, pq_cnx->path[0]->unique_path_id, &path_quality);
 
             QUICR_LOGGER_INFO(
-              transport->logger,
+              transport->logger_,
               "Pacing rate changed; conn_id: {} rate Kbps: {} cwin_bytes: {} rtt_us: {} rate Kbps: {} cwin_bytes: "
               "{} rtt_us: {} rtt_max: {} rtt_sample: {} lost_pkts: {} bytes_in_transit: {} recv_rate_Kbps: {}",
               conn_id,
@@ -296,7 +296,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
         }
 
         case picoquic_callback_application_close:
-            QUICR_LOGGER_INFO(transport->logger, "Application closed conn_id: {}", conn_id);
+            QUICR_LOGGER_INFO(transport->logger_, "Application closed conn_id: {}", conn_id);
             [[fallthrough]];
         case picoquic_callback_close: {
             uint64_t app_reason_code = picoquic_get_application_error(pq_cnx);
@@ -323,7 +323,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
                 log_msg << " remote: " << connection->peer_addr_text;
             }
 
-            QUICR_LOGGER_INFO(transport->logger, log_msg.str());
+            QUICR_LOGGER_INFO(transport->logger_, log_msg.str());
 
             switch (app_reason_code) {
                 case static_cast<uint64_t>(AppReasonForClose::kIdleTimeout):
@@ -349,7 +349,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
 
         case picoquic_callback_ready: { // Connection callback, not per stream
             if (transport->is_server_mode) {
-                QUICR_LOGGER_INFO(transport->logger,
+                QUICR_LOGGER_INFO(transport->logger_,
                                   "PqEventCb: Creating connection context in picoquic_callback_ready");
                 transport->HandleNewConnection(transport->CreateConnection(pq_cnx));
             } else {
@@ -368,7 +368,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
         }
 
         default:
-            QUICR_LOGGER_DEBUG(transport->logger, "Got event {}", static_cast<int>(fin_or_event));
+            QUICR_LOGGER_DEBUG(transport->logger_, "Got event {}", static_cast<int>(fin_or_event));
             break;
     }
 
@@ -397,7 +397,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
 
     switch (cb_mode) {
         case picoquic_packet_loop_ready: {
-            QUICR_LOGGER_INFO(transport->logger, "packet_loop_ready, waiting for packets");
+            QUICR_LOGGER_INFO(transport->logger_, "packet_loop_ready, waiting for packets");
 
             if (transport->is_server_mode)
                 transport->SetStatus(TransportStatus::kReady);
@@ -421,7 +421,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
             break;
 
         case picoquic_packet_loop_port_update:
-            QUICR_LOGGER_DEBUG(transport->logger, "packet_loop_port_update");
+            QUICR_LOGGER_DEBUG(transport->logger_, "packet_loop_port_update");
             break;
 
         case picoquic_packet_loop_time_check: {
@@ -463,7 +463,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
             }
 
             if (transport->Status() == TransportStatus::kShuttingDown) {
-                QUICR_LOGGER_INFO(transport->logger, "picoquic is shutting down");
+                QUICR_LOGGER_INFO(transport->logger_, "picoquic is shutting down");
 
                 picoquic_cnx_t* close_cnx = picoquic_get_first_cnx(quic);
 
@@ -474,7 +474,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
 
                 while (close_cnx != NULL) {
                     QUICR_LOGGER_INFO(
-                      transport->logger, "Closing connection id {}", reinterpret_cast<uint64_t>(close_cnx));
+                      transport->logger_, "Closing connection id {}", reinterpret_cast<uint64_t>(close_cnx));
                     transport->CloseInternal(transport->GetConnection(reinterpret_cast<uint64_t>(close_cnx)),
                                              AppReasonForClose::kShutdown);
                     close_cnx = picoquic_get_next_cnx(close_cnx);
@@ -488,7 +488,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
 
         default:
             // ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
-            QUICR_LOGGER_WARN(transport->logger, "pq_loop_cb() does not implement ", std::to_string(cb_mode));
+            QUICR_LOGGER_WARN(transport->logger_, "pq_loop_cb() does not implement ", std::to_string(cb_mode));
             break;
     }
 
@@ -542,7 +542,7 @@ GetConnCtxForWT(PicoQuicTransport* transport, std::uint64_t conn_id, picohttp_ca
     auto connection = transport->GetConnection(conn_id);
     if (!connection) {
         QUICR_LOGGER_WARN(
-          transport->logger, "DefaultWT: {} No connection context for conn_id {}", WtEventToString(wt_event), conn_id);
+          transport->logger_, "DefaultWT: {} No connection context for conn_id {}", WtEventToString(wt_event), conn_id);
     }
     return connection;
 }
@@ -602,13 +602,13 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_connecting:
             // Called when initiating WebTransport connect
             QUICR_LOGGER_TRACE(
-              transport->logger, "DefaultWT: {} for connection {}", WtEventToString(wt_event), conn_id);
+              transport->logger_, "DefaultWT: {} for connection {}", WtEventToString(wt_event), conn_id);
             break;
 
         case picohttp_callback_connect:
             /* A connect has been received on this stream, and could be accepted.
              */
-            QUICR_LOGGER_TRACE(transport->logger,
+            QUICR_LOGGER_TRACE(transport->logger_,
                                "DefaultWT: {} connect received on path for connection {}",
                                WtEventToString(wt_event),
                                conn_id);
@@ -620,20 +620,21 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
                 ret = transport->AcceptWebTransportConnection(cnx, bytes, length, stream_ctx);
                 if (ret != 0) {
                     QUICR_LOGGER_ERROR(
-                      transport->logger, "DefaultWT: Failed to accept WebTransport connection {}", conn_id);
+                      transport->logger_, "DefaultWT: Failed to accept WebTransport connection {}", conn_id);
                 }
             }
             break;
 
         case picohttp_callback_connect_refused:
-            QUICR_LOGGER_WARN(transport->logger, "DefaultWT: {} for connection {}", WtEventToString(wt_event), conn_id);
+            QUICR_LOGGER_WARN(
+              transport->logger_, "DefaultWT: {} for connection {}", WtEventToString(wt_event), conn_id);
             if (auto connection = transport->GetConnection(conn_id)) {
                 transport->OnConnectionStatus(connection, TransportStatus::kDisconnected);
             }
             break;
 
         case picohttp_callback_connect_accepted:
-            QUICR_LOGGER_TRACE(transport->logger,
+            QUICR_LOGGER_TRACE(transport->logger_,
                                "DefaultWT: {} for connection {}, h3 stream {}",
                                WtEventToString(wt_event),
                                conn_id,
@@ -649,7 +650,7 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_post_fin: {
             // Data received on a stream - similar to picoquic_callback_stream_data in PqEventCb
             if (!stream_ctx) {
-                QUICR_LOGGER_TRACE(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
+                QUICR_LOGGER_TRACE(transport->logger_, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
                 return -1;
             }
 
@@ -657,14 +658,14 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
             bool is_fin = (wt_event == picohttp_callback_post_fin);
 
             if (is_fin) {
-                QUICR_LOGGER_DEBUG(transport->logger,
+                QUICR_LOGGER_DEBUG(transport->logger_,
                                    "DefaultWT: {} conn_id: {} stream_id: {} FIN",
                                    WtEventToString(wt_event),
                                    conn_id,
                                    stream_id);
             }
 
-            QUICR_LOGGER_TRACE(transport->logger,
+            QUICR_LOGGER_TRACE(transport->logger_,
                                "DefaultWT: {} received {} bytes on stream {} for connection {}, is_fin {}",
                                WtEventToString(wt_event),
                                length,
@@ -712,7 +713,7 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
             }
 
             if (is_fin) {
-                QUICR_LOGGER_TRACE(transport->logger,
+                QUICR_LOGGER_TRACE(transport->logger_,
                                    "DefaultWT: {} Received FIN for connection{}, stream {}",
                                    WtEventToString(wt_event),
                                    conn_id,
@@ -739,13 +740,13 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_provide_data: {
             // Stack is ready to send data on a stream - similar to picoquic_callback_prepare_to_send in PqEventCb
             if (!stream_ctx) {
-                QUICR_LOGGER_WARN(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
+                QUICR_LOGGER_WARN(transport->logger_, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
                 return -1;
             }
 
             uint64_t stream_id = stream_ctx->stream_id;
 
-            QUICR_LOGGER_TRACE(transport->logger,
+            QUICR_LOGGER_TRACE(transport->logger_,
                                "DefaultWT: {} for connection {}, h3 stream {}",
                                WtEventToString(wt_event),
                                conn_id,
@@ -760,7 +761,7 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
             if (data_ctx == nullptr) {
                 // No data context, nothing to send
                 QUICR_LOGGER_TRACE(
-                  transport->logger, "DefaultWT: {} no data_ctx for stream {}", WtEventToString(wt_event), stream_id);
+                  transport->logger_, "DefaultWT: {} no data_ctx for stream {}", WtEventToString(wt_event), stream_id);
                 break;
             }
 
@@ -771,7 +772,7 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
 
             data_ctx->metrics.tx_stream_cb++;
 
-            QUICR_LOGGER_TRACE(transport->logger,
+            QUICR_LOGGER_TRACE(transport->logger_,
                                "DefaultWT: {} Invoking to send stream bytes on stream {}",
                                WtEventToString(wt_event),
                                length,
@@ -784,7 +785,7 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
 
         case picohttp_callback_post_datagram: {
             // Datagram received
-            QUICR_LOGGER_TRACE(transport->logger,
+            QUICR_LOGGER_TRACE(transport->logger_,
                                "DefaultWT: {} received {} bytes for connection {}",
                                WtEventToString(wt_event),
                                length,
@@ -812,13 +813,13 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_reset: {
             // Stream has been abandoned
             if (!stream_ctx) {
-                QUICR_LOGGER_WARN(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
+                QUICR_LOGGER_WARN(transport->logger_, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
                 return -1;
             }
 
             uint64_t stream_id = stream_ctx->stream_id;
 
-            QUICR_LOGGER_DEBUG(transport->logger,
+            QUICR_LOGGER_DEBUG(transport->logger_,
                                "DefaultWT: {} for stream {} on connection {}",
                                WtEventToString(wt_event),
                                stream_id,
@@ -849,13 +850,13 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_stop_sending: {
             // Peer wants to abandon receiving on the stream
             if (!stream_ctx) {
-                QUICR_LOGGER_WARN(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
+                QUICR_LOGGER_WARN(transport->logger_, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
                 return -1;
             }
 
             uint64_t stream_id = stream_ctx->stream_id;
 
-            QUICR_LOGGER_DEBUG(transport->logger,
+            QUICR_LOGGER_DEBUG(transport->logger_,
                                "DefaultWT: {} for stream {} on connection {}",
                                WtEventToString(wt_event),
                                stream_id,
@@ -886,14 +887,14 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_free:
             // Clean up the stream
             QUICR_LOGGER_DEBUG(
-              transport->logger, "DefaultWT: {} callback for connection {}", WtEventToString(wt_event), conn_id);
+              transport->logger_, "DefaultWT: {} callback for connection {}", WtEventToString(wt_event), conn_id);
             break;
 
         case picohttp_callback_deregister: {
             // The app context has been removed from the registry.
             // Its references should be removed from streams belonging to this session.
             QUICR_LOGGER_DEBUG(
-              transport->logger, "DefaultWT: {} callback for connection {}", WtEventToString(wt_event), conn_id);
+              transport->logger_, "DefaultWT: {} callback for connection {}", WtEventToString(wt_event), conn_id);
 
             transport->DeregisterWebTransport(cnx);
 
@@ -982,17 +983,17 @@ PicoQuicTransport::Start()
 #endif
 
     if (tconfig_.use_reset_wait_strategy) {
-        QUICR_LOGGER_INFO(logger, "Using Reset and Wait congestion control strategy");
+        QUICR_LOGGER_INFO(logger_, "Using Reset and Wait congestion control strategy");
     }
 
     // Initialize WebTransport
     if (auto wt_ret = InitializeWebTransportContext(); wt_ret != 0) {
-        QUICR_LOGGER_ERROR(logger, "Failed to initialize WebTransport");
+        QUICR_LOGGER_ERROR(logger_, "Failed to initialize WebTransport");
         return nullptr;
     }
 
     if (not tconfig_.use_bbr) {
-        QUICR_LOGGER_INFO(logger, "Using NewReno congestion control");
+        QUICR_LOGGER_INFO(logger_, "Using NewReno congestion control");
         (void)picoquic_config_set_option(&config_, picoquic_option_CC_ALGO, "reno");
     }
 
@@ -1006,7 +1007,7 @@ PicoQuicTransport::Start()
       &config_, picoquic_option_MAX_CONNECTIONS, std::to_string(tconfig_.max_connections).c_str());
 
     if (is_server_mode) {
-        QUICR_LOGGER_DEBUG(logger, "Start: As Server, configuring WebTransport Path Params");
+        QUICR_LOGGER_DEBUG(logger_, "Start: As Server, configuring WebTransport Path Params");
 
         // Store path items in the class member to ensure memory persists after Start() returns
         wt_config_->path_items = { { serverInfo_.path.c_str(), 6, DefaultWebTransportCallback, this } };
@@ -1026,22 +1027,22 @@ PicoQuicTransport::Start()
         picoquic_use_unique_log_names(quic_ctx_, 1);
     } else {
         if (connection_api == Connection::API::kWebTransport) {
-            QUICR_LOGGER_INFO(logger, "Client configured for WebTransport over QUIC");
+            QUICR_LOGGER_INFO(logger_, "Client configured for WebTransport over QUIC");
             quic_ctx_ = picoquic_create_and_configure(&config_, NULL, NULL, current_time, NULL);
         } else {
-            QUICR_LOGGER_INFO(logger, "Client configured for Raw QUIC");
+            QUICR_LOGGER_INFO(logger_, "Client configured for Raw QUIC");
             quic_ctx_ = picoquic_create_and_configure(&config_, PqEventCb, this, current_time, NULL);
         }
     }
 
     if (quic_ctx_ == NULL) {
-        QUICR_LOGGER_CRITICAL(logger, "Unable to create picoquic context, check certificate and key filenames");
+        QUICR_LOGGER_CRITICAL(logger_, "Unable to create picoquic context, check certificate and key filenames");
         throw PicoQuicException("Unable to create picoquic context");
     }
 
     if (config_.enable_sslkeylog) {
         if (std::getenv("SSLKEYLOGFILE") == nullptr) {
-            QUICR_LOGGER_WARN(logger, "Key log enabled but $SSLKEYLOGFILE not set");
+            QUICR_LOGGER_WARN(logger_, "Key log enabled but $SSLKEYLOGFILE not set");
         }
         picoquic_set_key_log_file_from_env(quic_ctx_);
     }
@@ -1077,7 +1078,7 @@ PicoQuicTransport::Start()
     picoquic_set_default_priority(quic_ctx_, 2);
     picoquic_set_default_datagram_priority(quic_ctx_, 1);
 
-    QUICR_LOGGER_INFO(logger, "Setting idle timeout to {}ms", tconfig_.idle_timeout_ms);
+    QUICR_LOGGER_INFO(logger_, "Setting idle timeout to {}ms", tconfig_.idle_timeout_ms);
 
     picoquic_runner_queue_.SetLimit(tconfig_.callback_queue_size);
 
@@ -1085,7 +1086,7 @@ PicoQuicTransport::Start()
     cbNotifyThread_ = std::thread(&PicoQuicTransport::CbNotifier, this);
 
     if (!tconfig_.quic_qlog_path.empty()) {
-        QUICR_LOGGER_INFO(logger, "Enabling qlog using '{}' path", tconfig_.quic_qlog_path);
+        QUICR_LOGGER_INFO(logger_, "Enabling qlog using '{}' path", tconfig_.quic_qlog_path);
         picoquic_set_qlog(quic_ctx_, tconfig_.quic_qlog_path.c_str());
     }
 
@@ -1093,11 +1094,11 @@ PicoQuicTransport::Start()
 
     if (is_server_mode) {
 
-        QUICR_LOGGER_INFO(logger, "Starting server, listening on {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
+        QUICR_LOGGER_INFO(logger_, "Starting server, listening on {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
         Server();
 
     } else {
-        QUICR_LOGGER_INFO(logger, "Connecting to server {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
+        QUICR_LOGGER_INFO(logger_, "Connecting to server {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
 
         if (ClientLoop()) {
             return StartClient();
@@ -1127,7 +1128,7 @@ PicoQuicTransport::Enqueue(const std::shared_ptr<Connection>& connection,
                            [[maybe_unused]] const uint32_t delay_ms,
                            const EnqueueFlags flags)
 {
-    QUICR_LOGGER_TRACE(logger,
+    QUICR_LOGGER_TRACE(logger_,
                        "Enqueue conn_id: {} data_ctx_id: {} stream_id: {} size: {}",
                        connection->GetID(),
                        data_ctx_id,
@@ -1277,7 +1278,7 @@ PicoQuicTransport::CreateDataContext(const std::shared_ptr<Connection>& connecti
 
         if (!use_reliable_transport) {
             picoquic_set_datagram_priority(pq_conn->pq_cnx, priority);
-            QUICR_LOGGER_DEBUG(logger,
+            QUICR_LOGGER_DEBUG(logger_,
                                "Created DGRAM data context id: {} pri: {}",
                                data_ctx_it->second.data_ctx_id,
                                static_cast<int>(priority));
@@ -1307,7 +1308,7 @@ PicoQuicTransport::Close(const std::shared_ptr<Connection>& connection, AppReaso
 
     // TODO: Maybe this timeout should be configurable?
     if (future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout) {
-        QUICR_LOGGER_ERROR(logger, "Timed out waiting for connection to close (conn_id={})", connection->GetID());
+        QUICR_LOGGER_ERROR(logger_, "Timed out waiting for connection to close (conn_id={})", connection->GetID());
     }
 }
 
@@ -1387,7 +1388,7 @@ PicoQuicTransport::CloseInternal(const std::shared_ptr<Connection>& connection, 
     // Cleanup client-owned WebTransport h3_ctx before closing connection
     // Server-side h3_ctx is managed by h3zero library and shared across connections
     if (pq_conn->wt_h3_ctx_owned && pq_conn->wt_h3_ctx) {
-        QUICR_LOGGER_DEBUG(logger, "Cleaning up client-owned h3_ctx for connection {}", connection->GetID());
+        QUICR_LOGGER_DEBUG(logger_, "Cleaning up client-owned h3_ctx for connection {}", connection->GetID());
         // Note: h3zero_callback_delete_context may not exist in all versions
         // The h3zero library typically cleans this up automatically on connection close
         // So we just mark it as null here
@@ -1438,17 +1439,17 @@ PicoQuicTransport::CreateConnection(picoquic_cnx_t* pq_cnx, Connection::API api)
         if (negotiated_alpn) {
             if (strcmp(negotiated_alpn, webtransport_alpn) == 0) {
                 api = Connection::API::kWebTransport;
-                QUICR_LOGGER_INFO(logger, "Server connection using WebTransport (ALPN: {})", negotiated_alpn);
+                QUICR_LOGGER_INFO(logger_, "Server connection using WebTransport (ALPN: {})", negotiated_alpn);
             } else if (strcmp(negotiated_alpn, kMoqtAlpn) == 0) {
                 api = Connection::API::kNativeQuic;
-                QUICR_LOGGER_INFO(logger, "Server connection using raw QUIC (ALPN: {})", negotiated_alpn);
+                QUICR_LOGGER_INFO(logger_, "Server connection using raw QUIC (ALPN: {})", negotiated_alpn);
             } else {
                 api = Connection::API::kNativeQuic; // Default fallback
-                QUICR_LOGGER_WARN(logger, "Unknown ALPN: {}, defaulting to raw QUIC", negotiated_alpn);
+                QUICR_LOGGER_WARN(logger_, "Unknown ALPN: {}, defaulting to raw QUIC", negotiated_alpn);
             }
         } else {
             api = Connection::API::kNativeQuic; // Default fallback
-            QUICR_LOGGER_WARN(logger, "No ALPN negotiated, defaulting to raw QUIC");
+            QUICR_LOGGER_WARN(logger_, "No ALPN negotiated, defaulting to raw QUIC");
         }
     }
 
@@ -1481,7 +1482,7 @@ PicoQuicTransport::CreateConnection(picoquic_cnx_t* pq_cnx, Connection::API api)
     }
 
     if (is_new) {
-        QUICR_LOGGER_INFO(logger, "Created new connection context for conn_id: {}", connection->GetID());
+        QUICR_LOGGER_INFO(logger_, "Created new connection context for conn_id: {}", connection->GetID());
 
         connection->dgram_rx_data->SetLimit(tconfig_.time_queue_rx_size);
         connection->dgram_tx_data = std::make_shared<PriorityQueue<ConnData>>(tconfig_.time_queue_max_duration,
@@ -1499,7 +1500,7 @@ PicoQuicTransport::PicoQuicTransport(const TransportRemote& server,
                                      std::shared_ptr<timeq::tick_service> tick_service,
                                      std::shared_ptr<Logger> logger,
                                      Connection::API connection_api)
-  : logger(std::move(logger))
+  : logger_(std::move(logger))
   , is_server_mode(is_server_mode)
   , connection_api(connection_api)
   , stop_(false)
@@ -1552,7 +1553,7 @@ PicoQuicTransport::CreateDataContextBiDirRecv(std::uint64_t conn_id, uint64_t st
 
     const auto conn_it = connections_.find(conn_id);
     if (conn_it == connections_.end()) {
-        QUICR_LOGGER_ERROR(logger, "Invalid conn_id: {}, cannot create data context", conn_id);
+        QUICR_LOGGER_ERROR(logger_, "Invalid conn_id: {}, cannot create data context", conn_id);
         return nullptr;
     }
 
@@ -1570,7 +1571,7 @@ PicoQuicTransport::CreateDataContextBiDirRecv(std::uint64_t conn_id, uint64_t st
                                                                    tconfig_.time_queue_init_queue_size);
         data_ctx_it->second.streams[stream_id] = std::move(stream);
 
-        QUICR_LOGGER_INFO(logger,
+        QUICR_LOGGER_INFO(logger_,
                           "Created new bidir data context conn_id: {} data_ctx_id: {} stream_id: {}",
                           conn_id,
                           data_ctx_it->second.data_ctx_id,
@@ -1593,12 +1594,12 @@ PicoQuicTransport::PqRunner()
     while (auto cb = picoquic_runner_queue_.Pop()) {
         try {
             if (auto ret = (*cb)()) {
-                QUICR_LOGGER_ERROR(logger, "PQ function resulted in error: {}", ret);
+                QUICR_LOGGER_ERROR(logger_, "PQ function resulted in error: {}", ret);
                 return ret;
             }
         } catch (const std::exception& e) {
             QUICR_LOGGER_ERROR(
-              logger, "Caught exception running callback via notify thread (error={}), ignoring", e.what());
+              logger_, "Caught exception running callback via notify thread (error={}), ignoring", e.what());
             // TODO(tievens): Add metrics to track if this happens
         }
     }
@@ -1616,7 +1617,7 @@ PicoQuicTransport::DeleteDataContextInternal(const std::shared_ptr<PicoQuicConne
         return;
 
     const auto& streams = data_ctx_it->second.streams;
-    QUICR_LOGGER_DEBUG(logger,
+    QUICR_LOGGER_DEBUG(logger_,
                        "Delete data context {} in conn_id: {} doe: {} / {} stream count: {}",
                        data_ctx_id,
                        connection->GetID(),
@@ -1627,7 +1628,7 @@ PicoQuicTransport::DeleteDataContextInternal(const std::shared_ptr<PicoQuicConne
     if (delete_on_empty && !streams.empty()) {
         data_ctx_it->second.delete_on_empty = true;
         QUICR_LOGGER_DEBUG(
-          logger, "Delete data context {} in conn_id: {} using delete on empty", data_ctx_id, connection->GetID());
+          logger_, "Delete data context {} in conn_id: {} using delete on empty", data_ctx_id, connection->GetID());
 
         // Delegate removal of stream to SendStreamBytes() to ensure all data is transmitted before closing stream
         void* stream_ctx = nullptr;
@@ -1644,7 +1645,7 @@ PicoQuicTransport::DeleteDataContextInternal(const std::shared_ptr<PicoQuicConne
         }
 
     } else {
-        QUICR_LOGGER_DEBUG(logger, "Delete data context {} in conn_id: {}", data_ctx_id, connection->GetID());
+        QUICR_LOGGER_DEBUG(logger_, "Delete data context {} in conn_id: {}", data_ctx_id, connection->GetID());
 
         std::vector<std::uint64_t> stream_ids;
         stream_ids.reserve(streams.size());
@@ -1707,7 +1708,7 @@ PicoQuicTransport::SendNextDatagram(const std::shared_ptr<PicoQuicConnection>& c
     if (out_data.has_value()) {
         const auto data_ctx_it = connection->active_data_contexts.find(out_data->get().data_ctx_id);
         if (data_ctx_it == connection->active_data_contexts.end()) {
-            QUICR_LOGGER_DEBUG(logger,
+            QUICR_LOGGER_DEBUG(logger_,
                                "send_next_dgram has no data context conn_id: {} data len: {} dropping",
                                connection->GetID(),
                                out_data->get().data->size());
@@ -1716,7 +1717,7 @@ PicoQuicTransport::SendNextDatagram(const std::shared_ptr<PicoQuicConnection>& c
         }
 
         if (out_data->get().data == nullptr || out_data->get().data->size() == 0) {
-            QUICR_LOGGER_ERROR(logger,
+            QUICR_LOGGER_ERROR(logger_,
                                "conn_id: {} data_ctx_id: {} has ZERO data size",
                                data_ctx_it->second.conn_id,
                                data_ctx_it->second.data_ctx_id);
@@ -1766,7 +1767,7 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
 
     auto stream_it = data_ctx->streams.find(stream_id);
     if (stream_it == data_ctx->streams.end()) {
-        QUICR_LOGGER_WARN(logger,
+        QUICR_LOGGER_WARN(logger_,
                           "SendStreamBytes conn_id: {} data_ctx_id: {} stream_id: {} bytes_len: {}, stream not found",
                           data_ctx->conn_id,
                           data_ctx->data_ctx_id,
@@ -1778,7 +1779,7 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
     auto& stream_ctx = stream_it->second;
 
     if (stream_ctx.tx_data == nullptr) {
-        QUICR_LOGGER_WARN(logger,
+        QUICR_LOGGER_WARN(logger_,
                           "SendStreamBytes conn_id: {} data_ctx_id: {} stream_id: {} has no TX queue, skipping",
                           data_ctx->conn_id,
                           data_ctx->data_ctx_id,
@@ -1786,7 +1787,7 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
         return;
     }
 
-    QUICR_LOGGER_TRACE(logger,
+    QUICR_LOGGER_TRACE(logger_,
                        "SendStreamBytes conn_id: {} data_ctx_id: {} stream_id: {} bytes_len: {}",
                        data_ctx->conn_id,
                        data_ctx->data_ctx_id,
@@ -1855,7 +1856,7 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
     }
 
     if (stream_ctx.tx_object == nullptr) {
-        QUICR_LOGGER_TRACE(logger,
+        QUICR_LOGGER_TRACE(logger_,
                            "SendStreamBytes conn_id: {} data_ctx_id: {} stream_tx_object is nullptr",
                            data_ctx->conn_id,
                            data_ctx->data_ctx_id);
@@ -1865,7 +1866,7 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
         if (obj.expired) {
             data_ctx->metrics.tx_queue_expired += obj.expired;
             QUICR_LOGGER_DEBUG(
-              logger,
+              logger_,
               "Send stream objects expired; conn_id: {} data_ctx_id: {} stream_id: {} expired: {} queue_size: {}",
               data_ctx->conn_id,
               data_ctx->data_ctx_id,
@@ -1905,7 +1906,7 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
 
             if (obj.value->stream_action != StreamAction::kNoAction) {
                 QUICR_LOGGER_TRACE(
-                  logger,
+                  logger_,
                   "Object wants New Stream conn_id: {} data_ctx_id: {} stream_id: {}, object size: {} queue_size: {}",
                   data_ctx->conn_id,
                   data_ctx->data_ctx_id,
@@ -1946,7 +1947,7 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
 
     if (buf == NULL) {
         // Error allocating memory to write
-        QUICR_LOGGER_ERROR(logger,
+        QUICR_LOGGER_ERROR(logger_,
                            "conn_id: {} data_ctx_id: {} priority: {} unable to allocate pq buffer size: {}",
                            data_ctx->conn_id,
                            data_ctx->data_ctx_id,
@@ -1973,10 +1974,10 @@ PicoQuicTransport::OnConnectionStatus(const std::shared_ptr<PicoQuicConnection>&
     }
 
     QUICR_LOGGER_DEBUG(
-      logger, "Connection changed conn_id: {} to status: {}", connection->GetID(), static_cast<int>(status));
+      logger_, "Connection changed conn_id: {} to status: {}", connection->GetID(), static_cast<int>(status));
 
     if (status == TransportStatus::kReady) {
-        QUICR_LOGGER_INFO(logger, "Connection established to server {}", connection->peer_addr_text);
+        QUICR_LOGGER_INFO(logger_, "Connection established to server {}", connection->peer_addr_text);
     }
 
     cbNotifyQueue_.Push([connection, status]() { connection->SetStatus(static_cast<Connection::Status>(status)); });
@@ -1985,7 +1986,7 @@ PicoQuicTransport::OnConnectionStatus(const std::shared_ptr<PicoQuicConnection>&
 void
 PicoQuicTransport::HandleNewConnection(const std::shared_ptr<PicoQuicConnection>& connection)
 {
-    QUICR_LOGGER_INFO(logger,
+    QUICR_LOGGER_INFO(logger_,
                       "New Connection {} port: {} conn_id: {}",
                       connection->peer_addr_text,
                       connection->peer_port,
@@ -2011,7 +2012,7 @@ PicoQuicTransport::HandleNewConnection(const std::shared_ptr<PicoQuicConnection>
 
     if (tconfig_.quic_priority_limit > 0) {
         QUICR_LOGGER_INFO(
-          logger, "Setting priority bypass limit to {}", static_cast<int>(tconfig_.quic_priority_limit));
+          logger_, "Setting priority bypass limit to {}", static_cast<int>(tconfig_.quic_priority_limit));
         picoquic_set_priority_limit_for_bypass(connection->pq_cnx, tconfig_.quic_priority_limit);
     }
 
@@ -2028,7 +2029,7 @@ try {
     }
 
     if (connection == nullptr) {
-        QUICR_LOGGER_WARN(logger, "DGRAM received with NULL connection context; dropping length: {}", length);
+        QUICR_LOGGER_WARN(logger_, "DGRAM received with NULL connection context; dropping length: {}", length);
         return;
     }
 
@@ -2037,15 +2038,15 @@ try {
     connection->metrics.rx_dgrams_bytes += length;
 
     if (cbNotifyQueue_.Size() > 1000) {
-        QUICR_LOGGER_INFO(logger, "on_recv_datagram cbNotifyQueue size {}", cbNotifyQueue_.Size());
+        QUICR_LOGGER_INFO(logger_, "on_recv_datagram cbNotifyQueue size {}", cbNotifyQueue_.Size());
     }
 
     if (connection->dgram_rx_data->Size() < 10 &&
         !cbNotifyQueue_.Push([=, this]() { connection->OnRecvDgram(std::nullopt); })) {
-        QUICR_LOGGER_ERROR(logger, "conn_id: {} DGRAM notify queue is full", connection->GetID());
+        QUICR_LOGGER_ERROR(logger_, "conn_id: {} DGRAM notify queue is full", connection->GetID());
     }
 } catch (const std::exception& e) {
-    QUICR_LOGGER_ERROR(logger, "Caught exception in OnRecvDatagram. (error={})", e.what());
+    QUICR_LOGGER_ERROR(logger_, "Caught exception in OnRecvDatagram. (error={})", e.what());
     // TODO(tievens): Add metrics to track if this happens
 }
 
@@ -2065,7 +2066,7 @@ try {
     if (connection->GetAPI() == Connection::API::kWebTransport && connection->wt_control_stream_ctx != nullptr &&
         stream_id == connection->wt_control_stream_ctx->stream_id) {
 
-        QUICR_LOGGER_DEBUG(logger,
+        QUICR_LOGGER_DEBUG(logger_,
                            "OnRecvStreamBytes: Received data on control stream {} for conn_id={}, len={}",
                            stream_id,
                            connection->GetID(),
@@ -2078,7 +2079,7 @@ try {
               connection->pq_cnx, bytes.data(), bytes.data() + bytes.size(), &connection->wt_capsule);
 
             if (ret != 0) {
-                QUICR_LOGGER_ERROR(logger,
+                QUICR_LOGGER_ERROR(logger_,
                                    "OnRecvStreamBytes: Failed to parse capsule on control stream {} for conn_id={}",
                                    stream_id,
                                    connection->GetID());
@@ -2090,7 +2091,7 @@ try {
         // Check if capsule is fully received and stored
         if (connection->wt_capsule.h3_capsule.is_stored) {
             QUICR_LOGGER_INFO(
-              logger,
+              logger_,
               "OnRecvStreamBytes: Received capsule type={} error_code={} on control stream {} for conn_id={}",
               connection->wt_capsule.h3_capsule.capsule_type,
               connection->wt_capsule.error_code,
@@ -2104,14 +2105,14 @@ try {
                 if (!is_server_mode) {
                     // Client: close the connection
                     QUICR_LOGGER_INFO(
-                      logger,
+                      logger_,
                       "OnRecvStreamBytes: Client received control stream capsule, closing connection {}",
                       connection->GetID());
                     picoquic_close(connection->pq_cnx, 0);
                 } else {
                     // Server: send FIN back on control stream if not already sent
                     if (!connection->wt_control_stream_ctx->ps.stream_state.is_fin_sent) {
-                        QUICR_LOGGER_INFO(logger,
+                        QUICR_LOGGER_INFO(logger_,
                                           "OnRecvStreamBytes: Server sending FIN on control stream {} for conn_id={}",
                                           stream_id,
                                           connection->GetID());
@@ -2137,7 +2138,7 @@ try {
     auto rx_buf_it = connection->rx_stream_buffer.find(stream_id);
     if (rx_buf_it == connection->rx_stream_buffer.end()) {
         if (bytes.size() < kMinStreamBytesForSend) {
-            QUICR_LOGGER_DEBUG(logger,
+            QUICR_LOGGER_DEBUG(logger_,
                                "bytes received from picoquic stream {} len: {} is too small to process stream header",
                                stream_id,
                                bytes.size());
@@ -2153,7 +2154,7 @@ try {
       static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(tick_service_->get()).count());
 
     if (rx_buf.rx_ctx->unknown_expiry_tick_ms && curr_ticks_ms > rx_buf.rx_ctx->unknown_expiry_tick_ms) {
-        QUICR_LOGGER_DEBUG(logger,
+        QUICR_LOGGER_DEBUG(logger_,
                            "Stream is unknown and now has expired, resetting stream {} expiry {}ms > {}ms",
                            stream_id,
                            rx_buf.rx_ctx->unknown_expiry_tick_ms,
@@ -2177,7 +2178,7 @@ try {
             })) {
 
             QUICR_LOGGER_ERROR(
-              logger, "conn_id: {} stream_id: {} notify queue is full", connection->GetID(), stream_id);
+              logger_, "conn_id: {} stream_id: {} notify queue is full", connection->GetID(), stream_id);
         }
 
     } else {
@@ -2186,11 +2187,11 @@ try {
         if (!cbNotifyQueue_.Push(
               [=, this]() { connection->OnRecvStream(stream_id, std::nullopt, (stream_id & 2) == 0); })) {
             QUICR_LOGGER_ERROR(
-              logger, "conn_id: {} stream_id: {} notify queue is full", connection->GetID(), stream_id);
+              logger_, "conn_id: {} stream_id: {} notify queue is full", connection->GetID(), stream_id);
         }
     }
 } catch (const std::exception& e) {
-    QUICR_LOGGER_ERROR(logger, "Caught exception in OnRecvStreamBytes. (error={})", e.what());
+    QUICR_LOGGER_ERROR(logger_, "Caught exception in OnRecvStreamBytes. (error={})", e.what());
     // TODO(tievens): Add metrics to track if this happens
 }
 
@@ -2201,7 +2202,7 @@ PicoQuicTransport::OnStreamClosed(const std::shared_ptr<PicoQuicConnection>& con
                                   std::optional<uint64_t> data_ctx_id,
                                   StreamClosedFlag flag)
 {
-    QUICR_DEBUG("Stream {} closed for connection {}", stream_id, connection->GetID());
+    QUICR_LOGGER_DEBUG(logger_, "Stream {} closed for connection {}", stream_id, connection->GetID());
     cbNotifyQueue_.Push([=, rx_ctx = std::move(rx_ctx)]() {
         connection->OnStreamClosed(stream_id, std::move(rx_ctx), data_ctx_id, flag);
     });
@@ -2301,7 +2302,7 @@ PicoQuicTransport::CheckConnsForCongestion()
                 // Don't include control stream in delayed callbacks check. Control stream should be priority 0 or 1
                 if (stream.priority >= 2 &&
                     data_ctx.metrics.tx_delayed_callback - data_ctx.metrics.prev_tx_delayed_callback > 1) {
-                    QUICR_LOGGER_DEBUG(logger,
+                    QUICR_LOGGER_DEBUG(logger_,
                                        "CC: remote: {} port: {} conn_id: {} stream_id: {} queue_size: {}",
                                        connection->peer_addr_text,
                                        connection->peer_port,
@@ -2322,7 +2323,7 @@ PicoQuicTransport::CheckConnsForCongestion()
                 // TODO(tievens): size of TX is based on rate; adjust based on burst rates
                 if (tx_data_size >= 50) {
                     congested_count++;
-                    QUICR_LOGGER_DEBUG(logger,
+                    QUICR_LOGGER_DEBUG(logger_,
                                        "CC: remote: {} port: {} conn_id: {} stream_id: {} queue_size: {}",
                                        connection->peer_addr_text,
                                        connection->peer_port,
@@ -2341,7 +2342,7 @@ PicoQuicTransport::CheckConnsForCongestion()
 
         if (cwin_congested_count &&
             connection->pq_cnx->nb_retransmission_total - connection->metrics.tx_retransmits > 2) {
-            QUICR_LOGGER_DEBUG(logger,
+            QUICR_LOGGER_DEBUG(logger_,
                                "CC: remote: {} port: {} conn_id: {} retransmits increased, delta: {} total: {}",
                                connection->peer_addr_text,
                                connection->peer_port,
@@ -2359,7 +2360,7 @@ PicoQuicTransport::CheckConnsForCongestion()
 
             connection->is_congested = true;
             QUICR_LOGGER_DEBUG(
-              logger,
+              logger_,
               "CC: conn_id: {} has streams congested. congested_count: {} retrans: {} cwin_congested: {}",
               conn_id,
               congested_count,
@@ -2368,8 +2369,10 @@ PicoQuicTransport::CheckConnsForCongestion()
 
             if (tconfig_.use_reset_wait_strategy && reset_wait_data_ctx_id > 0) {
                 auto& data_ctx = connection->active_data_contexts[reset_wait_data_ctx_id];
-                QUICR_LOGGER_INFO(
-                  logger, "CC: conn_id: {} setting reset and wait to data_ctx_id: {}", conn_id, reset_wait_data_ctx_id);
+                QUICR_LOGGER_INFO(logger_,
+                                  "CC: conn_id: {} setting reset and wait to data_ctx_id: {}",
+                                  conn_id,
+                                  reset_wait_data_ctx_id);
 
                 for (auto& [_, stream] : data_ctx.streams) {
                     stream.tx_reset_wait_discard = true;
@@ -2390,7 +2393,7 @@ PicoQuicTransport::CheckConnsForCongestion()
                 connection->is_congested = false;
                 connection->not_congested_gauge = 0;
                 QUICR_LOGGER_DEBUG(
-                  logger, "CC: conn_id: {} congested_count: {} is no longer congested.", conn_id, congested_count);
+                  logger_, "CC: conn_id: {} congested_count: {} is no longer congested.", conn_id, congested_count);
             } else {
                 connection->not_congested_gauge++;
             }
@@ -2415,12 +2418,12 @@ PicoQuicTransport::Server()
     quic_network_thread_params_.simulate_eio = 0;
     quic_network_thread_params_.send_length_max = 0;
 
-    QUICR_LOGGER_DEBUG(logger, "Starting picoquic network thread");
+    QUICR_LOGGER_DEBUG(logger_, "Starting picoquic network thread");
     quic_network_thread_ctx_ =
       picoquic_start_network_thread(quic_ctx_, &quic_network_thread_params_, PqLoopCb, this, &quic_loop_return_value_);
 
     if (quic_ctx_ == NULL || quic_network_thread_ctx_ == NULL) {
-        QUICR_LOGGER_ERROR(logger, "Failed to start picoquic network thread");
+        QUICR_LOGGER_ERROR(logger_, "Failed to start picoquic network thread");
         picoquic_free(quic_ctx_);
         quic_ctx_ = NULL;
         SetStatus(TransportStatus::kShutdown);
@@ -2433,7 +2436,7 @@ PicoQuicTransport::Server()
 
     if (quic_network_thread_ctx_->return_code) {
         QUICR_LOGGER_ERROR(
-          logger, "Could not start quic network thread error: {}", quic_network_thread_ctx_->return_code);
+          logger_, "Could not start quic network thread error: {}", quic_network_thread_ctx_->return_code);
         SetStatus(TransportStatus::kShutdown);
         return;
     }
@@ -2468,7 +2471,7 @@ PicoQuicTransport::StartClient()
         ret = picoquic_get_server_address(serverInfo_.host_or_ip.c_str(), serverInfo_.port, &server_address, &is_name);
         if (ret != 0 || server_address.ss_family == 0) {
             QUICR_LOGGER_ERROR(
-              logger, "Failed to resolve server: {} port: {}", serverInfo_.host_or_ip, serverInfo_.port);
+              logger_, "Failed to resolve server: {} port: {}", serverInfo_.host_or_ip, serverInfo_.port);
             notify_caller(1);
             return 0;
         }
@@ -2489,7 +2492,7 @@ PicoQuicTransport::StartClient()
                                       config_.alpn,
                                       1);
             if (cnx == nullptr) {
-                QUICR_LOGGER_ERROR(logger, "Could not create picoquic connection client context");
+                QUICR_LOGGER_ERROR(logger_, "Could not create picoquic connection client context");
                 notify_caller(1);
                 return PICOQUIC_ERROR_DISCONNECTED;
             }
@@ -2500,12 +2503,12 @@ PicoQuicTransport::StartClient()
             picoquic_set_callback(cnx, PqEventCb, this);
 
             if (auto ret = picoquic_start_client_cnx(cnx)) {
-                QUICR_LOGGER_ERROR(logger, "Could not activate connection ret: {}", ret);
+                QUICR_LOGGER_ERROR(logger_, "Could not activate connection ret: {}", ret);
                 notify_caller(1);
                 return PICOQUIC_ERROR_DISCONNECTED;
             }
 
-            QUICR_LOGGER_INFO(logger, "StartClient: Creating connection context");
+            QUICR_LOGGER_INFO(logger_, "StartClient: Creating connection context");
             state->connection = CreateConnection(cnx);
 
         } else if (connection_api == Connection::API::kWebTransport) {
@@ -2516,7 +2519,7 @@ PicoQuicTransport::StartClient()
             ret = picowt_prepare_client_cnx(
               quic_ctx_, (struct sockaddr*)&server_address, &cnx, &h3_ctx, &control_stream_ctx, current_time, sni);
             if (ret != 0) {
-                QUICR_LOGGER_ERROR(logger, "picowt_prepare_client_cnx failed with ret: {}", ret);
+                QUICR_LOGGER_ERROR(logger_, "picowt_prepare_client_cnx failed with ret: {}", ret);
                 notify_caller(1);
                 return ret;
             }
@@ -2535,7 +2538,7 @@ PicoQuicTransport::StartClient()
             state->connection->wt_h3_ctx_owned = true; // Client owns this and must free it
             state->connection->wt_authority = serverInfo_.host_or_ip + ":" + std::to_string(serverInfo_.port);
 
-            QUICR_LOGGER_INFO(logger,
+            QUICR_LOGGER_INFO(logger_,
                               "StartClient:Webtransport Connect: Control Stream ID: {}, "
                               "authority: {}, path: {}",
                               control_stream_ctx->stream_id,
@@ -2552,7 +2555,7 @@ PicoQuicTransport::StartClient()
                                  this,
                                  kMoqtAlpn);
             if (ret != 0) {
-                QUICR_LOGGER_ERROR(logger, "Failed to initiate WebTransport connect");
+                QUICR_LOGGER_ERROR(logger_, "Failed to initiate WebTransport connect");
                 notify_caller(1);
                 return ret;
             }
@@ -2560,7 +2563,7 @@ PicoQuicTransport::StartClient()
             ret = picoquic_start_client_cnx(cnx);
 
             if (ret != 0) {
-                QUICR_LOGGER_ERROR(logger, "Failed to initiate WebTransport client connection");
+                QUICR_LOGGER_ERROR(logger_, "Failed to initiate WebTransport client connection");
                 notify_caller(1);
                 return ret;
             }
@@ -2573,8 +2576,8 @@ PicoQuicTransport::StartClient()
                 snprintf(hex_chars, sizeof(hex_chars), "%02x", icid.id[i]);
                 icid_str += hex_chars;
             }
-            QUICR_LOGGER_INFO(logger, "WebTransport Initial connection ID: {}", icid_str);
-            QUICR_LOGGER_INFO(logger,
+            QUICR_LOGGER_INFO(logger_, "WebTransport Initial connection ID: {}", icid_str);
+            QUICR_LOGGER_INFO(logger_,
                               "StartClient:Webtransport (after connect): Control Stream ID: {}, "
                               "authority: {}, path: {}",
                               control_stream_ctx->stream_id,
@@ -2584,10 +2587,10 @@ PicoQuicTransport::StartClient()
 
         if (tconfig_.quic_priority_limit > 0) {
             QUICR_LOGGER_INFO(
-              logger, "Setting priority bypass limit to {}", static_cast<int>(tconfig_.quic_priority_limit));
+              logger_, "Setting priority bypass limit to {}", static_cast<int>(tconfig_.quic_priority_limit));
             picoquic_set_priority_limit_for_bypass(cnx, tconfig_.quic_priority_limit);
         } else {
-            QUICR_LOGGER_INFO(logger, "No priority bypass");
+            QUICR_LOGGER_INFO(logger_, "No priority bypass");
         }
 
         notify_caller(reinterpret_cast<uint64_t>(cnx));
@@ -2595,13 +2598,13 @@ PicoQuicTransport::StartClient()
         return 0;
     });
 
-    QUICR_LOGGER_DEBUG(logger, "Waiting for client connection context");
+    QUICR_LOGGER_DEBUG(logger_, "Waiting for client connection context");
 
     state->cv.wait_for(lock, std::chrono::milliseconds(3000), [&state]() { return state->conn_id > 0; });
 
-    QUICR_LOGGER_DEBUG(logger, "Got client connection context conn_id: {}", state->conn_id);
+    QUICR_LOGGER_DEBUG(logger_, "Got client connection context conn_id: {}", state->conn_id);
     if (state->conn_id <= 1) {
-        QUICR_LOGGER_DEBUG(logger, "Client connection to {}:{} failed", serverInfo_.host_or_ip, serverInfo_.port);
+        QUICR_LOGGER_DEBUG(logger_, "Client connection to {}:{} failed", serverInfo_.host_or_ip, serverInfo_.port);
         SetStatus(TransportStatus::kDisconnected);
         return 0;
     }
@@ -2612,7 +2615,7 @@ PicoQuicTransport::StartClient()
 bool
 PicoQuicTransport::ClientLoop()
 {
-    QUICR_LOGGER_INFO(logger, "Thread client packet loop starting");
+    QUICR_LOGGER_INFO(logger_, "Thread client packet loop starting");
 
     quic_network_thread_params_.local_port = 0;
     quic_network_thread_params_.local_af = PF_UNSPEC;
@@ -2631,7 +2634,7 @@ PicoQuicTransport::ClientLoop()
       picoquic_start_network_thread(quic_ctx_, &quic_network_thread_params_, PqLoopCb, this, &quic_loop_return_value_);
 
     if (quic_ctx_ == nullptr || quic_network_thread_ctx_ == nullptr) {
-        QUICR_LOGGER_ERROR(logger, "Failed to create picoquic network thread");
+        QUICR_LOGGER_ERROR(logger_, "Failed to create picoquic network thread");
         picoquic_free(quic_ctx_);
         quic_ctx_ = nullptr;
         return false;
@@ -2644,11 +2647,11 @@ PicoQuicTransport::ClientLoop()
 
     if (quic_network_thread_ctx_->return_code) {
         QUICR_LOGGER_ERROR(
-          logger, "Could not start client quic network thread error: {}", quic_network_thread_ctx_->return_code);
+          logger_, "Could not start client quic network thread error: {}", quic_network_thread_ctx_->return_code);
         return false;
     }
 
-    QUICR_LOGGER_DEBUG(logger, "Thread client packet loop started");
+    QUICR_LOGGER_DEBUG(logger_, "Thread client packet loop started");
 
     return true;
 }
@@ -2676,7 +2679,7 @@ PicoQuicTransport::Shutdown()
     }
 
     if (quic_network_thread_ctx_ != NULL) {
-        QUICR_LOGGER_INFO(logger, "Closing transport picoquic thread");
+        QUICR_LOGGER_INFO(logger_, "Closing transport picoquic thread");
         picoquic_delete_network_thread(quic_network_thread_ctx_);
         quic_network_thread_ctx_ = nullptr;
     }
@@ -2685,7 +2688,7 @@ PicoQuicTransport::Shutdown()
     cbNotifyQueue_.StopWaiting();
 
     if (cbNotifyThread_.joinable()) {
-        QUICR_LOGGER_INFO(logger, "Closing transport callback notifier thread");
+        QUICR_LOGGER_INFO(logger_, "Closing transport callback notifier thread");
         cbNotifyThread_.join();
     }
 
@@ -2695,7 +2698,7 @@ PicoQuicTransport::Shutdown()
     }
 
     tick_service_.reset();
-    QUICR_LOGGER_INFO(logger, "done closing transport threads");
+    QUICR_LOGGER_INFO(logger_, "done closing transport threads");
 
     picoquic_config_clear(&config_);
 }
@@ -2732,7 +2735,7 @@ PicoQuicTransport::CheckCallbackDelta(DataContext* data_ctx, bool tx)
 void
 PicoQuicTransport::CbNotifier()
 {
-    QUICR_LOGGER_INFO(logger, "Starting transport callback notifier thread");
+    QUICR_LOGGER_INFO(logger_, "Starting transport callback notifier thread");
 
     while (not stop_) {
         auto cb = cbNotifyQueue_.BlockPop();
@@ -2741,15 +2744,15 @@ PicoQuicTransport::CbNotifier()
                 (*cb)();
             } catch (const std::exception& e) {
                 QUICR_LOGGER_ERROR(
-                  logger, "Caught exception running callback via notify thread (error={}), ignoring", e.what());
+                  logger_, "Caught exception running callback via notify thread (error={}), ignoring", e.what());
                 // TODO(tievens): Add metrics to track if this happens
             }
         } else {
-            QUICR_LOGGER_INFO(logger, "Notify callback is NULL");
+            QUICR_LOGGER_INFO(logger_, "Notify callback is NULL");
         }
     }
 
-    QUICR_LOGGER_INFO(logger, "Done with transport callback notifier thread");
+    QUICR_LOGGER_INFO(logger_, "Done with transport callback notifier thread");
 }
 
 std::uint64_t
@@ -2782,7 +2785,7 @@ PicoQuicTransport::CreateStream(const std::shared_ptr<Connection>& connection,
         throw PicoQuicException("Unable to create stream");
     }
 
-    QUICR_LOGGER_DEBUG(logger,
+    QUICR_LOGGER_DEBUG(logger_,
                        "Created reliable data context id: {} stream_id: {}, pri: {}",
                        data_ctx_id,
                        state->stream_id.value(),
@@ -2818,7 +2821,7 @@ PicoQuicTransport::CreateStreamInternal(const std::shared_ptr<Connection>& conne
         // Use per-connection WebTransport context instead of global wt_context_
         if (!pq_conn->wt_h3_ctx || !pq_conn->wt_control_stream_ctx) {
             QUICR_LOGGER_ERROR(
-              logger, "WebTransport context not initialized for connection {} stream creation", pq_conn->GetID());
+              logger_, "WebTransport context not initialized for connection {} stream creation", pq_conn->GetID());
             throw PicoQuicException("WebTransport context not initialized for connection");
         }
 
@@ -2828,7 +2831,7 @@ PicoQuicTransport::CreateStreamInternal(const std::shared_ptr<Connection>& conne
                                                                      pq_conn->wt_control_stream_ctx->stream_id);
 
         if (!stream_ctx) {
-            QUICR_LOGGER_ERROR(logger, "Failed to create WebTransport stream");
+            QUICR_LOGGER_ERROR(logger_, "Failed to create WebTransport stream");
             throw PicoQuicException("Failed to create WebTransport stream");
         }
 
@@ -2845,7 +2848,7 @@ PicoQuicTransport::CreateStreamInternal(const std::shared_ptr<Connection>& conne
         pq_conn->last_stream_id = picoquic_get_next_local_stream_id(pq_conn->pq_cnx, !data_ctx_it->second.is_bidir);
         stream_id = pq_conn->last_stream_id;
 
-        QUICR_LOGGER_DEBUG(logger,
+        QUICR_LOGGER_DEBUG(logger_,
                            "conn_id: {} data_ctx_id: {} create new stream with stream_id: {}",
                            connection->GetID(),
                            data_ctx_id,
@@ -2886,15 +2889,16 @@ PicoQuicTransport::CloseStream(const std::shared_ptr<PicoQuicConnection>& connec
 {
     if (data_ctx) {
         if (!data_ctx->streams.contains(stream_id)) {
-            QUICR_ERROR("Failed to close stream as it does not exist (conn_id={}, data_ctx_id={}, stream_id={})",
-                        connection->GetID(),
-                        data_ctx->data_ctx_id,
-                        stream_id);
+            QUICR_LOGGER_ERROR(logger_,
+                               "Failed to close stream as it does not exist (conn_id={}, data_ctx_id={}, stream_id={})",
+                               connection->GetID(),
+                               data_ctx->data_ctx_id,
+                               stream_id);
             return;
         }
     }
 
-    QUICR_LOGGER_DEBUG(logger, "conn_id: {} closing stream stream_id: {}", connection->GetID(), stream_id);
+    QUICR_LOGGER_DEBUG(logger_, "conn_id: {} closing stream stream_id: {}", connection->GetID(), stream_id);
 
     if (use_reset) {
         picoquic_reset_stream_ctx(connection->pq_cnx, stream_id);
@@ -3030,7 +3034,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
     // This function is only called for WebTransport connections (checked by caller)
     // Just verify that WebTransport config is initialized
     if (!wt_config_) {
-        QUICR_LOGGER_ERROR(logger, "WebTransport config not initialized");
+        QUICR_LOGGER_ERROR(logger_, "WebTransport config not initialized");
         return -1;
     }
 
@@ -3042,7 +3046,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
         // Get or create connection context
         auto connection = GetConnection(conn_id);
         if (!connection) {
-            QUICR_LOGGER_ERROR(logger, "Failed to get connection context for client WebTransport setup");
+            QUICR_LOGGER_ERROR(logger_, "Failed to get connection context for client WebTransport setup");
             return -1;
         }
 
@@ -3055,7 +3059,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
         int is_name = 0;
         ret = picoquic_get_server_address(serverInfo_.host_or_ip.c_str(), serverInfo_.port, &server_addr, &is_name);
         if (ret != 0) {
-            QUICR_LOGGER_ERROR(logger, "Failed to get server address for WebTransport");
+            QUICR_LOGGER_ERROR(logger_, "Failed to get server address for WebTransport");
             return ret;
         }
 
@@ -3065,7 +3069,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
         ret = picowt_prepare_client_cnx(
           quic_ctx_, (struct sockaddr*)&server_addr, &prepared_cnx, &h3_ctx, &control_stream_ctx, current_time, sni);
         if (ret != 0) {
-            QUICR_LOGGER_ERROR(logger, "picowt_prepare_client_cnx failed with ret: {}", ret);
+            QUICR_LOGGER_ERROR(logger_, "picowt_prepare_client_cnx failed with ret: {}", ret);
             return ret;
         }
 
@@ -3085,7 +3089,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
                              this,
                              kMoqtAlpn);
         if (ret != 0) {
-            QUICR_LOGGER_ERROR(logger, "Failed to initiate WebTransport connect");
+            QUICR_LOGGER_ERROR(logger_, "Failed to initiate WebTransport connect");
             return ret;
         }
 
@@ -3097,9 +3101,9 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
             snprintf(hex_chars, sizeof(hex_chars), "%02x", icid.id[i]);
             icid_str += hex_chars;
         }
-        QUICR_LOGGER_INFO(logger, "WebTransport Initial connection ID: {}", icid_str);
+        QUICR_LOGGER_INFO(logger_, "WebTransport Initial connection ID: {}", icid_str);
         QUICR_LOGGER_INFO(
-          logger, "WebTransport client connect initiated to {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
+          logger_, "WebTransport client connect initiated to {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
     } else {
         // Server mode: h3zero_callback will create per-connection h3_ctx automatically
         // when invoked with the picohttp_server_parameters_t (set in ALPN selection).
@@ -3109,10 +3113,10 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
         picowt_set_transport_parameters(cnx);
 
         QUICR_LOGGER_INFO(
-          logger, "WebTransport server connection setup - h3_ctx will be created per-connection by h3zero_callback");
+          logger_, "WebTransport server connection setup - h3_ctx will be created per-connection by h3zero_callback");
     }
 
-    QUICR_LOGGER_INFO(logger, "WebTransport connection setup completed");
+    QUICR_LOGGER_INFO(logger_, "WebTransport connection setup completed");
     return ret;
 }
 
@@ -3129,7 +3133,7 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
     // Validate path parameters
     if (path != nullptr && path_length > 0) {
         std::string path_str(reinterpret_cast<char*>(path), path_length);
-        QUICR_LOGGER_INFO(logger, "AcceptWebTransportConnection: received path '{}'", path_str);
+        QUICR_LOGGER_INFO(logger_, "AcceptWebTransportConnection: received path '{}'", path_str);
 
         // Get the path portion (before query parameters)
         size_t query_offset = h3zero_query_offset(path, path_length);
@@ -3138,7 +3142,7 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
         // Validate the path matches the expected path
         std::string expected_path = wt_config_ ? wt_config_->path : "/relay";
         if (path_only != expected_path) {
-            QUICR_LOGGER_ERROR(logger,
+            QUICR_LOGGER_ERROR(logger_,
                                "AcceptWebTransportConnection: path '{}' does not match expected path '{}'",
                                path_only,
                                expected_path);
@@ -3148,7 +3152,7 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
         if (query_offset < path_length) {
             const uint8_t* queries = path + query_offset;
             size_t queries_length = path_length - query_offset;
-            QUICR_LOGGER_DEBUG(logger,
+            QUICR_LOGGER_DEBUG(logger_,
                                "AcceptWebTransportConnection: query string '{}'",
                                std::string(reinterpret_cast<const char*>(queries), queries_length));
 
@@ -3160,7 +3164,7 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
             // }
         }
     } else {
-        QUICR_LOGGER_INFO(logger, "AcceptWebTransportConnection: no path provided");
+        QUICR_LOGGER_INFO(logger_, "AcceptWebTransportConnection: no path provided");
     }
 
     auto& connection = CreateConnection(cnx);
@@ -3181,19 +3185,19 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
 
         if (ret != 0) {
             QUICR_LOGGER_ERROR(
-              logger,
+              logger_,
               "AcceptWebTransportConnection: Failed to register stream prefix for WebTransport connection {}",
               conn_id);
             return ret;
         }
 
-        QUICR_LOGGER_INFO(logger,
+        QUICR_LOGGER_INFO(logger_,
                           "AcceptWebTransportConnection: Registered control stream (stream_id: {}) for connection {}",
                           stream_ctx->stream_id,
                           conn_id);
     } else {
         QUICR_LOGGER_ERROR(
-          logger, "AcceptWebTransportConnection: No stream context provided for WebTransport connection {}", conn_id);
+          logger_, "AcceptWebTransportConnection: No stream context provided for WebTransport connection {}", conn_id);
         return -1;
     }
 
@@ -3201,7 +3205,7 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
     stream_ctx->path_callback = DefaultWebTransportCallback;
     stream_ctx->path_callback_ctx = this;
 
-    QUICR_LOGGER_INFO(logger, "AcceptWebTransportConnection: Done accepting WebTransport connection {}", conn_id);
+    QUICR_LOGGER_INFO(logger_, "AcceptWebTransportConnection: Done accepting WebTransport connection {}", conn_id);
 
     HandleNewConnection(connection);
 
@@ -3226,14 +3230,14 @@ PicoQuicTransport::SetWebTransportPathCallback(const std::string& path,
     wt_config_->path_items.clear();
 
     QUICR_LOGGER_INFO(
-      logger, "WebTransport path callback configured: path={}, callback={}", path, callback ? "custom" : "default");
+      logger_, "WebTransport path callback configured: path={}, callback={}", path, callback ? "custom" : "default");
 }
 
 h3zero_stream_ctx_t*
 PicoQuicTransport::CreateWebTransportStream(picoquic_cnx_t* cnx, bool is_bidir)
 {
     if (connection_api != Connection::API::kWebTransport) {
-        QUICR_LOGGER_ERROR(logger, "CreateWebTransportStream called but not in WebTransport mode");
+        QUICR_LOGGER_ERROR(logger_, "CreateWebTransportStream called but not in WebTransport mode");
         return nullptr;
     }
 
@@ -3241,18 +3245,18 @@ PicoQuicTransport::CreateWebTransportStream(picoquic_cnx_t* cnx, bool is_bidir)
     auto conn_id = reinterpret_cast<std::uint64_t>(cnx);
     auto connection = GetConnection(conn_id);
     if (!connection) {
-        QUICR_LOGGER_ERROR(logger, "CreateWebTransportStream: Connection context not found for conn_id {}", conn_id);
+        QUICR_LOGGER_ERROR(logger_, "CreateWebTransportStream: Connection context not found for conn_id {}", conn_id);
         return nullptr;
     }
 
     if (!connection->wt_h3_ctx) {
         QUICR_LOGGER_ERROR(
-          logger, "CreateWebTransportStream: WebTransport h3_ctx not initialized for conn_id {}", conn_id);
+          logger_, "CreateWebTransportStream: WebTransport h3_ctx not initialized for conn_id {}", conn_id);
         return nullptr;
     }
 
     if (!connection->wt_control_stream_ctx) {
-        QUICR_LOGGER_ERROR(logger, "CreateWebTransportStream: No control stream context for conn_id {}", conn_id);
+        QUICR_LOGGER_ERROR(logger_, "CreateWebTransportStream: No control stream context for conn_id {}", conn_id);
         return nullptr;
     }
 
@@ -3264,13 +3268,13 @@ PicoQuicTransport::CreateWebTransportStream(picoquic_cnx_t* cnx, bool is_bidir)
         stream_ctx->path_callback = DefaultWebTransportCallback;
         stream_ctx->path_callback_ctx = this;
 
-        QUICR_LOGGER_DEBUG(logger,
+        QUICR_LOGGER_DEBUG(logger_,
                            "Created WebTransport {} stream: {}",
                            is_bidir ? "bidirectional" : "unidirectional",
                            stream_ctx->stream_id);
     } else {
         QUICR_LOGGER_ERROR(
-          logger, "Failed to create WebTransport {} stream", is_bidir ? "bidirectional" : "unidirectional");
+          logger_, "Failed to create WebTransport {} stream", is_bidir ? "bidirectional" : "unidirectional");
     }
 
     return stream_ctx;
@@ -3280,7 +3284,7 @@ int
 PicoQuicTransport::SendWebTransportCloseSession(picoquic_cnx_t* cnx, uint32_t error_code, const char* error_msg)
 {
     if (connection_api != Connection::API::kWebTransport) {
-        QUICR_LOGGER_ERROR(logger, "SendWebTransportCloseSession called but not in WebTransport mode");
+        QUICR_LOGGER_ERROR(logger_, "SendWebTransportCloseSession called but not in WebTransport mode");
         return -1;
     }
 
@@ -3289,12 +3293,12 @@ PicoQuicTransport::SendWebTransportCloseSession(picoquic_cnx_t* cnx, uint32_t er
     auto connection = GetConnection(conn_id);
     if (!connection) {
         QUICR_LOGGER_ERROR(
-          logger, "SendWebTransportCloseSession: Connection context not found for conn_id {}", conn_id);
+          logger_, "SendWebTransportCloseSession: Connection context not found for conn_id {}", conn_id);
         return -1;
     }
 
     if (!connection->wt_control_stream_ctx) {
-        QUICR_LOGGER_ERROR(logger, "SendWebTransportCloseSession: No control stream context for conn_id {}", conn_id);
+        QUICR_LOGGER_ERROR(logger_, "SendWebTransportCloseSession: No control stream context for conn_id {}", conn_id);
         return -1;
     }
 
@@ -3303,9 +3307,9 @@ PicoQuicTransport::SendWebTransportCloseSession(picoquic_cnx_t* cnx, uint32_t er
 
     if (ret == 0) {
         QUICR_LOGGER_INFO(
-          logger, "WebTransport close session sent: code={}, msg={}", error_code, error_msg ? error_msg : "");
+          logger_, "WebTransport close session sent: code={}, msg={}", error_code, error_msg ? error_msg : "");
     } else {
-        QUICR_LOGGER_ERROR(logger, "Failed to send WebTransport close session: ret={}", ret);
+        QUICR_LOGGER_ERROR(logger_, "Failed to send WebTransport close session: ret={}", ret);
     }
 
     return ret;
@@ -3315,7 +3319,7 @@ int
 PicoQuicTransport::SendWebTransportDrainSession(picoquic_cnx_t* cnx)
 {
     if (connection_api != Connection::API::kWebTransport) {
-        QUICR_LOGGER_ERROR(logger, "SendWebTransportDrainSession called but not in WebTransport mode");
+        QUICR_LOGGER_ERROR(logger_, "SendWebTransportDrainSession called but not in WebTransport mode");
         return -1;
     }
 
@@ -3324,12 +3328,12 @@ PicoQuicTransport::SendWebTransportDrainSession(picoquic_cnx_t* cnx)
     auto connection = GetConnection(conn_id);
     if (!connection) {
         QUICR_LOGGER_ERROR(
-          logger, "SendWebTransportDrainSession: Connection context not found for conn_id {}", conn_id);
+          logger_, "SendWebTransportDrainSession: Connection context not found for conn_id {}", conn_id);
         return -1;
     }
 
     if (!connection->wt_control_stream_ctx) {
-        QUICR_LOGGER_ERROR(logger, "SendWebTransportDrainSession: No control stream context for conn_id {}", conn_id);
+        QUICR_LOGGER_ERROR(logger_, "SendWebTransportDrainSession: No control stream context for conn_id {}", conn_id);
         return -1;
     }
 
@@ -3337,9 +3341,9 @@ PicoQuicTransport::SendWebTransportDrainSession(picoquic_cnx_t* cnx)
     int ret = picowt_send_drain_session_message(cnx, connection->wt_control_stream_ctx);
 
     if (ret == 0) {
-        QUICR_LOGGER_INFO(logger, "WebTransport drain session sent");
+        QUICR_LOGGER_INFO(logger_, "WebTransport drain session sent");
     } else {
-        QUICR_LOGGER_ERROR(logger, "Failed to send WebTransport drain session: ret={}", ret);
+        QUICR_LOGGER_ERROR(logger_, "Failed to send WebTransport drain session: ret={}", ret);
     }
 
     return ret;
@@ -3367,7 +3371,7 @@ void
 PicoQuicTransport::DeregisterWebTransport(picoquic_cnx_t* cnx)
 {
     if (!is_server_mode && connection_api != Connection::API::kWebTransport) {
-        QUICR_LOGGER_WARN(logger, "DeregisterWebTransport called but not in WebTransport mode");
+        QUICR_LOGGER_WARN(logger_, "DeregisterWebTransport called but not in WebTransport mode");
         return;
     }
 
@@ -3375,12 +3379,12 @@ PicoQuicTransport::DeregisterWebTransport(picoquic_cnx_t* cnx)
     auto conn_id = reinterpret_cast<std::uint64_t>(cnx);
     auto connection = GetConnection(conn_id);
     if (!connection) {
-        QUICR_LOGGER_WARN(logger, "DeregisterWebTransport: Connection context not found for conn_id {}", conn_id);
+        QUICR_LOGGER_WARN(logger_, "DeregisterWebTransport: Connection context not found for conn_id {}", conn_id);
         return;
     }
 
     if (!connection->wt_h3_ctx || !connection->wt_control_stream_ctx) {
-        QUICR_LOGGER_WARN(logger, "DeregisterWebTransport: WebTransport context already null for conn_id {}", conn_id);
+        QUICR_LOGGER_WARN(logger_, "DeregisterWebTransport: WebTransport context already null for conn_id {}", conn_id);
         return;
     }
 
@@ -3390,7 +3394,7 @@ PicoQuicTransport::DeregisterWebTransport(picoquic_cnx_t* cnx)
     // Release any accumulated capsule memory
     picowt_release_capsule(&connection->wt_capsule);
 
-    QUICR_LOGGER_INFO(logger, "WebTransport context deregistered for conn_id {}", conn_id);
+    QUICR_LOGGER_INFO(logger_, "WebTransport context deregistered for conn_id {}", conn_id);
 
     // Clear the per-connection context
     connection->wt_control_stream_ctx = nullptr;

--- a/src/transport_picoquic.cpp
+++ b/src/transport_picoquic.cpp
@@ -7,6 +7,7 @@
 #include "quicr/containers/priority_queue.h"
 #include "quicr/containers/safe_queue.h"
 #include "quicr/containers/stream_buffer.h"
+#include "quicr/log.h"
 #include "quicr/metrics.h"
 #include "quicr/session.h"
 #include "quicr/utilities/defer.h"
@@ -23,7 +24,6 @@
 #include <picoquic_packet_loop.h>
 #include <picoquic_utils.h>
 #include <picosocks.h>
-#include <spdlog/spdlog.h>
 #include <timeq/time_queue.h>
 #include <tls_api.h>
 
@@ -151,7 +151,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
 
             if (data_ctx == NULL) {
                 // picoquic calls this again even after reset/fin, here we ignore it
-                SPDLOG_LOGGER_INFO(transport->logger, "conn_id: {} stream_id: {} context is null", conn_id, stream_id);
+                QUICR_LOGGER_INFO(transport->logger, "conn_id: {} stream_id: {} context is null", conn_id, stream_id);
                 break;
             }
 
@@ -192,7 +192,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
                 transport->OnRecvStreamBytes(connection, data_ctx, stream_id, is_fin, std::span{ bytes, length });
 
                 if (is_fin) {
-                    SPDLOG_LOGGER_DEBUG(transport->logger, "Received FIN for stream {}", stream_id);
+                    QUICR_LOGGER_DEBUG(transport->logger, "Received FIN for stream {}", stream_id);
 
                     picoquic_reset_stream_ctx(pq_cnx, stream_id);
 
@@ -216,13 +216,13 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
 
         case picoquic_callback_stop_sending:
             // Stop sending is basically a reset initiated by the other side. MOQT suggests to RESET on this
-            SPDLOG_LOGGER_DEBUG(
+            QUICR_LOGGER_DEBUG(
               transport->logger, "Received STOP_SENDING stream conn_id: {} stream_id: {}", conn_id, stream_id);
             picoquic_reset_stream(pq_cnx, stream_id, 0);
             [[fallthrough]];
 
         case picoquic_callback_stream_reset: {
-            SPDLOG_LOGGER_DEBUG(
+            QUICR_LOGGER_DEBUG(
               transport->logger, "Received RESET stream conn_id: {} stream_id: {}", conn_id, stream_id);
 
             picoquic_reset_stream_ctx(pq_cnx, stream_id);
@@ -236,7 +236,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
                 }
 
                 if (data_ctx != nullptr) {
-                    SPDLOG_LOGGER_DEBUG(
+                    QUICR_LOGGER_DEBUG(
                       transport->logger,
                       "Received RESET stream with data context; conn_id: {} data_ctx_id: {} stream_id: {}",
                       data_ctx->conn_id,
@@ -276,7 +276,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
             picoquic_path_quality_t path_quality;
             picoquic_get_path_quality(pq_cnx, pq_cnx->path[0]->unique_path_id, &path_quality);
 
-            SPDLOG_LOGGER_INFO(
+            QUICR_LOGGER_INFO(
               transport->logger,
               "Pacing rate changed; conn_id: {} rate Kbps: {} cwin_bytes: {} rtt_us: {} rate Kbps: {} cwin_bytes: "
               "{} rtt_us: {} rtt_max: {} rtt_sample: {} lost_pkts: {} bytes_in_transit: {} recv_rate_Kbps: {}",
@@ -296,7 +296,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
         }
 
         case picoquic_callback_application_close:
-            SPDLOG_LOGGER_INFO(transport->logger, "Application closed conn_id: {}", conn_id);
+            QUICR_LOGGER_INFO(transport->logger, "Application closed conn_id: {}", conn_id);
             [[fallthrough]];
         case picoquic_callback_close: {
             uint64_t app_reason_code = picoquic_get_application_error(pq_cnx);
@@ -323,7 +323,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
                 log_msg << " remote: " << connection->peer_addr_text;
             }
 
-            SPDLOG_LOGGER_INFO(transport->logger, log_msg.str());
+            QUICR_LOGGER_INFO(transport->logger, log_msg.str());
 
             switch (app_reason_code) {
                 case static_cast<uint64_t>(AppReasonForClose::kIdleTimeout):
@@ -349,8 +349,8 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
 
         case picoquic_callback_ready: { // Connection callback, not per stream
             if (transport->is_server_mode) {
-                SPDLOG_LOGGER_INFO(transport->logger,
-                                   "PqEventCb: Creating connection context in picoquic_callback_ready");
+                QUICR_LOGGER_INFO(transport->logger,
+                                  "PqEventCb: Creating connection context in picoquic_callback_ready");
                 transport->HandleNewConnection(transport->CreateConnection(pq_cnx));
             } else {
                 // Client - for raw QUIC connections only, WebTransport connections use DefaultWebTransportCallback
@@ -368,7 +368,7 @@ PqEventCb(picoquic_cnx_t* pq_cnx,
         }
 
         default:
-            SPDLOG_LOGGER_DEBUG(transport->logger, "Got event {}", static_cast<int>(fin_or_event));
+            QUICR_LOGGER_DEBUG(transport->logger, "Got event {}", static_cast<int>(fin_or_event));
             break;
     }
 
@@ -397,7 +397,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
 
     switch (cb_mode) {
         case picoquic_packet_loop_ready: {
-            SPDLOG_LOGGER_INFO(transport->logger, "packet_loop_ready, waiting for packets");
+            QUICR_LOGGER_INFO(transport->logger, "packet_loop_ready, waiting for packets");
 
             if (transport->is_server_mode)
                 transport->SetStatus(TransportStatus::kReady);
@@ -421,7 +421,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
             break;
 
         case picoquic_packet_loop_port_update:
-            SPDLOG_LOGGER_DEBUG(transport->logger, "packet_loop_port_update");
+            QUICR_LOGGER_DEBUG(transport->logger, "packet_loop_port_update");
             break;
 
         case picoquic_packet_loop_time_check: {
@@ -463,7 +463,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
             }
 
             if (transport->Status() == TransportStatus::kShuttingDown) {
-                SPDLOG_LOGGER_INFO(transport->logger, "picoquic is shutting down");
+                QUICR_LOGGER_INFO(transport->logger, "picoquic is shutting down");
 
                 picoquic_cnx_t* close_cnx = picoquic_get_first_cnx(quic);
 
@@ -473,7 +473,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
                 }
 
                 while (close_cnx != NULL) {
-                    SPDLOG_LOGGER_INFO(
+                    QUICR_LOGGER_INFO(
                       transport->logger, "Closing connection id {}", reinterpret_cast<uint64_t>(close_cnx));
                     transport->CloseInternal(transport->GetConnection(reinterpret_cast<uint64_t>(close_cnx)),
                                              AppReasonForClose::kShutdown);
@@ -488,7 +488,7 @@ PqLoopCb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode, void* call
 
         default:
             // ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
-            SPDLOG_LOGGER_WARN(transport->logger, "pq_loop_cb() does not implement ", std::to_string(cb_mode));
+            QUICR_LOGGER_WARN(transport->logger, "pq_loop_cb() does not implement ", std::to_string(cb_mode));
             break;
     }
 
@@ -541,7 +541,7 @@ GetConnCtxForWT(PicoQuicTransport* transport, std::uint64_t conn_id, picohttp_ca
 {
     auto connection = transport->GetConnection(conn_id);
     if (!connection) {
-        SPDLOG_LOGGER_WARN(
+        QUICR_LOGGER_WARN(
           transport->logger, "DefaultWT: {} No connection context for conn_id {}", WtEventToString(wt_event), conn_id);
     }
     return connection;
@@ -601,17 +601,17 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
     switch (wt_event) {
         case picohttp_callback_connecting:
             // Called when initiating WebTransport connect
-            SPDLOG_LOGGER_TRACE(
+            QUICR_LOGGER_TRACE(
               transport->logger, "DefaultWT: {} for connection {}", WtEventToString(wt_event), conn_id);
             break;
 
         case picohttp_callback_connect:
             /* A connect has been received on this stream, and could be accepted.
              */
-            SPDLOG_LOGGER_TRACE(transport->logger,
-                                "DefaultWT: {} connect received on path for connection {}",
-                                WtEventToString(wt_event),
-                                conn_id);
+            QUICR_LOGGER_TRACE(transport->logger,
+                               "DefaultWT: {} connect received on path for connection {}",
+                               WtEventToString(wt_event),
+                               conn_id);
 
             if (transport->is_server_mode) {
                 // Accept the incoming WebTransport connection
@@ -619,26 +619,25 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
                 // and reports OnNewConnection() callback
                 ret = transport->AcceptWebTransportConnection(cnx, bytes, length, stream_ctx);
                 if (ret != 0) {
-                    SPDLOG_LOGGER_ERROR(
+                    QUICR_LOGGER_ERROR(
                       transport->logger, "DefaultWT: Failed to accept WebTransport connection {}", conn_id);
                 }
             }
             break;
 
         case picohttp_callback_connect_refused:
-            SPDLOG_LOGGER_WARN(
-              transport->logger, "DefaultWT: {} for connection {}", WtEventToString(wt_event), conn_id);
+            QUICR_LOGGER_WARN(transport->logger, "DefaultWT: {} for connection {}", WtEventToString(wt_event), conn_id);
             if (auto connection = transport->GetConnection(conn_id)) {
                 transport->OnConnectionStatus(connection, TransportStatus::kDisconnected);
             }
             break;
 
         case picohttp_callback_connect_accepted:
-            SPDLOG_LOGGER_TRACE(transport->logger,
-                                "DefaultWT: {} for connection {}, h3 stream {}",
-                                WtEventToString(wt_event),
-                                conn_id,
-                                stream_ctx->stream_id);
+            QUICR_LOGGER_TRACE(transport->logger,
+                               "DefaultWT: {} for connection {}, h3 stream {}",
+                               WtEventToString(wt_event),
+                               conn_id,
+                               stream_ctx->stream_id);
 
             transport->SetStatus(TransportStatus::kReady);
             if (auto connection = transport->GetConnection(conn_id)) {
@@ -650,7 +649,7 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_post_fin: {
             // Data received on a stream - similar to picoquic_callback_stream_data in PqEventCb
             if (!stream_ctx) {
-                SPDLOG_LOGGER_TRACE(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
+                QUICR_LOGGER_TRACE(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
                 return -1;
             }
 
@@ -658,20 +657,20 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
             bool is_fin = (wt_event == picohttp_callback_post_fin);
 
             if (is_fin) {
-                SPDLOG_LOGGER_DEBUG(transport->logger,
-                                    "DefaultWT: {} conn_id: {} stream_id: {} FIN",
-                                    WtEventToString(wt_event),
-                                    conn_id,
-                                    stream_id);
+                QUICR_LOGGER_DEBUG(transport->logger,
+                                   "DefaultWT: {} conn_id: {} stream_id: {} FIN",
+                                   WtEventToString(wt_event),
+                                   conn_id,
+                                   stream_id);
             }
 
-            SPDLOG_LOGGER_TRACE(transport->logger,
-                                "DefaultWT: {} received {} bytes on stream {} for connection {}, is_fin {}",
-                                WtEventToString(wt_event),
-                                length,
-                                stream_id,
-                                conn_id,
-                                is_fin);
+            QUICR_LOGGER_TRACE(transport->logger,
+                               "DefaultWT: {} received {} bytes on stream {} for connection {}, is_fin {}",
+                               WtEventToString(wt_event),
+                               length,
+                               stream_id,
+                               conn_id,
+                               is_fin);
 
             auto connection = GetConnCtxForWT(transport, conn_id, wt_event);
             if (!connection) {
@@ -713,11 +712,11 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
             }
 
             if (is_fin) {
-                SPDLOG_LOGGER_TRACE(transport->logger,
-                                    "DefaultWT: {} Received FIN for connection{}, stream {}",
-                                    WtEventToString(wt_event),
-                                    conn_id,
-                                    stream_id);
+                QUICR_LOGGER_TRACE(transport->logger,
+                                   "DefaultWT: {} Received FIN for connection{}, stream {}",
+                                   WtEventToString(wt_event),
+                                   conn_id,
+                                   stream_id);
 
                 picoquic_reset_stream_ctx(cnx, stream_id);
 
@@ -740,17 +739,17 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_provide_data: {
             // Stack is ready to send data on a stream - similar to picoquic_callback_prepare_to_send in PqEventCb
             if (!stream_ctx) {
-                SPDLOG_LOGGER_WARN(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
+                QUICR_LOGGER_WARN(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
                 return -1;
             }
 
             uint64_t stream_id = stream_ctx->stream_id;
 
-            SPDLOG_LOGGER_TRACE(transport->logger,
-                                "DefaultWT: {} for connection {}, h3 stream {}",
-                                WtEventToString(wt_event),
-                                conn_id,
-                                stream_id);
+            QUICR_LOGGER_TRACE(transport->logger,
+                               "DefaultWT: {} for connection {}, h3 stream {}",
+                               WtEventToString(wt_event),
+                               conn_id,
+                               stream_id);
 
             auto connection = GetConnCtxForWT(transport, conn_id, wt_event);
             if (!connection) {
@@ -760,7 +759,7 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
             auto data_ctx = GetDataCtxForWT(connection, stream_id);
             if (data_ctx == nullptr) {
                 // No data context, nothing to send
-                SPDLOG_LOGGER_TRACE(
+                QUICR_LOGGER_TRACE(
                   transport->logger, "DefaultWT: {} no data_ctx for stream {}", WtEventToString(wt_event), stream_id);
                 break;
             }
@@ -772,11 +771,11 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
 
             data_ctx->metrics.tx_stream_cb++;
 
-            SPDLOG_LOGGER_TRACE(transport->logger,
-                                "DefaultWT: {} Invoking to send stream bytes on stream {}",
-                                WtEventToString(wt_event),
-                                length,
-                                stream_id);
+            QUICR_LOGGER_TRACE(transport->logger,
+                               "DefaultWT: {} Invoking to send stream bytes on stream {}",
+                               WtEventToString(wt_event),
+                               length,
+                               stream_id);
 
             // Send stream bytes - this will call picoquic_provide_stream_data_buffer internally
             transport->SendStreamBytes(data_ctx, stream_id, bytes, length);
@@ -785,11 +784,11 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
 
         case picohttp_callback_post_datagram: {
             // Datagram received
-            SPDLOG_LOGGER_TRACE(transport->logger,
-                                "DefaultWT: {} received {} bytes for connection {}",
-                                WtEventToString(wt_event),
-                                length,
-                                conn_id);
+            QUICR_LOGGER_TRACE(transport->logger,
+                               "DefaultWT: {} received {} bytes for connection {}",
+                               WtEventToString(wt_event),
+                               length,
+                               conn_id);
 
             if (auto connection = GetConnCtxForWT(transport, conn_id, wt_event)) {
                 transport->OnRecvDatagram(connection, bytes, length);
@@ -813,17 +812,17 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_reset: {
             // Stream has been abandoned
             if (!stream_ctx) {
-                SPDLOG_LOGGER_WARN(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
+                QUICR_LOGGER_WARN(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
                 return -1;
             }
 
             uint64_t stream_id = stream_ctx->stream_id;
 
-            SPDLOG_LOGGER_DEBUG(transport->logger,
-                                "DefaultWT: {} for stream {} on connection {}",
-                                WtEventToString(wt_event),
-                                stream_id,
-                                conn_id);
+            QUICR_LOGGER_DEBUG(transport->logger,
+                               "DefaultWT: {} for stream {} on connection {}",
+                               WtEventToString(wt_event),
+                               stream_id,
+                               conn_id);
 
             if (auto connection = transport->GetConnection(conn_id)) {
                 auto rx_buf_it = connection->rx_stream_buffer.find(stream_id);
@@ -850,17 +849,17 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
         case picohttp_callback_stop_sending: {
             // Peer wants to abandon receiving on the stream
             if (!stream_ctx) {
-                SPDLOG_LOGGER_WARN(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
+                QUICR_LOGGER_WARN(transport->logger, "DefaultWT: {} with null stream_ctx", WtEventToString(wt_event));
                 return -1;
             }
 
             uint64_t stream_id = stream_ctx->stream_id;
 
-            SPDLOG_LOGGER_DEBUG(transport->logger,
-                                "DefaultWT: {} for stream {} on connection {}",
-                                WtEventToString(wt_event),
-                                stream_id,
-                                conn_id);
+            QUICR_LOGGER_DEBUG(transport->logger,
+                               "DefaultWT: {} for stream {} on connection {}",
+                               WtEventToString(wt_event),
+                               stream_id,
+                               conn_id);
 
             if (auto connection = transport->GetConnection(conn_id)) {
                 auto rx_buf_it = connection->rx_stream_buffer.find(stream_id);
@@ -886,14 +885,14 @@ DefaultWebTransportCallback(picoquic_cnx_t* cnx,
 
         case picohttp_callback_free:
             // Clean up the stream
-            SPDLOG_LOGGER_DEBUG(
+            QUICR_LOGGER_DEBUG(
               transport->logger, "DefaultWT: {} callback for connection {}", WtEventToString(wt_event), conn_id);
             break;
 
         case picohttp_callback_deregister: {
             // The app context has been removed from the registry.
             // Its references should be removed from streams belonging to this session.
-            SPDLOG_LOGGER_DEBUG(
+            QUICR_LOGGER_DEBUG(
               transport->logger, "DefaultWT: {} callback for connection {}", WtEventToString(wt_event), conn_id);
 
             transport->DeregisterWebTransport(cnx);
@@ -983,17 +982,17 @@ PicoQuicTransport::Start()
 #endif
 
     if (tconfig_.use_reset_wait_strategy) {
-        SPDLOG_LOGGER_INFO(logger, "Using Reset and Wait congestion control strategy");
+        QUICR_LOGGER_INFO(logger, "Using Reset and Wait congestion control strategy");
     }
 
     // Initialize WebTransport
     if (auto wt_ret = InitializeWebTransportContext(); wt_ret != 0) {
-        SPDLOG_LOGGER_ERROR(logger, "Failed to initialize WebTransport");
+        QUICR_LOGGER_ERROR(logger, "Failed to initialize WebTransport");
         return nullptr;
     }
 
     if (not tconfig_.use_bbr) {
-        SPDLOG_LOGGER_INFO(logger, "Using NewReno congestion control");
+        QUICR_LOGGER_INFO(logger, "Using NewReno congestion control");
         (void)picoquic_config_set_option(&config_, picoquic_option_CC_ALGO, "reno");
     }
 
@@ -1007,7 +1006,7 @@ PicoQuicTransport::Start()
       &config_, picoquic_option_MAX_CONNECTIONS, std::to_string(tconfig_.max_connections).c_str());
 
     if (is_server_mode) {
-        SPDLOG_LOGGER_DEBUG(logger, "Start: As Server, configuring WebTransport Path Params");
+        QUICR_LOGGER_DEBUG(logger, "Start: As Server, configuring WebTransport Path Params");
 
         // Store path items in the class member to ensure memory persists after Start() returns
         wt_config_->path_items = { { serverInfo_.path.c_str(), 6, DefaultWebTransportCallback, this } };
@@ -1027,22 +1026,22 @@ PicoQuicTransport::Start()
         picoquic_use_unique_log_names(quic_ctx_, 1);
     } else {
         if (connection_api == Connection::API::kWebTransport) {
-            SPDLOG_LOGGER_INFO(logger, "Client configured for WebTransport over QUIC");
+            QUICR_LOGGER_INFO(logger, "Client configured for WebTransport over QUIC");
             quic_ctx_ = picoquic_create_and_configure(&config_, NULL, NULL, current_time, NULL);
         } else {
-            SPDLOG_LOGGER_INFO(logger, "Client configured for Raw QUIC");
+            QUICR_LOGGER_INFO(logger, "Client configured for Raw QUIC");
             quic_ctx_ = picoquic_create_and_configure(&config_, PqEventCb, this, current_time, NULL);
         }
     }
 
     if (quic_ctx_ == NULL) {
-        SPDLOG_LOGGER_CRITICAL(logger, "Unable to create picoquic context, check certificate and key filenames");
+        QUICR_LOGGER_CRITICAL(logger, "Unable to create picoquic context, check certificate and key filenames");
         throw PicoQuicException("Unable to create picoquic context");
     }
 
     if (config_.enable_sslkeylog) {
         if (std::getenv("SSLKEYLOGFILE") == nullptr) {
-            SPDLOG_LOGGER_WARN(logger, "Key log enabled but $SSLKEYLOGFILE not set");
+            QUICR_LOGGER_WARN(logger, "Key log enabled but $SSLKEYLOGFILE not set");
         }
         picoquic_set_key_log_file_from_env(quic_ctx_);
     }
@@ -1078,7 +1077,7 @@ PicoQuicTransport::Start()
     picoquic_set_default_priority(quic_ctx_, 2);
     picoquic_set_default_datagram_priority(quic_ctx_, 1);
 
-    SPDLOG_LOGGER_INFO(logger, "Setting idle timeout to {}ms", tconfig_.idle_timeout_ms);
+    QUICR_LOGGER_INFO(logger, "Setting idle timeout to {}ms", tconfig_.idle_timeout_ms);
 
     picoquic_runner_queue_.SetLimit(tconfig_.callback_queue_size);
 
@@ -1086,7 +1085,7 @@ PicoQuicTransport::Start()
     cbNotifyThread_ = std::thread(&PicoQuicTransport::CbNotifier, this);
 
     if (!tconfig_.quic_qlog_path.empty()) {
-        SPDLOG_LOGGER_INFO(logger, "Enabling qlog using '{}' path", tconfig_.quic_qlog_path);
+        QUICR_LOGGER_INFO(logger, "Enabling qlog using '{}' path", tconfig_.quic_qlog_path);
         picoquic_set_qlog(quic_ctx_, tconfig_.quic_qlog_path.c_str());
     }
 
@@ -1094,11 +1093,11 @@ PicoQuicTransport::Start()
 
     if (is_server_mode) {
 
-        SPDLOG_LOGGER_INFO(logger, "Starting server, listening on {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
+        QUICR_LOGGER_INFO(logger, "Starting server, listening on {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
         Server();
 
     } else {
-        SPDLOG_LOGGER_INFO(logger, "Connecting to server {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
+        QUICR_LOGGER_INFO(logger, "Connecting to server {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
 
         if (ClientLoop()) {
             return StartClient();
@@ -1128,12 +1127,12 @@ PicoQuicTransport::Enqueue(const std::shared_ptr<Connection>& connection,
                            [[maybe_unused]] const uint32_t delay_ms,
                            const EnqueueFlags flags)
 {
-    SPDLOG_LOGGER_TRACE(logger,
-                        "Enqueue conn_id: {} data_ctx_id: {} stream_id: {} size: {}",
-                        conn_id,
-                        data_ctx_id,
-                        stream_id,
-                        bytes->size());
+    QUICR_LOGGER_TRACE(logger,
+                       "Enqueue conn_id: {} data_ctx_id: {} stream_id: {} size: {}",
+                       connection->GetID(),
+                       data_ctx_id,
+                       stream_id,
+                       (bytes ? bytes->size() : 0));
 
     std::lock_guard<std::mutex> _(state_mutex_);
 
@@ -1278,10 +1277,10 @@ PicoQuicTransport::CreateDataContext(const std::shared_ptr<Connection>& connecti
 
         if (!use_reliable_transport) {
             picoquic_set_datagram_priority(pq_conn->pq_cnx, priority);
-            SPDLOG_LOGGER_DEBUG(logger,
-                                "Created DGRAM data context id: {} pri: {}",
-                                data_ctx_it->second.data_ctx_id,
-                                static_cast<int>(priority));
+            QUICR_LOGGER_DEBUG(logger,
+                               "Created DGRAM data context id: {} pri: {}",
+                               data_ctx_it->second.data_ctx_id,
+                               static_cast<int>(priority));
         }
     }
 
@@ -1308,7 +1307,7 @@ PicoQuicTransport::Close(const std::shared_ptr<Connection>& connection, AppReaso
 
     // TODO: Maybe this timeout should be configurable?
     if (future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout) {
-        SPDLOG_LOGGER_ERROR(logger, "Timed out waiting for connection to close (conn_id={})", connection->GetID());
+        QUICR_LOGGER_ERROR(logger, "Timed out waiting for connection to close (conn_id={})", connection->GetID());
     }
 }
 
@@ -1388,7 +1387,7 @@ PicoQuicTransport::CloseInternal(const std::shared_ptr<Connection>& connection, 
     // Cleanup client-owned WebTransport h3_ctx before closing connection
     // Server-side h3_ctx is managed by h3zero library and shared across connections
     if (pq_conn->wt_h3_ctx_owned && pq_conn->wt_h3_ctx) {
-        SPDLOG_LOGGER_DEBUG(logger, "Cleaning up client-owned h3_ctx for connection {}", connection->GetID());
+        QUICR_LOGGER_DEBUG(logger, "Cleaning up client-owned h3_ctx for connection {}", connection->GetID());
         // Note: h3zero_callback_delete_context may not exist in all versions
         // The h3zero library typically cleans this up automatically on connection close
         // So we just mark it as null here
@@ -1439,17 +1438,17 @@ PicoQuicTransport::CreateConnection(picoquic_cnx_t* pq_cnx, Connection::API api)
         if (negotiated_alpn) {
             if (strcmp(negotiated_alpn, webtransport_alpn) == 0) {
                 api = Connection::API::kWebTransport;
-                SPDLOG_LOGGER_INFO(logger, "Server connection using WebTransport (ALPN: {})", negotiated_alpn);
+                QUICR_LOGGER_INFO(logger, "Server connection using WebTransport (ALPN: {})", negotiated_alpn);
             } else if (strcmp(negotiated_alpn, kMoqtAlpn) == 0) {
                 api = Connection::API::kNativeQuic;
-                SPDLOG_LOGGER_INFO(logger, "Server connection using raw QUIC (ALPN: {})", negotiated_alpn);
+                QUICR_LOGGER_INFO(logger, "Server connection using raw QUIC (ALPN: {})", negotiated_alpn);
             } else {
                 api = Connection::API::kNativeQuic; // Default fallback
-                SPDLOG_LOGGER_WARN(logger, "Unknown ALPN: {}, defaulting to raw QUIC", negotiated_alpn);
+                QUICR_LOGGER_WARN(logger, "Unknown ALPN: {}, defaulting to raw QUIC", negotiated_alpn);
             }
         } else {
             api = Connection::API::kNativeQuic; // Default fallback
-            SPDLOG_LOGGER_WARN(logger, "No ALPN negotiated, defaulting to raw QUIC");
+            QUICR_LOGGER_WARN(logger, "No ALPN negotiated, defaulting to raw QUIC");
         }
     }
 
@@ -1482,7 +1481,7 @@ PicoQuicTransport::CreateConnection(picoquic_cnx_t* pq_cnx, Connection::API api)
     }
 
     if (is_new) {
-        SPDLOG_LOGGER_INFO(logger, "Created new connection context for conn_id: {}", connection->GetID());
+        QUICR_LOGGER_INFO(logger, "Created new connection context for conn_id: {}", connection->GetID());
 
         connection->dgram_rx_data->SetLimit(tconfig_.time_queue_rx_size);
         connection->dgram_tx_data = std::make_shared<PriorityQueue<ConnData>>(tconfig_.time_queue_max_duration,
@@ -1498,7 +1497,7 @@ PicoQuicTransport::PicoQuicTransport(const TransportRemote& server,
                                      const TransportConfig& tcfg,
                                      bool is_server_mode,
                                      std::shared_ptr<timeq::tick_service> tick_service,
-                                     std::shared_ptr<spdlog::logger> logger,
+                                     std::shared_ptr<Logger> logger,
                                      Connection::API connection_api)
   : logger(std::move(logger))
   , is_server_mode(is_server_mode)
@@ -1553,7 +1552,7 @@ PicoQuicTransport::CreateDataContextBiDirRecv(std::uint64_t conn_id, uint64_t st
 
     const auto conn_it = connections_.find(conn_id);
     if (conn_it == connections_.end()) {
-        SPDLOG_LOGGER_ERROR(logger, "Invalid conn_id: {}, cannot create data context", conn_id);
+        QUICR_LOGGER_ERROR(logger, "Invalid conn_id: {}, cannot create data context", conn_id);
         return nullptr;
     }
 
@@ -1571,11 +1570,11 @@ PicoQuicTransport::CreateDataContextBiDirRecv(std::uint64_t conn_id, uint64_t st
                                                                    tconfig_.time_queue_init_queue_size);
         data_ctx_it->second.streams[stream_id] = std::move(stream);
 
-        SPDLOG_LOGGER_INFO(logger,
-                           "Created new bidir data context conn_id: {} data_ctx_id: {} stream_id: {}",
-                           conn_id,
-                           data_ctx_it->second.data_ctx_id,
-                           stream_id);
+        QUICR_LOGGER_INFO(logger,
+                          "Created new bidir data context conn_id: {} data_ctx_id: {} stream_id: {}",
+                          conn_id,
+                          data_ctx_it->second.data_ctx_id,
+                          stream_id);
 
         return &data_ctx_it->second;
     }
@@ -1594,11 +1593,11 @@ PicoQuicTransport::PqRunner()
     while (auto cb = picoquic_runner_queue_.Pop()) {
         try {
             if (auto ret = (*cb)()) {
-                SPDLOG_LOGGER_ERROR(logger, "PQ function resulted in error: {}", ret);
+                QUICR_LOGGER_ERROR(logger, "PQ function resulted in error: {}", ret);
                 return ret;
             }
         } catch (const std::exception& e) {
-            SPDLOG_LOGGER_ERROR(
+            QUICR_LOGGER_ERROR(
               logger, "Caught exception running callback via notify thread (error={}), ignoring", e.what());
             // TODO(tievens): Add metrics to track if this happens
         }
@@ -1617,17 +1616,17 @@ PicoQuicTransport::DeleteDataContextInternal(const std::shared_ptr<PicoQuicConne
         return;
 
     const auto& streams = data_ctx_it->second.streams;
-    SPDLOG_LOGGER_DEBUG(logger,
-                        "Delete data context {} in conn_id: {} doe: {} / {} stream count: {}",
-                        data_ctx_id,
-                        connection->GetID(),
-                        delete_on_empty,
-                        data_ctx_it->second.delete_on_empty,
-                        streams.size());
+    QUICR_LOGGER_DEBUG(logger,
+                       "Delete data context {} in conn_id: {} doe: {} / {} stream count: {}",
+                       data_ctx_id,
+                       connection->GetID(),
+                       delete_on_empty,
+                       data_ctx_it->second.delete_on_empty,
+                       streams.size());
 
     if (delete_on_empty && !streams.empty()) {
         data_ctx_it->second.delete_on_empty = true;
-        SPDLOG_LOGGER_DEBUG(
+        QUICR_LOGGER_DEBUG(
           logger, "Delete data context {} in conn_id: {} using delete on empty", data_ctx_id, connection->GetID());
 
         // Delegate removal of stream to SendStreamBytes() to ensure all data is transmitted before closing stream
@@ -1645,7 +1644,7 @@ PicoQuicTransport::DeleteDataContextInternal(const std::shared_ptr<PicoQuicConne
         }
 
     } else {
-        SPDLOG_LOGGER_DEBUG(logger, "Delete data context {} in conn_id: {}", data_ctx_id, connection->GetID());
+        QUICR_LOGGER_DEBUG(logger, "Delete data context {} in conn_id: {}", data_ctx_id, connection->GetID());
 
         std::vector<std::uint64_t> stream_ids;
         stream_ids.reserve(streams.size());
@@ -1708,19 +1707,19 @@ PicoQuicTransport::SendNextDatagram(const std::shared_ptr<PicoQuicConnection>& c
     if (out_data.has_value()) {
         const auto data_ctx_it = connection->active_data_contexts.find(out_data->get().data_ctx_id);
         if (data_ctx_it == connection->active_data_contexts.end()) {
-            SPDLOG_LOGGER_DEBUG(logger,
-                                "send_next_dgram has no data context conn_id: {} data len: {} dropping",
-                                connection->GetID(),
-                                out_data->get().data->size());
+            QUICR_LOGGER_DEBUG(logger,
+                               "send_next_dgram has no data context conn_id: {} data len: {} dropping",
+                               connection->GetID(),
+                               out_data->get().data->size());
             connection->metrics.tx_dgram_drops++;
             return;
         }
 
         if (out_data->get().data == nullptr || out_data->get().data->size() == 0) {
-            SPDLOG_LOGGER_ERROR(logger,
-                                "conn_id: {} data_ctx_id: {} has ZERO data size",
-                                data_ctx_it->second.conn_id,
-                                data_ctx_it->second.data_ctx_id);
+            QUICR_LOGGER_ERROR(logger,
+                               "conn_id: {} data_ctx_id: {} has ZERO data size",
+                               data_ctx_it->second.conn_id,
+                               data_ctx_it->second.data_ctx_id);
             connection->dgram_tx_data->Pop();
             return;
         }
@@ -1767,32 +1766,32 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
 
     auto stream_it = data_ctx->streams.find(stream_id);
     if (stream_it == data_ctx->streams.end()) {
-        SPDLOG_LOGGER_WARN(logger,
-                           "SendStreamBytes conn_id: {} data_ctx_id: {} stream_id: {} bytes_len: {}, stream not found",
-                           data_ctx->conn_id,
-                           data_ctx->data_ctx_id,
-                           stream_id,
-                           max_len);
+        QUICR_LOGGER_WARN(logger,
+                          "SendStreamBytes conn_id: {} data_ctx_id: {} stream_id: {} bytes_len: {}, stream not found",
+                          data_ctx->conn_id,
+                          data_ctx->data_ctx_id,
+                          stream_id,
+                          max_len);
         return;
     }
 
     auto& stream_ctx = stream_it->second;
 
     if (stream_ctx.tx_data == nullptr) {
-        SPDLOG_LOGGER_WARN(logger,
-                           "SendStreamBytes conn_id: {} data_ctx_id: {} stream_id: {} has no TX queue, skipping",
-                           data_ctx->conn_id,
-                           data_ctx->data_ctx_id,
-                           stream_id);
+        QUICR_LOGGER_WARN(logger,
+                          "SendStreamBytes conn_id: {} data_ctx_id: {} stream_id: {} has no TX queue, skipping",
+                          data_ctx->conn_id,
+                          data_ctx->data_ctx_id,
+                          stream_id);
         return;
     }
 
-    SPDLOG_LOGGER_TRACE(logger,
-                        "SendStreamBytes conn_id: {} data_ctx_id: {} stream_id: {} bytes_len: {}",
-                        data_ctx->conn_id,
-                        data_ctx->data_ctx_id,
-                        stream_id,
-                        max_len);
+    QUICR_LOGGER_TRACE(logger,
+                       "SendStreamBytes conn_id: {} data_ctx_id: {} stream_id: {} bytes_len: {}",
+                       data_ctx->conn_id,
+                       data_ctx->data_ctx_id,
+                       stream_id,
+                       max_len);
 
     uint32_t data_len = 0; /// Length of data to follow the 4 byte length
     size_t offset = 0;
@@ -1856,16 +1855,16 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
     }
 
     if (stream_ctx.tx_object == nullptr) {
-        SPDLOG_LOGGER_TRACE(logger,
-                            "SendStreamBytes conn_id: {} data_ctx_id: {} stream_tx_object is nullptr",
-                            data_ctx->conn_id,
-                            data_ctx->data_ctx_id);
+        QUICR_LOGGER_TRACE(logger,
+                           "SendStreamBytes conn_id: {} data_ctx_id: {} stream_tx_object is nullptr",
+                           data_ctx->conn_id,
+                           data_ctx->data_ctx_id);
 
         auto obj = stream_ctx.tx_data->PopFront();
 
         if (obj.expired) {
             data_ctx->metrics.tx_queue_expired += obj.expired;
-            SPDLOG_LOGGER_DEBUG(
+            QUICR_LOGGER_DEBUG(
               logger,
               "Send stream objects expired; conn_id: {} data_ctx_id: {} stream_id: {} expired: {} queue_size: {}",
               data_ctx->conn_id,
@@ -1905,14 +1904,14 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
                                                              obj.value->tick_microseconds);
 
             if (obj.value->stream_action != StreamAction::kNoAction) {
-                SPDLOG_LOGGER_TRACE(
+                QUICR_LOGGER_TRACE(
                   logger,
                   "Object wants New Stream conn_id: {} data_ctx_id: {} stream_id: {}, object size: {} queue_size: {}",
                   data_ctx->conn_id,
                   data_ctx->data_ctx_id,
-                  *data_ctx->current_stream_id,
-                  obj.value.data->size(),
-                  data_ctx->tx_data->Size());
+                  stream_id,
+                  obj.value->data->size(),
+                  stream_ctx.tx_data->Size());
             }
 
             stream_ctx.tx_object = std::move(obj.value->data);
@@ -1947,12 +1946,12 @@ PicoQuicTransport::SendStreamBytes(DataContext* data_ctx, std::uint64_t stream_i
 
     if (buf == NULL) {
         // Error allocating memory to write
-        SPDLOG_LOGGER_ERROR(logger,
-                            "conn_id: {} data_ctx_id: {} priority: {} unable to allocate pq buffer size: {}",
-                            data_ctx->conn_id,
-                            data_ctx->data_ctx_id,
-                            static_cast<int>(stream_ctx.priority),
-                            data_len);
+        QUICR_LOGGER_ERROR(logger,
+                           "conn_id: {} data_ctx_id: {} priority: {} unable to allocate pq buffer size: {}",
+                           data_ctx->conn_id,
+                           data_ctx->data_ctx_id,
+                           static_cast<int>(stream_ctx.priority),
+                           data_len);
         return;
     }
 
@@ -1973,11 +1972,11 @@ PicoQuicTransport::OnConnectionStatus(const std::shared_ptr<PicoQuicConnection>&
         return;
     }
 
-    SPDLOG_LOGGER_DEBUG(
+    QUICR_LOGGER_DEBUG(
       logger, "Connection changed conn_id: {} to status: {}", connection->GetID(), static_cast<int>(status));
 
     if (status == TransportStatus::kReady) {
-        SPDLOG_LOGGER_INFO(logger, "Connection established to server {}", connection->peer_addr_text);
+        QUICR_LOGGER_INFO(logger, "Connection established to server {}", connection->peer_addr_text);
     }
 
     cbNotifyQueue_.Push([connection, status]() { connection->SetStatus(static_cast<Connection::Status>(status)); });
@@ -1986,11 +1985,11 @@ PicoQuicTransport::OnConnectionStatus(const std::shared_ptr<PicoQuicConnection>&
 void
 PicoQuicTransport::HandleNewConnection(const std::shared_ptr<PicoQuicConnection>& connection)
 {
-    SPDLOG_LOGGER_INFO(logger,
-                       "New Connection {} port: {} conn_id: {}",
-                       connection->peer_addr_text,
-                       connection->peer_port,
-                       connection->GetID());
+    QUICR_LOGGER_INFO(logger,
+                      "New Connection {} port: {} conn_id: {}",
+                      connection->peer_addr_text,
+                      connection->peer_port,
+                      connection->GetID());
 
     TransportRemote remote{ .host_or_ip = connection->peer_addr_text,
                             .port = connection->peer_port,
@@ -2003,7 +2002,7 @@ PicoQuicTransport::HandleNewConnection(const std::shared_ptr<PicoQuicConnection>
     // Setup WebTransport for server connections if needed
     if (connection->GetAPI() == Connection::API::kWebTransport) {
         if (auto wt_ret = SetupWebTransportConnection(connection->pq_cnx); wt_ret != 0) {
-            SPDLOG_LOGGER_ERROR(logger, "Failed to setup WebTransport connection for server");
+            QUICR_LOGGER_ERROR(logger, "Failed to setup WebTransport connection for server");
         }
     } else {
         picoquic_set_callback(connection->pq_cnx, PqEventCb, this);
@@ -2011,7 +2010,7 @@ PicoQuicTransport::HandleNewConnection(const std::shared_ptr<PicoQuicConnection>
 #endif
 
     if (tconfig_.quic_priority_limit > 0) {
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger, "Setting priority bypass limit to {}", static_cast<int>(tconfig_.quic_priority_limit));
         picoquic_set_priority_limit_for_bypass(connection->pq_cnx, tconfig_.quic_priority_limit);
     }
@@ -2029,7 +2028,7 @@ try {
     }
 
     if (connection == nullptr) {
-        SPDLOG_LOGGER_WARN(logger, "DGRAM received with NULL connection context; dropping length: {}", length);
+        QUICR_LOGGER_WARN(logger, "DGRAM received with NULL connection context; dropping length: {}", length);
         return;
     }
 
@@ -2038,15 +2037,15 @@ try {
     connection->metrics.rx_dgrams_bytes += length;
 
     if (cbNotifyQueue_.Size() > 1000) {
-        SPDLOG_LOGGER_INFO(logger, "on_recv_datagram cbNotifyQueue size {}", cbNotifyQueue_.Size());
+        QUICR_LOGGER_INFO(logger, "on_recv_datagram cbNotifyQueue size {}", cbNotifyQueue_.Size());
     }
 
     if (connection->dgram_rx_data->Size() < 10 &&
         !cbNotifyQueue_.Push([=, this]() { connection->OnRecvDgram(std::nullopt); })) {
-        SPDLOG_LOGGER_ERROR(logger, "conn_id: {} DGRAM notify queue is full", connection->GetID());
+        QUICR_LOGGER_ERROR(logger, "conn_id: {} DGRAM notify queue is full", connection->GetID());
     }
 } catch (const std::exception& e) {
-    SPDLOG_LOGGER_ERROR(logger, "Caught exception in OnRecvDatagram. (error={})", e.what());
+    QUICR_LOGGER_ERROR(logger, "Caught exception in OnRecvDatagram. (error={})", e.what());
     // TODO(tievens): Add metrics to track if this happens
 }
 
@@ -2066,11 +2065,11 @@ try {
     if (connection->GetAPI() == Connection::API::kWebTransport && connection->wt_control_stream_ctx != nullptr &&
         stream_id == connection->wt_control_stream_ctx->stream_id) {
 
-        SPDLOG_LOGGER_DEBUG(logger,
-                            "OnRecvStreamBytes: Received data on control stream {} for conn_id={}, len={}",
-                            stream_id,
-                            connection->GetID(),
-                            bytes.size());
+        QUICR_LOGGER_DEBUG(logger,
+                           "OnRecvStreamBytes: Received data on control stream {} for conn_id={}, len={}",
+                           stream_id,
+                           connection->GetID(),
+                           bytes.size());
 
         // Parse the capsule data using picowt_receive_capsule
         // This accumulates partial capsule data across multiple calls
@@ -2079,10 +2078,10 @@ try {
               connection->pq_cnx, bytes.data(), bytes.data() + bytes.size(), &connection->wt_capsule);
 
             if (ret != 0) {
-                SPDLOG_LOGGER_ERROR(logger,
-                                    "OnRecvStreamBytes: Failed to parse capsule on control stream {} for conn_id={}",
-                                    stream_id,
-                                    connection->GetID());
+                QUICR_LOGGER_ERROR(logger,
+                                   "OnRecvStreamBytes: Failed to parse capsule on control stream {} for conn_id={}",
+                                   stream_id,
+                                   connection->GetID());
                 picowt_release_capsule(&connection->wt_capsule);
                 return;
             }
@@ -2090,7 +2089,7 @@ try {
 
         // Check if capsule is fully received and stored
         if (connection->wt_capsule.h3_capsule.is_stored) {
-            SPDLOG_LOGGER_INFO(
+            QUICR_LOGGER_INFO(
               logger,
               "OnRecvStreamBytes: Received capsule type={} error_code={} on control stream {} for conn_id={}",
               connection->wt_capsule.h3_capsule.capsule_type,
@@ -2104,7 +2103,7 @@ try {
 
                 if (!is_server_mode) {
                     // Client: close the connection
-                    SPDLOG_LOGGER_INFO(
+                    QUICR_LOGGER_INFO(
                       logger,
                       "OnRecvStreamBytes: Client received control stream capsule, closing connection {}",
                       connection->GetID());
@@ -2112,10 +2111,10 @@ try {
                 } else {
                     // Server: send FIN back on control stream if not already sent
                     if (!connection->wt_control_stream_ctx->ps.stream_state.is_fin_sent) {
-                        SPDLOG_LOGGER_INFO(logger,
-                                           "OnRecvStreamBytes: Server sending FIN on control stream {} for conn_id={}",
-                                           stream_id,
-                                           connection->GetID());
+                        QUICR_LOGGER_INFO(logger,
+                                          "OnRecvStreamBytes: Server sending FIN on control stream {} for conn_id={}",
+                                          stream_id,
+                                          connection->GetID());
                         picoquic_add_to_stream(connection->pq_cnx, stream_id, NULL, 0, 1);
                     }
                     // Delete the stream prefix for this WebTransport session
@@ -2138,10 +2137,10 @@ try {
     auto rx_buf_it = connection->rx_stream_buffer.find(stream_id);
     if (rx_buf_it == connection->rx_stream_buffer.end()) {
         if (bytes.size() < kMinStreamBytesForSend) {
-            SPDLOG_LOGGER_DEBUG(logger,
-                                "bytes received from picoquic stream {} len: {} is too small to process stream header",
-                                stream_id,
-                                bytes.size());
+            QUICR_LOGGER_DEBUG(logger,
+                               "bytes received from picoquic stream {} len: {} is too small to process stream header",
+                               stream_id,
+                               bytes.size());
         }
         auto [it, _] = connection->rx_stream_buffer.try_emplace(stream_id);
         it->second.rx_ctx->data_queue.SetLimit(tconfig_.time_queue_rx_size);
@@ -2154,11 +2153,11 @@ try {
       static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(tick_service_->get()).count());
 
     if (rx_buf.rx_ctx->unknown_expiry_tick_ms && curr_ticks_ms > rx_buf.rx_ctx->unknown_expiry_tick_ms) {
-        SPDLOG_LOGGER_DEBUG(logger,
-                            "Stream is unknown and now has expired, resetting stream {} expiry {}ms > {}ms",
-                            stream_id,
-                            rx_buf.rx_ctx->unknown_expiry_tick_ms,
-                            curr_ticks_ms);
+        QUICR_LOGGER_DEBUG(logger,
+                           "Stream is unknown and now has expired, resetting stream {} expiry {}ms > {}ms",
+                           stream_id,
+                           rx_buf.rx_ctx->unknown_expiry_tick_ms,
+                           curr_ticks_ms);
         picoquic_reset_stream_ctx(connection->pq_cnx, stream_id);
         picoquic_reset_stream(connection->pq_cnx, stream_id, static_cast<uint64_t>(StreamErrorCodes::kUnknownExpiry));
         rx_buf.closed = true;
@@ -2177,7 +2176,7 @@ try {
                 connection->OnRecvStream(stream_id, data_ctx_id, (stream_id & 2) == 0);
             })) {
 
-            SPDLOG_LOGGER_ERROR(
+            QUICR_LOGGER_ERROR(
               logger, "conn_id: {} stream_id: {} notify queue is full", connection->GetID(), stream_id);
         }
 
@@ -2186,12 +2185,12 @@ try {
         // QUIC stream IDs have bit 1 set to 0 for bidirectional streams
         if (!cbNotifyQueue_.Push(
               [=, this]() { connection->OnRecvStream(stream_id, std::nullopt, (stream_id & 2) == 0); })) {
-            SPDLOG_LOGGER_ERROR(
+            QUICR_LOGGER_ERROR(
               logger, "conn_id: {} stream_id: {} notify queue is full", connection->GetID(), stream_id);
         }
     }
 } catch (const std::exception& e) {
-    SPDLOG_LOGGER_ERROR(logger, "Caught exception in OnRecvStreamBytes. (error={})", e.what());
+    QUICR_LOGGER_ERROR(logger, "Caught exception in OnRecvStreamBytes. (error={})", e.what());
     // TODO(tievens): Add metrics to track if this happens
 }
 
@@ -2202,7 +2201,7 @@ PicoQuicTransport::OnStreamClosed(const std::shared_ptr<PicoQuicConnection>& con
                                   std::optional<uint64_t> data_ctx_id,
                                   StreamClosedFlag flag)
 {
-    SPDLOG_DEBUG("Stream {} closed for connection {}", stream_id, connection->GetID());
+    QUICR_DEBUG("Stream {} closed for connection {}", stream_id, connection->GetID());
     cbNotifyQueue_.Push([=, rx_ctx = std::move(rx_ctx)]() {
         connection->OnStreamClosed(stream_id, std::move(rx_ctx), data_ctx_id, flag);
     });
@@ -2302,14 +2301,14 @@ PicoQuicTransport::CheckConnsForCongestion()
                 // Don't include control stream in delayed callbacks check. Control stream should be priority 0 or 1
                 if (stream.priority >= 2 &&
                     data_ctx.metrics.tx_delayed_callback - data_ctx.metrics.prev_tx_delayed_callback > 1) {
-                    SPDLOG_LOGGER_DEBUG(logger,
-                                        "CC: remote: {} port: {} conn_id: {} stream_id: {} queue_size: {}",
-                                        connection->peer_addr_text,
-                                        connection->peer_port,
-                                        conn_id,
-                                        stream_id,
-                                        data_ctx.metrics.tx_delayed_callback -
-                                          data_ctx.metrics.prev_tx_delayed_callback);
+                    QUICR_LOGGER_DEBUG(logger,
+                                       "CC: remote: {} port: {} conn_id: {} stream_id: {} queue_size: {}",
+                                       connection->peer_addr_text,
+                                       connection->peer_port,
+                                       conn_id,
+                                       stream_id,
+                                       data_ctx.metrics.tx_delayed_callback -
+                                         data_ctx.metrics.prev_tx_delayed_callback);
 
                     congested_count++;
                 }
@@ -2323,13 +2322,13 @@ PicoQuicTransport::CheckConnsForCongestion()
                 // TODO(tievens): size of TX is based on rate; adjust based on burst rates
                 if (tx_data_size >= 50) {
                     congested_count++;
-                    SPDLOG_LOGGER_DEBUG(logger,
-                                        "CC: remote: {} port: {} conn_id: {} stream_id: {} queue_size: {}",
-                                        connection->peer_addr_text,
-                                        connection->peer_port,
-                                        conn_id,
-                                        stream_id,
-                                        tx_data_size);
+                    QUICR_LOGGER_DEBUG(logger,
+                                       "CC: remote: {} port: {} conn_id: {} stream_id: {} queue_size: {}",
+                                       connection->peer_addr_text,
+                                       connection->peer_port,
+                                       conn_id,
+                                       stream_id,
+                                       tx_data_size);
                 }
 
                 if (stream.priority >= kPqRestWaitMinPriority && data_ctx.uses_reset_wait &&
@@ -2342,13 +2341,13 @@ PicoQuicTransport::CheckConnsForCongestion()
 
         if (cwin_congested_count &&
             connection->pq_cnx->nb_retransmission_total - connection->metrics.tx_retransmits > 2) {
-            SPDLOG_LOGGER_DEBUG(logger,
-                                "CC: remote: {} port: {} conn_id: {} retransmits increased, delta: {} total: {}",
-                                connection->peer_addr_text,
-                                connection->peer_port,
-                                conn_id,
-                                (connection->pq_cnx->nb_retransmission_total - connection->metrics.tx_retransmits),
-                                connection->pq_cnx->nb_retransmission_total);
+            QUICR_LOGGER_DEBUG(logger,
+                               "CC: remote: {} port: {} conn_id: {} retransmits increased, delta: {} total: {}",
+                               connection->peer_addr_text,
+                               connection->peer_port,
+                               conn_id,
+                               (connection->pq_cnx->nb_retransmission_total - connection->metrics.tx_retransmits),
+                               connection->pq_cnx->nb_retransmission_total);
 
             connection->metrics.tx_retransmits = connection->pq_cnx->nb_retransmission_total;
             congested_count++;
@@ -2359,7 +2358,7 @@ PicoQuicTransport::CheckConnsForCongestion()
             connection->metrics.tx_congested++;
 
             connection->is_congested = true;
-            SPDLOG_LOGGER_DEBUG(
+            QUICR_LOGGER_DEBUG(
               logger,
               "CC: conn_id: {} has streams congested. congested_count: {} retrans: {} cwin_congested: {}",
               conn_id,
@@ -2369,7 +2368,7 @@ PicoQuicTransport::CheckConnsForCongestion()
 
             if (tconfig_.use_reset_wait_strategy && reset_wait_data_ctx_id > 0) {
                 auto& data_ctx = connection->active_data_contexts[reset_wait_data_ctx_id];
-                SPDLOG_LOGGER_INFO(
+                QUICR_LOGGER_INFO(
                   logger, "CC: conn_id: {} setting reset and wait to data_ctx_id: {}", conn_id, reset_wait_data_ctx_id);
 
                 for (auto& [_, stream] : data_ctx.streams) {
@@ -2390,7 +2389,7 @@ PicoQuicTransport::CheckConnsForCongestion()
                 // No longer congested
                 connection->is_congested = false;
                 connection->not_congested_gauge = 0;
-                SPDLOG_LOGGER_DEBUG(
+                QUICR_LOGGER_DEBUG(
                   logger, "CC: conn_id: {} congested_count: {} is no longer congested.", conn_id, congested_count);
             } else {
                 connection->not_congested_gauge++;
@@ -2416,12 +2415,12 @@ PicoQuicTransport::Server()
     quic_network_thread_params_.simulate_eio = 0;
     quic_network_thread_params_.send_length_max = 0;
 
-    SPDLOG_LOGGER_DEBUG(logger, "Starting picoquic network thread");
+    QUICR_LOGGER_DEBUG(logger, "Starting picoquic network thread");
     quic_network_thread_ctx_ =
       picoquic_start_network_thread(quic_ctx_, &quic_network_thread_params_, PqLoopCb, this, &quic_loop_return_value_);
 
     if (quic_ctx_ == NULL || quic_network_thread_ctx_ == NULL) {
-        SPDLOG_LOGGER_ERROR(logger, "Failed to start picoquic network thread");
+        QUICR_LOGGER_ERROR(logger, "Failed to start picoquic network thread");
         picoquic_free(quic_ctx_);
         quic_ctx_ = NULL;
         SetStatus(TransportStatus::kShutdown);
@@ -2433,7 +2432,7 @@ PicoQuicTransport::Server()
     }
 
     if (quic_network_thread_ctx_->return_code) {
-        SPDLOG_LOGGER_ERROR(
+        QUICR_LOGGER_ERROR(
           logger, "Could not start quic network thread error: {}", quic_network_thread_ctx_->return_code);
         SetStatus(TransportStatus::kShutdown);
         return;
@@ -2468,7 +2467,7 @@ PicoQuicTransport::StartClient()
         int is_name = 0;
         ret = picoquic_get_server_address(serverInfo_.host_or_ip.c_str(), serverInfo_.port, &server_address, &is_name);
         if (ret != 0 || server_address.ss_family == 0) {
-            SPDLOG_LOGGER_ERROR(
+            QUICR_LOGGER_ERROR(
               logger, "Failed to resolve server: {} port: {}", serverInfo_.host_or_ip, serverInfo_.port);
             notify_caller(1);
             return 0;
@@ -2490,7 +2489,7 @@ PicoQuicTransport::StartClient()
                                       config_.alpn,
                                       1);
             if (cnx == nullptr) {
-                SPDLOG_LOGGER_ERROR(logger, "Could not create picoquic connection client context");
+                QUICR_LOGGER_ERROR(logger, "Could not create picoquic connection client context");
                 notify_caller(1);
                 return PICOQUIC_ERROR_DISCONNECTED;
             }
@@ -2501,12 +2500,12 @@ PicoQuicTransport::StartClient()
             picoquic_set_callback(cnx, PqEventCb, this);
 
             if (auto ret = picoquic_start_client_cnx(cnx)) {
-                SPDLOG_LOGGER_ERROR(logger, "Could not activate connection ret: {}", ret);
+                QUICR_LOGGER_ERROR(logger, "Could not activate connection ret: {}", ret);
                 notify_caller(1);
                 return PICOQUIC_ERROR_DISCONNECTED;
             }
 
-            SPDLOG_LOGGER_INFO(logger, "StartClient: Creating connection context");
+            QUICR_LOGGER_INFO(logger, "StartClient: Creating connection context");
             state->connection = CreateConnection(cnx);
 
         } else if (connection_api == Connection::API::kWebTransport) {
@@ -2517,7 +2516,7 @@ PicoQuicTransport::StartClient()
             ret = picowt_prepare_client_cnx(
               quic_ctx_, (struct sockaddr*)&server_address, &cnx, &h3_ctx, &control_stream_ctx, current_time, sni);
             if (ret != 0) {
-                SPDLOG_LOGGER_ERROR(logger, "picowt_prepare_client_cnx failed with ret: {}", ret);
+                QUICR_LOGGER_ERROR(logger, "picowt_prepare_client_cnx failed with ret: {}", ret);
                 notify_caller(1);
                 return ret;
             }
@@ -2536,12 +2535,12 @@ PicoQuicTransport::StartClient()
             state->connection->wt_h3_ctx_owned = true; // Client owns this and must free it
             state->connection->wt_authority = serverInfo_.host_or_ip + ":" + std::to_string(serverInfo_.port);
 
-            SPDLOG_LOGGER_INFO(logger,
-                               "StartClient:Webtransport Connect: Control Stream ID: {}, "
-                               "authority: {}, path: {}",
-                               control_stream_ctx->stream_id,
-                               state->connection->wt_authority,
-                               wt_config_->path);
+            QUICR_LOGGER_INFO(logger,
+                              "StartClient:Webtransport Connect: Control Stream ID: {}, "
+                              "authority: {}, path: {}",
+                              control_stream_ctx->stream_id,
+                              state->connection->wt_authority,
+                              wt_config_->path);
 
             // Initiate the WebTransport connect
             ret = picowt_connect(cnx,
@@ -2553,7 +2552,7 @@ PicoQuicTransport::StartClient()
                                  this,
                                  kMoqtAlpn);
             if (ret != 0) {
-                SPDLOG_LOGGER_ERROR(logger, "Failed to initiate WebTransport connect");
+                QUICR_LOGGER_ERROR(logger, "Failed to initiate WebTransport connect");
                 notify_caller(1);
                 return ret;
             }
@@ -2561,7 +2560,7 @@ PicoQuicTransport::StartClient()
             ret = picoquic_start_client_cnx(cnx);
 
             if (ret != 0) {
-                SPDLOG_LOGGER_ERROR(logger, "Failed to initiate WebTransport client connection");
+                QUICR_LOGGER_ERROR(logger, "Failed to initiate WebTransport client connection");
                 notify_caller(1);
                 return ret;
             }
@@ -2574,21 +2573,21 @@ PicoQuicTransport::StartClient()
                 snprintf(hex_chars, sizeof(hex_chars), "%02x", icid.id[i]);
                 icid_str += hex_chars;
             }
-            SPDLOG_LOGGER_INFO(logger, "WebTransport Initial connection ID: {}", icid_str);
-            SPDLOG_LOGGER_INFO(logger,
-                               "StartClient:Webtransport (after connect): Control Stream ID: {}, "
-                               "authority: {}, path: {}",
-                               control_stream_ctx->stream_id,
-                               state->connection->wt_authority,
-                               wt_config_->path);
+            QUICR_LOGGER_INFO(logger, "WebTransport Initial connection ID: {}", icid_str);
+            QUICR_LOGGER_INFO(logger,
+                              "StartClient:Webtransport (after connect): Control Stream ID: {}, "
+                              "authority: {}, path: {}",
+                              control_stream_ctx->stream_id,
+                              state->connection->wt_authority,
+                              wt_config_->path);
         }
 
         if (tconfig_.quic_priority_limit > 0) {
-            SPDLOG_LOGGER_INFO(
+            QUICR_LOGGER_INFO(
               logger, "Setting priority bypass limit to {}", static_cast<int>(tconfig_.quic_priority_limit));
             picoquic_set_priority_limit_for_bypass(cnx, tconfig_.quic_priority_limit);
         } else {
-            SPDLOG_LOGGER_INFO(logger, "No priority bypass");
+            QUICR_LOGGER_INFO(logger, "No priority bypass");
         }
 
         notify_caller(reinterpret_cast<uint64_t>(cnx));
@@ -2596,13 +2595,13 @@ PicoQuicTransport::StartClient()
         return 0;
     });
 
-    SPDLOG_LOGGER_DEBUG(logger, "Waiting for client connection context");
+    QUICR_LOGGER_DEBUG(logger, "Waiting for client connection context");
 
     state->cv.wait_for(lock, std::chrono::milliseconds(3000), [&state]() { return state->conn_id > 0; });
 
-    SPDLOG_LOGGER_DEBUG(logger, "Got client connection context conn_id: {}", state->conn_id);
+    QUICR_LOGGER_DEBUG(logger, "Got client connection context conn_id: {}", state->conn_id);
     if (state->conn_id <= 1) {
-        SPDLOG_LOGGER_DEBUG(logger, "Client connection to {}:{} failed", serverInfo_.host_or_ip, serverInfo_.port);
+        QUICR_LOGGER_DEBUG(logger, "Client connection to {}:{} failed", serverInfo_.host_or_ip, serverInfo_.port);
         SetStatus(TransportStatus::kDisconnected);
         return 0;
     }
@@ -2613,7 +2612,7 @@ PicoQuicTransport::StartClient()
 bool
 PicoQuicTransport::ClientLoop()
 {
-    SPDLOG_LOGGER_INFO(logger, "Thread client packet loop starting");
+    QUICR_LOGGER_INFO(logger, "Thread client packet loop starting");
 
     quic_network_thread_params_.local_port = 0;
     quic_network_thread_params_.local_af = PF_UNSPEC;
@@ -2632,7 +2631,7 @@ PicoQuicTransport::ClientLoop()
       picoquic_start_network_thread(quic_ctx_, &quic_network_thread_params_, PqLoopCb, this, &quic_loop_return_value_);
 
     if (quic_ctx_ == nullptr || quic_network_thread_ctx_ == nullptr) {
-        SPDLOG_LOGGER_ERROR(logger, "Failed to create picoquic network thread");
+        QUICR_LOGGER_ERROR(logger, "Failed to create picoquic network thread");
         picoquic_free(quic_ctx_);
         quic_ctx_ = nullptr;
         return false;
@@ -2644,12 +2643,12 @@ PicoQuicTransport::ClientLoop()
     }
 
     if (quic_network_thread_ctx_->return_code) {
-        SPDLOG_LOGGER_ERROR(
+        QUICR_LOGGER_ERROR(
           logger, "Could not start client quic network thread error: {}", quic_network_thread_ctx_->return_code);
         return false;
     }
 
-    SPDLOG_LOGGER_DEBUG(logger, "Thread client packet loop started");
+    QUICR_LOGGER_DEBUG(logger, "Thread client packet loop started");
 
     return true;
 }
@@ -2677,7 +2676,7 @@ PicoQuicTransport::Shutdown()
     }
 
     if (quic_network_thread_ctx_ != NULL) {
-        SPDLOG_LOGGER_INFO(logger, "Closing transport picoquic thread");
+        QUICR_LOGGER_INFO(logger, "Closing transport picoquic thread");
         picoquic_delete_network_thread(quic_network_thread_ctx_);
         quic_network_thread_ctx_ = nullptr;
     }
@@ -2686,7 +2685,7 @@ PicoQuicTransport::Shutdown()
     cbNotifyQueue_.StopWaiting();
 
     if (cbNotifyThread_.joinable()) {
-        SPDLOG_LOGGER_INFO(logger, "Closing transport callback notifier thread");
+        QUICR_LOGGER_INFO(logger, "Closing transport callback notifier thread");
         cbNotifyThread_.join();
     }
 
@@ -2696,7 +2695,7 @@ PicoQuicTransport::Shutdown()
     }
 
     tick_service_.reset();
-    SPDLOG_LOGGER_INFO(logger, "done closing transport threads");
+    QUICR_LOGGER_INFO(logger, "done closing transport threads");
 
     picoquic_config_clear(&config_);
 }
@@ -2733,7 +2732,7 @@ PicoQuicTransport::CheckCallbackDelta(DataContext* data_ctx, bool tx)
 void
 PicoQuicTransport::CbNotifier()
 {
-    SPDLOG_LOGGER_INFO(logger, "Starting transport callback notifier thread");
+    QUICR_LOGGER_INFO(logger, "Starting transport callback notifier thread");
 
     while (not stop_) {
         auto cb = cbNotifyQueue_.BlockPop();
@@ -2741,16 +2740,16 @@ PicoQuicTransport::CbNotifier()
             try {
                 (*cb)();
             } catch (const std::exception& e) {
-                SPDLOG_LOGGER_ERROR(
+                QUICR_LOGGER_ERROR(
                   logger, "Caught exception running callback via notify thread (error={}), ignoring", e.what());
                 // TODO(tievens): Add metrics to track if this happens
             }
         } else {
-            SPDLOG_LOGGER_INFO(logger, "Notify callback is NULL");
+            QUICR_LOGGER_INFO(logger, "Notify callback is NULL");
         }
     }
 
-    SPDLOG_LOGGER_INFO(logger, "Done with transport callback notifier thread");
+    QUICR_LOGGER_INFO(logger, "Done with transport callback notifier thread");
 }
 
 std::uint64_t
@@ -2783,11 +2782,11 @@ PicoQuicTransport::CreateStream(const std::shared_ptr<Connection>& connection,
         throw PicoQuicException("Unable to create stream");
     }
 
-    SPDLOG_LOGGER_DEBUG(logger,
-                        "Created reliable data context id: {} stream_id: {}, pri: {}",
-                        data_ctx_id,
-                        state->stream_id.value(),
-                        static_cast<int>(priority));
+    QUICR_LOGGER_DEBUG(logger,
+                       "Created reliable data context id: {} stream_id: {}, pri: {}",
+                       data_ctx_id,
+                       state->stream_id.value(),
+                       static_cast<int>(priority));
 
     return state->stream_id.value();
 }
@@ -2818,7 +2817,7 @@ PicoQuicTransport::CreateStreamInternal(const std::shared_ptr<Connection>& conne
         // For WebTransport, create stream using picowt_create_local_stream
         // Use per-connection WebTransport context instead of global wt_context_
         if (!pq_conn->wt_h3_ctx || !pq_conn->wt_control_stream_ctx) {
-            SPDLOG_LOGGER_ERROR(
+            QUICR_LOGGER_ERROR(
               logger, "WebTransport context not initialized for connection {} stream creation", pq_conn->GetID());
             throw PicoQuicException("WebTransport context not initialized for connection");
         }
@@ -2829,7 +2828,7 @@ PicoQuicTransport::CreateStreamInternal(const std::shared_ptr<Connection>& conne
                                                                      pq_conn->wt_control_stream_ctx->stream_id);
 
         if (!stream_ctx) {
-            SPDLOG_LOGGER_ERROR(logger, "Failed to create WebTransport stream");
+            QUICR_LOGGER_ERROR(logger, "Failed to create WebTransport stream");
             throw PicoQuicException("Failed to create WebTransport stream");
         }
 
@@ -2846,11 +2845,11 @@ PicoQuicTransport::CreateStreamInternal(const std::shared_ptr<Connection>& conne
         pq_conn->last_stream_id = picoquic_get_next_local_stream_id(pq_conn->pq_cnx, !data_ctx_it->second.is_bidir);
         stream_id = pq_conn->last_stream_id;
 
-        SPDLOG_LOGGER_DEBUG(logger,
-                            "conn_id: {} data_ctx_id: {} create new stream with stream_id: {}",
-                            connection->GetID(),
-                            data_ctx_id,
-                            pq_conn->last_stream_id);
+        QUICR_LOGGER_DEBUG(logger,
+                           "conn_id: {} data_ctx_id: {} create new stream with stream_id: {}",
+                           connection->GetID(),
+                           data_ctx_id,
+                           pq_conn->last_stream_id);
 
         picoquic_set_app_stream_ctx(pq_conn->pq_cnx, stream_id, &data_ctx_it->second);
     }
@@ -2887,15 +2886,15 @@ PicoQuicTransport::CloseStream(const std::shared_ptr<PicoQuicConnection>& connec
 {
     if (data_ctx) {
         if (!data_ctx->streams.contains(stream_id)) {
-            SPDLOG_ERROR("Failed to close stream as it does not exist (conn_id={}, data_ctx_id={}, stream_id={})",
-                         connection->GetID(),
-                         data_ctx->data_ctx_id,
-                         stream_id);
+            QUICR_ERROR("Failed to close stream as it does not exist (conn_id={}, data_ctx_id={}, stream_id={})",
+                        connection->GetID(),
+                        data_ctx->data_ctx_id,
+                        stream_id);
             return;
         }
     }
 
-    SPDLOG_LOGGER_DEBUG(logger, "conn_id: {} closing stream stream_id: {}", connection->GetID(), stream_id);
+    QUICR_LOGGER_DEBUG(logger, "conn_id: {} closing stream stream_id: {}", connection->GetID(), stream_id);
 
     if (use_reset) {
         picoquic_reset_stream_ctx(connection->pq_cnx, stream_id);
@@ -3031,7 +3030,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
     // This function is only called for WebTransport connections (checked by caller)
     // Just verify that WebTransport config is initialized
     if (!wt_config_) {
-        SPDLOG_LOGGER_ERROR(logger, "WebTransport config not initialized");
+        QUICR_LOGGER_ERROR(logger, "WebTransport config not initialized");
         return -1;
     }
 
@@ -3043,7 +3042,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
         // Get or create connection context
         auto connection = GetConnection(conn_id);
         if (!connection) {
-            SPDLOG_LOGGER_ERROR(logger, "Failed to get connection context for client WebTransport setup");
+            QUICR_LOGGER_ERROR(logger, "Failed to get connection context for client WebTransport setup");
             return -1;
         }
 
@@ -3056,7 +3055,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
         int is_name = 0;
         ret = picoquic_get_server_address(serverInfo_.host_or_ip.c_str(), serverInfo_.port, &server_addr, &is_name);
         if (ret != 0) {
-            SPDLOG_LOGGER_ERROR(logger, "Failed to get server address for WebTransport");
+            QUICR_LOGGER_ERROR(logger, "Failed to get server address for WebTransport");
             return ret;
         }
 
@@ -3066,7 +3065,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
         ret = picowt_prepare_client_cnx(
           quic_ctx_, (struct sockaddr*)&server_addr, &prepared_cnx, &h3_ctx, &control_stream_ctx, current_time, sni);
         if (ret != 0) {
-            SPDLOG_LOGGER_ERROR(logger, "picowt_prepare_client_cnx failed with ret: {}", ret);
+            QUICR_LOGGER_ERROR(logger, "picowt_prepare_client_cnx failed with ret: {}", ret);
             return ret;
         }
 
@@ -3086,7 +3085,7 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
                              this,
                              kMoqtAlpn);
         if (ret != 0) {
-            SPDLOG_LOGGER_ERROR(logger, "Failed to initiate WebTransport connect");
+            QUICR_LOGGER_ERROR(logger, "Failed to initiate WebTransport connect");
             return ret;
         }
 
@@ -3098,8 +3097,8 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
             snprintf(hex_chars, sizeof(hex_chars), "%02x", icid.id[i]);
             icid_str += hex_chars;
         }
-        SPDLOG_LOGGER_INFO(logger, "WebTransport Initial connection ID: {}", icid_str);
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(logger, "WebTransport Initial connection ID: {}", icid_str);
+        QUICR_LOGGER_INFO(
           logger, "WebTransport client connect initiated to {}:{}", serverInfo_.host_or_ip, serverInfo_.port);
     } else {
         // Server mode: h3zero_callback will create per-connection h3_ctx automatically
@@ -3109,11 +3108,11 @@ PicoQuicTransport::SetupWebTransportConnection(picoquic_cnx_t* cnx)
         // Set WebTransport transport parameters
         picowt_set_transport_parameters(cnx);
 
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger, "WebTransport server connection setup - h3_ctx will be created per-connection by h3zero_callback");
     }
 
-    SPDLOG_LOGGER_INFO(logger, "WebTransport connection setup completed");
+    QUICR_LOGGER_INFO(logger, "WebTransport connection setup completed");
     return ret;
 }
 
@@ -3130,7 +3129,7 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
     // Validate path parameters
     if (path != nullptr && path_length > 0) {
         std::string path_str(reinterpret_cast<char*>(path), path_length);
-        SPDLOG_LOGGER_INFO(logger, "AcceptWebTransportConnection: received path '{}'", path_str);
+        QUICR_LOGGER_INFO(logger, "AcceptWebTransportConnection: received path '{}'", path_str);
 
         // Get the path portion (before query parameters)
         size_t query_offset = h3zero_query_offset(path, path_length);
@@ -3139,29 +3138,29 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
         // Validate the path matches the expected path
         std::string expected_path = wt_config_ ? wt_config_->path : "/relay";
         if (path_only != expected_path) {
-            SPDLOG_LOGGER_ERROR(logger,
-                                "AcceptWebTransportConnection: path '{}' does not match expected path '{}'",
-                                path_only,
-                                expected_path);
+            QUICR_LOGGER_ERROR(logger,
+                               "AcceptWebTransportConnection: path '{}' does not match expected path '{}'",
+                               path_only,
+                               expected_path);
             return -1;
         }
         // Parse query parameters if present
         if (query_offset < path_length) {
             const uint8_t* queries = path + query_offset;
             size_t queries_length = path_length - query_offset;
-            SPDLOG_LOGGER_DEBUG(logger,
-                                "AcceptWebTransportConnection: query string '{}'",
-                                std::string(reinterpret_cast<const char*>(queries), queries_length));
+            QUICR_LOGGER_DEBUG(logger,
+                               "AcceptWebTransportConnection: query string '{}'",
+                               std::string(reinterpret_cast<const char*>(queries), queries_length));
 
             // Example: Parse a "version" parameter if needed in the future
             // uint64_t version = 0;
             // if (h3zero_query_parameter_number(queries, queries_length, "version", 7, &version, 1) != 0) {
-            //     SPDLOG_LOGGER_ERROR(logger, "AcceptWebTransportConnection: failed to parse version parameter");
+            //     QUICR_LOGGER_ERROR(logger, "AcceptWebTransportConnection: failed to parse version parameter");
             //     return -1;
             // }
         }
     } else {
-        SPDLOG_LOGGER_INFO(logger, "AcceptWebTransportConnection: no path provided");
+        QUICR_LOGGER_INFO(logger, "AcceptWebTransportConnection: no path provided");
     }
 
     auto& connection = CreateConnection(cnx);
@@ -3181,19 +3180,19 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
         ret = h3zero_declare_stream_prefix(h3_ctx, stream_ctx->stream_id, DefaultWebTransportCallback, this);
 
         if (ret != 0) {
-            SPDLOG_LOGGER_ERROR(
+            QUICR_LOGGER_ERROR(
               logger,
               "AcceptWebTransportConnection: Failed to register stream prefix for WebTransport connection {}",
               conn_id);
             return ret;
         }
 
-        SPDLOG_LOGGER_INFO(logger,
-                           "AcceptWebTransportConnection: Registered control stream (stream_id: {}) for connection {}",
-                           stream_ctx->stream_id,
-                           conn_id);
+        QUICR_LOGGER_INFO(logger,
+                          "AcceptWebTransportConnection: Registered control stream (stream_id: {}) for connection {}",
+                          stream_ctx->stream_id,
+                          conn_id);
     } else {
-        SPDLOG_LOGGER_ERROR(
+        QUICR_LOGGER_ERROR(
           logger, "AcceptWebTransportConnection: No stream context provided for WebTransport connection {}", conn_id);
         return -1;
     }
@@ -3202,7 +3201,7 @@ PicoQuicTransport::AcceptWebTransportConnection(picoquic_cnx_t* cnx,
     stream_ctx->path_callback = DefaultWebTransportCallback;
     stream_ctx->path_callback_ctx = this;
 
-    SPDLOG_LOGGER_INFO(logger, "AcceptWebTransportConnection: Done accepting WebTransport connection {}", conn_id);
+    QUICR_LOGGER_INFO(logger, "AcceptWebTransportConnection: Done accepting WebTransport connection {}", conn_id);
 
     HandleNewConnection(connection);
 
@@ -3226,7 +3225,7 @@ PicoQuicTransport::SetWebTransportPathCallback(const std::string& path,
     // Clear existing path items to force recreation with new settings
     wt_config_->path_items.clear();
 
-    SPDLOG_LOGGER_INFO(
+    QUICR_LOGGER_INFO(
       logger, "WebTransport path callback configured: path={}, callback={}", path, callback ? "custom" : "default");
 }
 
@@ -3234,7 +3233,7 @@ h3zero_stream_ctx_t*
 PicoQuicTransport::CreateWebTransportStream(picoquic_cnx_t* cnx, bool is_bidir)
 {
     if (connection_api != Connection::API::kWebTransport) {
-        SPDLOG_LOGGER_ERROR(logger, "CreateWebTransportStream called but not in WebTransport mode");
+        QUICR_LOGGER_ERROR(logger, "CreateWebTransportStream called but not in WebTransport mode");
         return nullptr;
     }
 
@@ -3242,18 +3241,18 @@ PicoQuicTransport::CreateWebTransportStream(picoquic_cnx_t* cnx, bool is_bidir)
     auto conn_id = reinterpret_cast<std::uint64_t>(cnx);
     auto connection = GetConnection(conn_id);
     if (!connection) {
-        SPDLOG_LOGGER_ERROR(logger, "CreateWebTransportStream: Connection context not found for conn_id {}", conn_id);
+        QUICR_LOGGER_ERROR(logger, "CreateWebTransportStream: Connection context not found for conn_id {}", conn_id);
         return nullptr;
     }
 
     if (!connection->wt_h3_ctx) {
-        SPDLOG_LOGGER_ERROR(
+        QUICR_LOGGER_ERROR(
           logger, "CreateWebTransportStream: WebTransport h3_ctx not initialized for conn_id {}", conn_id);
         return nullptr;
     }
 
     if (!connection->wt_control_stream_ctx) {
-        SPDLOG_LOGGER_ERROR(logger, "CreateWebTransportStream: No control stream context for conn_id {}", conn_id);
+        QUICR_LOGGER_ERROR(logger, "CreateWebTransportStream: No control stream context for conn_id {}", conn_id);
         return nullptr;
     }
 
@@ -3265,12 +3264,12 @@ PicoQuicTransport::CreateWebTransportStream(picoquic_cnx_t* cnx, bool is_bidir)
         stream_ctx->path_callback = DefaultWebTransportCallback;
         stream_ctx->path_callback_ctx = this;
 
-        SPDLOG_LOGGER_DEBUG(logger,
-                            "Created WebTransport {} stream: {}",
-                            is_bidir ? "bidirectional" : "unidirectional",
-                            stream_ctx->stream_id);
+        QUICR_LOGGER_DEBUG(logger,
+                           "Created WebTransport {} stream: {}",
+                           is_bidir ? "bidirectional" : "unidirectional",
+                           stream_ctx->stream_id);
     } else {
-        SPDLOG_LOGGER_ERROR(
+        QUICR_LOGGER_ERROR(
           logger, "Failed to create WebTransport {} stream", is_bidir ? "bidirectional" : "unidirectional");
     }
 
@@ -3281,7 +3280,7 @@ int
 PicoQuicTransport::SendWebTransportCloseSession(picoquic_cnx_t* cnx, uint32_t error_code, const char* error_msg)
 {
     if (connection_api != Connection::API::kWebTransport) {
-        SPDLOG_LOGGER_ERROR(logger, "SendWebTransportCloseSession called but not in WebTransport mode");
+        QUICR_LOGGER_ERROR(logger, "SendWebTransportCloseSession called but not in WebTransport mode");
         return -1;
     }
 
@@ -3289,13 +3288,13 @@ PicoQuicTransport::SendWebTransportCloseSession(picoquic_cnx_t* cnx, uint32_t er
     auto conn_id = reinterpret_cast<std::uint64_t>(cnx);
     auto connection = GetConnection(conn_id);
     if (!connection) {
-        SPDLOG_LOGGER_ERROR(
+        QUICR_LOGGER_ERROR(
           logger, "SendWebTransportCloseSession: Connection context not found for conn_id {}", conn_id);
         return -1;
     }
 
     if (!connection->wt_control_stream_ctx) {
-        SPDLOG_LOGGER_ERROR(logger, "SendWebTransportCloseSession: No control stream context for conn_id {}", conn_id);
+        QUICR_LOGGER_ERROR(logger, "SendWebTransportCloseSession: No control stream context for conn_id {}", conn_id);
         return -1;
     }
 
@@ -3303,10 +3302,10 @@ PicoQuicTransport::SendWebTransportCloseSession(picoquic_cnx_t* cnx, uint32_t er
     int ret = picowt_send_close_session_message(cnx, connection->wt_control_stream_ctx, error_code, error_msg);
 
     if (ret == 0) {
-        SPDLOG_LOGGER_INFO(
+        QUICR_LOGGER_INFO(
           logger, "WebTransport close session sent: code={}, msg={}", error_code, error_msg ? error_msg : "");
     } else {
-        SPDLOG_LOGGER_ERROR(logger, "Failed to send WebTransport close session: ret={}", ret);
+        QUICR_LOGGER_ERROR(logger, "Failed to send WebTransport close session: ret={}", ret);
     }
 
     return ret;
@@ -3316,7 +3315,7 @@ int
 PicoQuicTransport::SendWebTransportDrainSession(picoquic_cnx_t* cnx)
 {
     if (connection_api != Connection::API::kWebTransport) {
-        SPDLOG_LOGGER_ERROR(logger, "SendWebTransportDrainSession called but not in WebTransport mode");
+        QUICR_LOGGER_ERROR(logger, "SendWebTransportDrainSession called but not in WebTransport mode");
         return -1;
     }
 
@@ -3324,13 +3323,13 @@ PicoQuicTransport::SendWebTransportDrainSession(picoquic_cnx_t* cnx)
     auto conn_id = reinterpret_cast<std::uint64_t>(cnx);
     auto connection = GetConnection(conn_id);
     if (!connection) {
-        SPDLOG_LOGGER_ERROR(
+        QUICR_LOGGER_ERROR(
           logger, "SendWebTransportDrainSession: Connection context not found for conn_id {}", conn_id);
         return -1;
     }
 
     if (!connection->wt_control_stream_ctx) {
-        SPDLOG_LOGGER_ERROR(logger, "SendWebTransportDrainSession: No control stream context for conn_id {}", conn_id);
+        QUICR_LOGGER_ERROR(logger, "SendWebTransportDrainSession: No control stream context for conn_id {}", conn_id);
         return -1;
     }
 
@@ -3338,9 +3337,9 @@ PicoQuicTransport::SendWebTransportDrainSession(picoquic_cnx_t* cnx)
     int ret = picowt_send_drain_session_message(cnx, connection->wt_control_stream_ctx);
 
     if (ret == 0) {
-        SPDLOG_LOGGER_INFO(logger, "WebTransport drain session sent");
+        QUICR_LOGGER_INFO(logger, "WebTransport drain session sent");
     } else {
-        SPDLOG_LOGGER_ERROR(logger, "Failed to send WebTransport drain session: ret={}", ret);
+        QUICR_LOGGER_ERROR(logger, "Failed to send WebTransport drain session: ret={}", ret);
     }
 
     return ret;
@@ -3368,7 +3367,7 @@ void
 PicoQuicTransport::DeregisterWebTransport(picoquic_cnx_t* cnx)
 {
     if (!is_server_mode && connection_api != Connection::API::kWebTransport) {
-        SPDLOG_LOGGER_WARN(logger, "DeregisterWebTransport called but not in WebTransport mode");
+        QUICR_LOGGER_WARN(logger, "DeregisterWebTransport called but not in WebTransport mode");
         return;
     }
 
@@ -3376,12 +3375,12 @@ PicoQuicTransport::DeregisterWebTransport(picoquic_cnx_t* cnx)
     auto conn_id = reinterpret_cast<std::uint64_t>(cnx);
     auto connection = GetConnection(conn_id);
     if (!connection) {
-        SPDLOG_LOGGER_WARN(logger, "DeregisterWebTransport: Connection context not found for conn_id {}", conn_id);
+        QUICR_LOGGER_WARN(logger, "DeregisterWebTransport: Connection context not found for conn_id {}", conn_id);
         return;
     }
 
     if (!connection->wt_h3_ctx || !connection->wt_control_stream_ctx) {
-        SPDLOG_LOGGER_WARN(logger, "DeregisterWebTransport: WebTransport context already null for conn_id {}", conn_id);
+        QUICR_LOGGER_WARN(logger, "DeregisterWebTransport: WebTransport context already null for conn_id {}", conn_id);
         return;
     }
 
@@ -3391,7 +3390,7 @@ PicoQuicTransport::DeregisterWebTransport(picoquic_cnx_t* cnx)
     // Release any accumulated capsule memory
     picowt_release_capsule(&connection->wt_capsule);
 
-    SPDLOG_LOGGER_INFO(logger, "WebTransport context deregistered for conn_id {}", conn_id);
+    QUICR_LOGGER_INFO(logger, "WebTransport context deregistered for conn_id {}", conn_id);
 
     // Clear the per-connection context
     connection->wt_control_stream_ctx = nullptr;

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -8,6 +8,7 @@
 #include "quicr/containers/safe_queue.h"
 #include "quicr/containers/safe_time_queue.h"
 #include "quicr/containers/stream_buffer.h"
+#include "quicr/log.h"
 #include "quicr/metrics.h"
 #include "quicr/transport.h"
 
@@ -17,7 +18,6 @@
 #include <picoquic.h>
 #include <picoquic_config.h>
 #include <picoquic_packet_loop.h>
-#include <spdlog/spdlog.h>
 #include <timeq/time_queue.h>
 #include <tls_api.h>
 
@@ -99,7 +99,7 @@ namespace quicr {
                           const TransportConfig& tcfg,
                           bool is_server_mode,
                           std::shared_ptr<timeq::tick_service> tick_service,
-                          std::shared_ptr<spdlog::logger> logger,
+                          std::shared_ptr<Logger> logger,
                           Connection::API connection_api);
 
         virtual ~PicoQuicTransport();
@@ -289,7 +289,7 @@ namespace quicr {
                               std::uint64_t stream_id);
 
       public:
-        std::shared_ptr<spdlog::logger> logger;
+        std::shared_ptr<Logger> logger;
         bool is_server_mode;
         bool is_unidirectional{ false };
         bool debug{ false };

--- a/src/transport_picoquic.h
+++ b/src/transport_picoquic.h
@@ -289,7 +289,7 @@ namespace quicr {
                               std::uint64_t stream_id);
 
       public:
-        std::shared_ptr<Logger> logger;
+        std::shared_ptr<Logger> logger_;
         bool is_server_mode;
         bool is_unidirectional{ false };
         bool debug{ false };

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -19,7 +19,6 @@
 #include <future>
 #include <iostream>
 #include <mutex>
-#include <spdlog/spdlog.h>
 #include <string>
 #include <thread>
 #include <vector>

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -44,12 +44,6 @@ namespace quicr_test {
         {
             std::lock_guard lock(mutex_);
             // Forward to subscriber if we have a publish handler bound
-            QUICR_TRACE("Received conn_id: {} object group: {} subgroup: {} object: {} size: {}",
-                        GetConnectionId(),
-                        object_headers.group_id,
-                        object_headers.subgroup_id,
-                        object_headers.object_id,
-                        data.size());
             if (pub_handler_) {
                 pub_handler_->PublishObject(object_headers, data, stream_mode);
             }
@@ -61,12 +55,6 @@ namespace quicr_test {
         {
             auto it = streams_.find(stream_id);
             if (it != streams_.end()) {
-                QUICR_TRACE("Stream closed by {} stream_id: {} group: {} subgroup: {}",
-                            reset ? "RESET" : "FIN",
-                            stream_id,
-                            it->second.current_group_id,
-                            it->second.current_subgroup_id);
-
                 quicr::ObjectHeaders object_headers;
                 object_headers.group_id = it->second.current_group_id;
                 object_headers.subgroup_id = it->second.current_subgroup_id;

--- a/test/integration_test/test_server.h
+++ b/test/integration_test/test_server.h
@@ -3,9 +3,8 @@
 #include "quicr/handlers/publish_namespace_handler.h"
 #include "quicr/handlers/publish_track_handler.h"
 #include "quicr/handlers/subscribe_track_handler.h"
+#include "quicr/log.h"
 #include "quicr/session_callbacks.h"
-
-#include <spdlog/spdlog.h>
 
 #include <future>
 #include <map>
@@ -45,12 +44,12 @@ namespace quicr_test {
         {
             std::lock_guard lock(mutex_);
             // Forward to subscriber if we have a publish handler bound
-            SPDLOG_TRACE("Received conn_id: {} object group: {} subgroup: {} object: {} size: {}",
-                         GetConnectionId(),
-                         object_headers.group_id,
-                         object_headers.subgroup_id,
-                         object_headers.object_id,
-                         data.size());
+            QUICR_TRACE("Received conn_id: {} object group: {} subgroup: {} object: {} size: {}",
+                        GetConnectionId(),
+                        object_headers.group_id,
+                        object_headers.subgroup_id,
+                        object_headers.object_id,
+                        data.size());
             if (pub_handler_) {
                 pub_handler_->PublishObject(object_headers, data, stream_mode);
             }
@@ -62,11 +61,11 @@ namespace quicr_test {
         {
             auto it = streams_.find(stream_id);
             if (it != streams_.end()) {
-                SPDLOG_TRACE("Stream closed by {} stream_id: {} group: {} subgroup: {}",
-                             reset ? "RESET" : "FIN",
-                             stream_id,
-                             it->second.current_group_id,
-                             it->second.current_subgroup_id);
+                QUICR_TRACE("Stream closed by {} stream_id: {} group: {} subgroup: {}",
+                            reset ? "RESET" : "FIN",
+                            stream_id,
+                            it->second.current_group_id,
+                            it->second.current_subgroup_id);
 
                 quicr::ObjectHeaders object_headers;
                 object_headers.group_id = it->second.current_group_id;


### PR DESCRIPTION
Spdlog really shouldn't be an exposed dependency that other libraries magically have included for them. If we ever decided to change loggers randomly suddenly people wouldn't have it for themselves. Instead this just wraps it in our own logger interface that uses spdlog under the hood.

Also in this PR, some of the Trace logs were broken (we clearly never compile with Trace enabled enough), so those needed some fixing as well.