### PR TITLE
Stream buffer fix

### DIFF
--- a/include/quicr/handlers/fetch_track_handler.h
+++ b/include/quicr/handlers/fetch_track_handler.h
@@ -72,10 +72,7 @@ namespace quicr {
          */
         constexpr const messages::FetchEndLocation& GetEndLocation() const noexcept { return end_location_; }
 
-        void StreamDataRecv(bool is_start,
-                            uint64_t stream_id,
-                            std::shared_ptr<const std::vector<uint8_t>> data) override;
-
+      protected:
         void TryParseStreamBufferData(StreamContext& stream) override;
 
       private:

--- a/include/quicr/handlers/joining_fetch_handler.h
+++ b/include/quicr/handlers/joining_fetch_handler.h
@@ -22,9 +22,6 @@ namespace quicr {
           , joining_subscribe_(std::move(joining_subscribe))
         {
         }
-        void StreamDataRecv(bool is_start,
-                            uint64_t stream_id,
-                            std::shared_ptr<const std::vector<uint8_t>> data) override;
 
       protected:
         void TryParseStreamBufferData(StreamContext& stream) override;

--- a/include/quicr/handlers/subscribe_track_handler.h
+++ b/include/quicr/handlers/subscribe_track_handler.h
@@ -313,14 +313,19 @@ namespace quicr {
          * @brief Notification of received stream data slice
          *
          * @details Event notification to provide the caller the raw data received on a stream
+         * @param stream_id       Stream ID data was received on
+         * @param initial_buffer  Initial buffered stream data from start of stream
+         */
+        virtual void StreamDataRecv(uint64_t stream_id, StreamBuffer<uint8_t>&& initial_buffer);
+
+        /**
+         * @brief Notification of received stream data slice
          *
-         * @param is_start    True to indicate if this data is the start of a new stream
+         * @details Event notification to provide the caller the raw data received on a stream
          * @param stream_id   Stream ID data was received on
          * @param data        Shared pointer to the data received
          */
-        virtual void StreamDataRecv(bool is_start,
-                                    uint64_t stream_id,
-                                    std::shared_ptr<const std::vector<uint8_t>> data);
+        virtual void StreamDataRecv(uint64_t stream_id, std::shared_ptr<const std::vector<uint8_t>> data);
 
         /**
          * @brief Notification of received datagram data

--- a/include/quicr/handlers/subscribe_track_handler.h
+++ b/include/quicr/handlers/subscribe_track_handler.h
@@ -11,6 +11,14 @@
 
 namespace quicr {
 
+    struct InitialStreamData
+    {
+        // Accumulated stream data up to handoff.
+        StreamBuffer<uint8_t> buffer;
+        // Original data pointers used to construct stream buffer.
+        std::vector<std::shared_ptr<const std::vector<uint8_t>>> source_buffers;
+    };
+
     /**
      * @brief MOQ track handler for subscribed track
      *
@@ -316,7 +324,7 @@ namespace quicr {
          * @param stream_id       Stream ID data was received on
          * @param initial_buffer  Initial buffered stream data from start of stream
          */
-        virtual void StreamDataRecv(uint64_t stream_id, StreamBuffer<uint8_t>&& initial_buffer);
+        virtual void StreamDataRecv(uint64_t stream_id, InitialStreamData&& initial_buffer);
 
         /**
          * @brief Notification of received stream data slice

--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -973,7 +973,7 @@ namespace quicr {
             bool closed{ false };
             uint64_t client_version{ 0 };
 
-            /// Received data holders for streams: control, request.
+            /// Received data holders for streams: control, request, unrouted data.
             std::map<uint64_t, StreamBuffer<uint8_t>> stream_buffers;
 
             /** Next Connection request Id. This value is shifted left when setting Request Id.
@@ -1264,17 +1264,14 @@ namespace quicr {
 
         uint64_t GetNextRequestId();
 
-        bool OnRecvSubgroup(messages::StreamHeaderProperties properties,
-                            std::vector<uint8_t>::const_iterator cursor_it,
+        bool OnRecvSubgroup(std::uint64_t track_alias,
                             StreamRxContext& rx_ctx,
                             std::uint64_t stream_id,
-                            ConnectionContext& conn_ctx,
-                            std::shared_ptr<const std::vector<uint8_t>> data) const;
-        bool OnRecvFetch(std::vector<uint8_t>::const_iterator cursor_it,
+                            ConnectionContext& conn_ctx) const;
+        bool OnRecvFetch(std::uint64_t request_id,
                          StreamRxContext& rx_ctx,
                          std::uint64_t stream_id,
-                         ConnectionContext& conn_ctx,
-                         std::shared_ptr<const std::vector<uint8_t>> data) const;
+                         ConnectionContext& conn_ctx) const;
 
         std::uint64_t CreateStream(std::uint64_t conn, std::uint64_t data_ctx_id, uint8_t priority);
 

--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -6,6 +6,7 @@
 #include "quicr/attributes.h"
 #include "quicr/common.h"
 #include "quicr/config.h"
+#include "quicr/containers/stream_buffer.h"
 #include "quicr/handlers/fetch_track_handler.h"
 #include "quicr/handlers/publish_fetch_handler.h"
 #include "quicr/handlers/publish_namespace_handler.h"
@@ -972,11 +973,8 @@ namespace quicr {
             bool closed{ false };
             uint64_t client_version{ 0 };
 
-            struct CtrlMsgBuffer
-            {
-                std::vector<uint8_t> data; ///< Control message buffer
-            };
-            std::map<uint64_t, CtrlMsgBuffer> ctrl_msg_buffer; ///< Control message buffer
+            /// Received data holders for streams: control, request.
+            std::map<uint64_t, StreamBuffer<uint8_t>> stream_buffers;
 
             /** Next Connection request Id. This value is shifted left when setting Request Id.
              * The least significant bit is used to indicate client (0) vs server (1).

--- a/include/quicr/session.h
+++ b/include/quicr/session.h
@@ -974,7 +974,7 @@ namespace quicr {
             uint64_t client_version{ 0 };
 
             /// Received data holders for streams: control, request, unrouted data.
-            std::map<uint64_t, StreamBuffer<uint8_t>> stream_buffers;
+            std::map<uint64_t, InitialStreamData> stream_buffers;
 
             /** Next Connection request Id. This value is shifted left when setting Request Id.
              * The least significant bit is used to indicate client (0) vs server (1).

--- a/src/fetch_track_handler.cpp
+++ b/src/fetch_track_handler.cpp
@@ -8,6 +8,10 @@
 namespace quicr {
     void FetchTrackHandler::TryParseStreamBufferData(StreamContext& stream)
     {
+        if (not stream.buffer.AnyHasValue()) {
+            stream.buffer.InitAny<messages::FetchHeader>();
+        }
+
         auto& f_hdr = stream.buffer.GetAny<messages::FetchHeader>();
         if (not(stream.buffer >> f_hdr)) {
             return;

--- a/src/fetch_track_handler.cpp
+++ b/src/fetch_track_handler.cpp
@@ -6,46 +6,23 @@
 #include <spdlog/spdlog.h>
 
 namespace quicr {
-    void FetchTrackHandler::StreamDataRecv(bool is_start,
-                                           std::uint64_t stream_id,
-                                           std::shared_ptr<const std::vector<uint8_t>> data)
-    {
-        SPDLOG_DEBUG("Got fetch data size: {}", data->size());
-
-        auto& stream = streams_[stream_id];
-
-        if (is_start) {
-            stream.buffer.Clear();
-
-            stream.buffer.InitAny<messages::FetchHeader>();
-            stream.buffer.Push(*data);
-
-            // Expect that on initial start of stream, there is enough data to process the stream headers
-
-            auto& f_hdr = stream.buffer.GetAny<messages::FetchHeader>();
-            if (not(stream.buffer >> f_hdr)) {
-                SPDLOG_ERROR("Not enough data to process new stream headers, stream is invalid len: {} / {}",
-                             stream.buffer.Size(),
-                             data->size());
-                // TODO: Add metrics to track this
-                return;
-            }
-        } else {
-            stream.buffer.Push(*data);
-        }
-
-        TryParseStreamBufferData(stream);
-    }
-
     void FetchTrackHandler::TryParseStreamBufferData(StreamContext& stream)
     {
-        if (not stream.buffer.AnyHasValueB()) {
-            stream.buffer.InitAnyB<messages::FetchObject>();
+        auto& f_hdr = stream.buffer.GetAny<messages::FetchHeader>();
+        if (not(stream.buffer >> f_hdr)) {
+            return;
         }
 
-        auto& obj = stream.buffer.GetAnyB<messages::FetchObject>();
+        while (not stream.buffer.Empty()) {
+            if (not stream.buffer.AnyHasValueB()) {
+                stream.buffer.InitAnyB<messages::FetchObject>();
+            }
 
-        if (stream.buffer >> obj) {
+            auto& obj = stream.buffer.GetAnyB<messages::FetchObject>();
+            if (not(stream.buffer >> obj)) {
+                return;
+            }
+
             SPDLOG_TRACE("Received fetch_object subscribe_id: {} priority: {} "
                          "group_id: {} subgroup_id: {} object_id: {} data size: {}",
                          *GetSubscribeId(),
@@ -74,7 +51,7 @@ namespace quicr {
                 SPDLOG_ERROR("Caught exception trying to receive Fetch object. (error={})", e.what());
             }
 
-            stream.buffer.ResetAnyB<messages::FetchObject>();
+            stream.buffer.ResetAnyB();
         }
     }
 }

--- a/src/joining_fetch_handler.cpp
+++ b/src/joining_fetch_handler.cpp
@@ -6,39 +6,23 @@
 #include <spdlog/spdlog.h>
 
 namespace quicr {
-    void JoiningFetchHandler::StreamDataRecv(bool is_start,
-                                             std::uint64_t stream_id,
-                                             std::shared_ptr<const std::vector<uint8_t>> data)
-    {
-        auto& stream = streams_[stream_id];
-
-        if (is_start) {
-            stream.buffer.Clear();
-
-            stream.buffer.InitAny<messages::FetchHeader>();
-            stream.buffer.Push(*data);
-
-            // Expect that on initial start of stream, there is enough data to process the stream headers
-
-            auto& f_hdr = stream.buffer.GetAny<messages::FetchHeader>();
-            if (not(stream.buffer >> f_hdr)) {
-                SPDLOG_ERROR("Not enough data to process new stream headers, stream is invalid");
-                // TODO: Add metrics to track this
-                return;
-            }
-        } else {
-            stream.buffer.Push(*data);
-        }
-
-        TryParseStreamBufferData(stream);
-    }
-
     void JoiningFetchHandler::TryParseStreamBufferData(StreamContext& stream)
     {
-        stream.buffer.InitAnyB<messages::FetchObject>();
-        auto& obj = stream.buffer.GetAnyB<messages::FetchObject>();
+        auto& f_hdr = stream.buffer.GetAny<messages::FetchHeader>();
+        if (not(stream.buffer >> f_hdr)) {
+            return;
+        }
 
-        if (stream.buffer >> obj) {
+        while (not stream.buffer.Empty()) {
+            if (not stream.buffer.AnyHasValueB()) {
+                stream.buffer.InitAnyB<messages::FetchObject>();
+            }
+
+            auto& obj = stream.buffer.GetAnyB<messages::FetchObject>();
+            if (not(stream.buffer >> obj)) {
+                return;
+            }
+
             SPDLOG_TRACE("Received fetch_object subscribe_id: {} priority: {} "
                          "group_id: {} subgroup_id: {} object_id: {} data size: {}",
                          *GetSubscribeId(),
@@ -63,7 +47,7 @@ namespace quicr {
                 SPDLOG_ERROR("Caught exception trying to receive Joining Fetch object. (error={})", e.what());
             }
 
-            stream.buffer.ResetAnyB<messages::FetchObject>();
+            stream.buffer.ResetAnyB();
         }
     }
 }

--- a/src/joining_fetch_handler.cpp
+++ b/src/joining_fetch_handler.cpp
@@ -8,6 +8,10 @@
 namespace quicr {
     void JoiningFetchHandler::TryParseStreamBufferData(StreamContext& stream)
     {
+        if (not stream.buffer.AnyHasValue()) {
+            stream.buffer.InitAny<messages::FetchHeader>();
+        }
+
         auto& f_hdr = stream.buffer.GetAny<messages::FetchHeader>();
         if (not(stream.buffer >> f_hdr)) {
             return;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1853,11 +1853,12 @@ namespace quicr {
                 // Store arriving data into stream's buffer.
                 rx_ctx->data_queue.PopFront();
                 auto& initial_buffer = conn_ctx.stream_buffers[stream_id];
-                initial_buffer.Push(data);
+                initial_buffer.buffer.Push(data);
+                initial_buffer.source_buffers.push_back(std::move(*data_opt));
                 initial_data_buffered = true;
 
                 // Attempt to peek what type this message is.
-                initial_cursor = initial_buffer.Data();
+                initial_cursor = initial_buffer.buffer.Data();
                 initial_stream_type = TryDecodeUintV(initial_cursor);
                 if (!initial_stream_type.has_value()) {
                     SPDLOG_LOGGER_WARN(
@@ -1873,13 +1874,14 @@ namespace quicr {
                                     conn_id,
                                     stream_id,
                                     is_bidir,
-                                    initial_buffer.Size(),
+                                    initial_buffer.buffer.Size(),
                                     *initial_stream_type);
 
                 // This might be incoming control stream arriving.
                 if (static_cast<ControlMessageType>(*initial_stream_type) == ControlMessageType::kSetup) {
                     is_control_stream = true;
                     conn_ctx.rx_ctrl_stream_id = stream_id;
+                    initial_buffer.source_buffers.clear();
                 }
             }
 
@@ -1887,13 +1889,13 @@ namespace quicr {
             if (is_control_stream || is_request_stream) {
                 if (!initial_data_buffered) {
                     // Append.
-                    conn_ctx.stream_buffers[stream_id].Push(data);
+                    conn_ctx.stream_buffers[stream_id].buffer.Push(data);
                     rx_ctx->data_queue.PopFront();
                 }
 
                 rx_ctx->is_new = false;
 
-                auto& stream_buffer = conn_ctx.stream_buffers.at(stream_id);
+                auto& stream_buffer = conn_ctx.stream_buffers.at(stream_id).buffer;
 
                 SPDLOG_LOGGER_DEBUG(logger_,
                                     "Transport:ControlMessageReceived conn_id: {} stream_id: {} data size: {}",

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -35,6 +35,27 @@ namespace quicr {
         }
 
         /**
+         * Try parse uintvar from the front of the span, incrementing past on success.
+         * @param data Span to parse from.
+         * @return Extracted uintvar value, if any.
+         */
+        std::optional<std::uint64_t> TryDecodeUintV(BytesSpan& data) noexcept
+        {
+            if (data.empty()) {
+                return std::nullopt;
+            }
+
+            const auto size = UintVar::Size(data.front());
+            if (data.size() < size) {
+                return std::nullopt;
+            }
+
+            const auto value = static_cast<std::uint64_t>(UintVar(data.first(size)));
+            data = data.subspan(size);
+            return value;
+        }
+
+        /**
          * @brief Create a new server transport based on the remote (server) ip and port
          *
          * @details Server mode automatically supports BOTH raw QUIC (ALPN: moq-00) and
@@ -1198,7 +1219,6 @@ namespace quicr {
         // Incoming PUBNS requests are not handler based.
         if (std::erase(conn_ctx.recv_publish_namespaces, request_id) > 0) {
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.stream_buffers.erase(stream_id);
 
             lock.unlock();
 
@@ -1215,7 +1235,6 @@ namespace quicr {
             SPDLOG_LOGGER_DEBUG(
               logger_, "Stream closed for unknown request_id conn_id: {} request_id: {}", connection_id, request_id);
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.stream_buffers.erase(stream_id);
             return;
         }
 
@@ -1243,7 +1262,6 @@ namespace quicr {
             }
 
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.stream_buffers.erase(stream_id);
 
             lock.unlock();
             UnsubscribeReceived(connection_id, request_id);
@@ -1255,7 +1273,6 @@ namespace quicr {
 
             ClosePublishTrackLocal(conn_ctx, connection_id, *pub_handler, stream_id, is_reset);
             conn_ctx.request_handlers.erase(handler_it);
-            conn_ctx.stream_buffers.erase(stream_id);
 
             lock.unlock();
             UnsubscribeReceived(connection_id, request_id);
@@ -1267,7 +1284,6 @@ namespace quicr {
             RemoveSubscribeNamespace(conn_ctx, *ns_handler, false, false);
             conn_ctx.request_handlers.erase(handler_it);
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.stream_buffers.erase(stream_id);
             return;
         }
 
@@ -1275,7 +1291,6 @@ namespace quicr {
             pub_ns_handler->SetStatus(PublishNamespaceHandler::Status::kNotPublished);
             conn_ctx.request_handlers.erase(handler_it);
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.stream_buffers.erase(stream_id);
             return;
         }
 
@@ -1284,13 +1299,11 @@ namespace quicr {
                                               : FetchTrackHandler::Status::kDoneByFin);
             conn_ctx.request_handlers.erase(handler_it);
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.stream_buffers.erase(stream_id);
             return;
         }
 
         conn_ctx.request_handlers.erase(handler_it);
         conn_ctx.recv_req_id.erase(request_id);
-        conn_ctx.stream_buffers.erase(stream_id);
     }
 
     void Session::UnpublishTrack(std::uint64_t conn_id, const std::shared_ptr<PublishTrackHandler>& track_handler)
@@ -1824,9 +1837,10 @@ namespace quicr {
                 break;
             }
 
-            auto& data = *data_opt.value();
-            auto cursor_it = data.begin();
-            uint64_t msg_type{ 0 };
+            auto& data = *data_opt.value(); // TODO: What's this double de-ref.
+            std::optional<std::uint64_t> initial_stream_type;
+            bool initial_data_buffered = false;
+            BytesSpan initial_cursor;
 
             // All bidir streams are requests.
             const bool is_request_stream = is_bidir;
@@ -1835,33 +1849,35 @@ namespace quicr {
             bool is_control_stream = !is_request_stream && stream_id == conn_ctx.rx_ctrl_stream_id;
 
             // Get message type if new stream
-            if (rx_ctx->is_new) {
-                auto type_sz = UintVar::Size(data.front());
-                if (data.size() < type_sz) {
-                    SPDLOG_LOGGER_WARN(logger_,
-                                       "New stream {} bidir: {} does not have enough bytes to process start of stream "
-                                       "header len: {} < {}",
-                                       stream_id,
-                                       is_bidir,
-                                       data.size(),
-                                       type_sz);
-                    i = kReadLoopMaxPerStream;
-                    continue; // Not enough bytes to process control message. Try again once more.
+            if (rx_ctx->is_new && !is_request_stream && !is_control_stream) {
+                // Store arriving data into stream's buffer.
+                rx_ctx->data_queue.PopFront();
+                auto& initial_buffer = conn_ctx.stream_buffers[stream_id];
+                initial_buffer.Push(data);
+                initial_data_buffered = true;
+
+                // Attempt to peek what type this message is.
+                initial_cursor = initial_buffer.Data();
+                initial_stream_type = TryDecodeUintV(initial_cursor);
+                if (!initial_stream_type.has_value()) {
+                    SPDLOG_LOGGER_WARN(
+                      logger_,
+                      "New stream {} bidir: {} does not have enough bytes to process start of stream yet",
+                      stream_id,
+                      is_bidir);
+                    continue;
                 }
 
                 SPDLOG_LOGGER_DEBUG(logger_,
-                                    "New stream conn_id: {} stream_id: {} bidir: {} data size: {}",
+                                    "New stream conn_id: {} stream_id: {} bidir: {} data size: {} msg_type: {}",
                                     conn_id,
                                     stream_id,
                                     is_bidir,
-                                    data.size());
-
-                msg_type = uint64_t(quicr::UintVar({ data.begin(), data.begin() + type_sz }));
-                cursor_it = std::next(data.begin(), type_sz);
+                                    initial_buffer.Size(),
+                                    *initial_stream_type);
 
                 // This might be incoming control stream arriving.
-                if (!is_request_stream && !is_control_stream &&
-                    static_cast<ControlMessageType>(msg_type) == ControlMessageType::kSetup) {
+                if (static_cast<ControlMessageType>(*initial_stream_type) == ControlMessageType::kSetup) {
                     is_control_stream = true;
                     conn_ctx.rx_ctrl_stream_id = stream_id;
                 }
@@ -1869,11 +1885,15 @@ namespace quicr {
 
             // Control or request handling.
             if (is_control_stream || is_request_stream) {
-                auto& stream_buffer = conn_ctx.stream_buffers[stream_id];
-                stream_buffer.Push(data);
+                if (!initial_data_buffered) {
+                    // Append.
+                    conn_ctx.stream_buffers[stream_id].Push(data);
+                    rx_ctx->data_queue.PopFront();
+                }
 
-                rx_ctx->data_queue.PopFront();
                 rx_ctx->is_new = false;
+
+                auto& stream_buffer = conn_ctx.stream_buffers.at(stream_id);
 
                 SPDLOG_LOGGER_DEBUG(logger_,
                                     "Transport:ControlMessageReceived conn_id: {} stream_id: {} data size: {}",
@@ -1881,53 +1901,51 @@ namespace quicr {
                                     stream_id,
                                     stream_buffer.Size());
 
+                // Parse control messages out of this stream data.
                 while (!stream_buffer.Empty()) {
-                    auto message_view = stream_buffer.Data();
+                    const auto message_data = stream_buffer.Data();
+                    auto cursor = message_data;
 
                     // Type.
-                    const auto size = UintVar::Size(message_view.front());
-                    if (message_view.size() < size) {
+                    const auto message_type = TryDecodeUintV(cursor);
+                    if (!message_type.has_value()) {
                         i = kReadLoopMaxPerStream - 4;
                         break;
                     }
-                    const auto decoded_type = static_cast<std::uint64_t>(UintVar(message_view.first(size)));
-                    const auto msg_type = static_cast<ControlMessageType>(decoded_type);
-                    message_view = message_view.subspan(size);
+                    const auto resolved_msg_type = static_cast<ControlMessageType>(*message_type);
 
-                    // Length.
-                    std::uint16_t payload_len;
-                    if (message_view.size() < sizeof(payload_len)) {
+                    // Payload length.
+                    if (cursor.size() < sizeof(std::uint16_t)) {
                         i = kReadLoopMaxPerStream - 4;
                         break;
                     }
-                    std::memcpy(&payload_len, message_view.data(), sizeof(payload_len));
+                    std::uint16_t payload_len;
+                    std::memcpy(&payload_len, cursor.data(), sizeof(payload_len));
                     payload_len = SwapBytes(payload_len);
-                    message_view = message_view.subspan(sizeof(payload_len));
 
                     // Payload.
-                    if (message_view.size() < payload_len) {
+                    cursor = cursor.subspan(sizeof(payload_len));
+                    if (cursor.size() < payload_len) {
                         i = kReadLoopMaxPerStream - 4;
                         break;
                     }
-                    const auto payload = message_view.first(payload_len);
-                    message_view = message_view.subspan(payload_len);
+                    const auto payload = cursor.first(payload_len);
+                    const auto message_size = message_data.size() - cursor.size() + payload_len;
 
-                    // Consume completed message.
-                    const auto message_size = stream_buffer.Size() - message_view.size();
                     bool processed = false;
                     try {
                         if (is_control_stream) {
-                            processed = ProcessCtrlMessage(conn_ctx, msg_type, payload);
+                            processed = ProcessCtrlMessage(conn_ctx, resolved_msg_type, payload);
                         } else if (is_request_stream) {
                             if (!data_ctx_id.has_value()) {
                                 throw std::invalid_argument("Missing data ctx id");
                             }
-                            processed = ProcessRequestMessage(conn_ctx, *data_ctx_id, msg_type, payload);
+                            processed = ProcessRequestMessage(conn_ctx, *data_ctx_id, resolved_msg_type, payload);
                         }
                     } catch (const std::exception& e) {
                         SPDLOG_LOGGER_ERROR(logger_,
                                             "Caught exception trying to process control message. (type={}, error={})",
-                                            static_cast<int>(msg_type),
+                                            static_cast<int>(resolved_msg_type),
                                             e.what());
                         CloseConnection(
                           conn_ctx.connection_id, messages::TerminationReason::kProtocolViolation, e.what());
@@ -1938,36 +1956,46 @@ namespace quicr {
                                         "Control message cannot be parsed");
                     }
 
-                    stream_buffer.Pop(message_size);
                     if (!processed) {
                         conn_ctx.metrics.invalid_ctrl_stream_msg++;
                     }
+                    stream_buffer.Pop(message_size);
                 }
                 continue;
             } // end of control message processing
 
             // DATA OBJECT
             if (rx_ctx->is_new) {
-                /*
-                 * Process data subgroup header - assume that the start of stream will always have enough bytes
-                 * for track alias
-                 */
-                SPDLOG_LOGGER_TRACE(logger_, "Received stream message type: 0x{:02x} ({})", msg_type, msg_type);
+                SPDLOG_LOGGER_TRACE(
+                  logger_, "Received stream message type: 0x{:02x} ({})", *initial_stream_type, *initial_stream_type);
 
                 bool parsed_header = false;
-                switch (GetStreamMessageType(msg_type)) {
+                auto& initial_buffer = conn_ctx.stream_buffers.at(stream_id);
+                switch (GetStreamMessageType(*initial_stream_type)) {
                     case StreamMessageType::kSubgroupHeader: {
-                        const auto properties = StreamHeaderProperties(msg_type);
-                        parsed_header = OnRecvSubgroup(properties, cursor_it, *rx_ctx, stream_id, conn_ctx, *data_opt);
+                        // Subgroup needs at least track alias decoded before handoff.
+                        const auto track_alias = TryDecodeUintV(initial_cursor);
+                        if (!track_alias.has_value()) {
+                            continue; // Need more bytes, will try again.
+                        }
+                        initial_buffer.InitAny<StreamHeaderSubGroup>(*initial_stream_type);
+                        parsed_header = OnRecvSubgroup(*track_alias, *rx_ctx, stream_id, conn_ctx);
                         break;
                     }
                     case StreamMessageType::kFetchHeader: {
-                        parsed_header = OnRecvFetch(cursor_it, *rx_ctx, stream_id, conn_ctx, *data_opt);
+                        // Fetch needs at least request ID decoded before handoff.
+                        const auto request_id = TryDecodeUintV(initial_cursor);
+                        if (!request_id.has_value()) {
+                            continue; // Need more bytes, will try again.
+                        }
+                        initial_buffer.InitAny<FetchHeader>(*initial_stream_type);
+                        parsed_header = OnRecvFetch(*request_id, *rx_ctx, stream_id, conn_ctx);
                         break;
                     }
                     default:
-                        SPDLOG_LOGGER_WARN(
-                          logger_, "Received start of stream with invalid header type {}, dropping", msg_type);
+                        SPDLOG_LOGGER_WARN(logger_,
+                                           "Received start of stream with invalid header type {}, dropping",
+                                           *initial_stream_type);
                         conn_ctx.metrics.rx_stream_invalid_type++;
 
                         // TODO(tievens): Need to reset this stream as this is invalid.
@@ -1996,8 +2024,6 @@ namespace quicr {
                     break;
                 }
 
-                rx_ctx->data_queue.PopFront();
-
             } else if (rx_ctx->caller_any.has_value()) {
                 rx_ctx->data_queue.PopFront();
 
@@ -2005,7 +2031,7 @@ namespace quicr {
                 auto sub_handler_weak = std::any_cast<std::weak_ptr<SubscribeTrackHandler>>(rx_ctx->caller_any);
                 if (auto sub_handler = sub_handler_weak.lock()) {
                     try {
-                        sub_handler->StreamDataRecv(false, stream_id, data_opt.value());
+                        sub_handler->StreamDataRecv(stream_id, *data_opt);
                     } catch (const ProtocolViolationException& e) {
                         SPDLOG_LOGGER_ERROR(logger_, "Protocol violation on stream data recv: {}", e.reason);
                         CloseConnection(conn_id, TerminationReason::kProtocolViolation, e.reason);
@@ -2041,6 +2067,10 @@ namespace quicr {
                                  StreamClosedFlag flag)
     {
         SPDLOG_LOGGER_DEBUG(logger_, "Stream {} closed", stream_id);
+
+        if (const auto conn_it = connections_.find(connection_id); conn_it != connections_.end()) {
+            conn_it->second.stream_buffers.erase(stream_id);
+        }
 
         if (data_ctx_id.has_value()) {
             try {
@@ -2078,8 +2108,6 @@ namespace quicr {
                         if (conn_ctx.tx_ctrl_stream_id.has_value() && conn_ctx.tx_ctrl_stream_id == stream_id) {
                             CloseConnection(
                               connection_id, TerminationReason::kProtocolViolation, "Primary control stream FIN");
-                        } else {
-                            conn_ctx.stream_buffers.erase(stream_id);
                         }
 
                         break;
@@ -2087,8 +2115,6 @@ namespace quicr {
                         if (conn_ctx.tx_ctrl_stream_id.has_value() && conn_ctx.tx_ctrl_stream_id == stream_id) {
                             CloseConnection(
                               connection_id, TerminationReason::kProtocolViolation, "Primary control stream RESET");
-                        } else {
-                            conn_ctx.stream_buffers.erase(stream_id);
                         }
                         break;
                 }
@@ -2132,39 +2158,11 @@ namespace quicr {
         }
     }
 
-    bool Session::OnRecvSubgroup(StreamHeaderProperties properties,
-                                 std::vector<uint8_t>::const_iterator cursor_it,
+    bool Session::OnRecvSubgroup(std::uint64_t track_alias,
                                  StreamRxContext& rx_ctx,
                                  std::uint64_t stream_id,
-                                 ConnectionContext& conn_ctx,
-                                 std::shared_ptr<const std::vector<uint8_t>> data) const
+                                 ConnectionContext& conn_ctx) const
     {
-        uint64_t track_alias = 0;
-        std::optional<uint8_t> priority;
-
-        try {
-            // First header in subgroup starts with track alias
-            auto ta_sz = UintVar::Size(*cursor_it);
-            track_alias = uint64_t(quicr::UintVar({ cursor_it, cursor_it + ta_sz }));
-            cursor_it += ta_sz;
-
-            auto group_id_sz = UintVar::Size(*cursor_it);
-            cursor_it += group_id_sz;
-
-            if (properties.subgroup_id_mode == SubgroupIdType::kExplicit) {
-                auto subgroup_id_sz = UintVar::Size(*cursor_it);
-                cursor_it += subgroup_id_sz;
-            }
-
-            if (!properties.default_priority) {
-                priority = *cursor_it;
-            }
-
-        } catch (std::invalid_argument&) {
-            SPDLOG_LOGGER_WARN(logger_, "Received start of stream without enough bytes to process uintvar");
-            return false;
-        }
-
         auto sub_it = conn_ctx.sub_by_recv_track_alias.find(track_alias);
         if ((sub_it == conn_ctx.sub_by_recv_track_alias.end() || sub_it->second == nullptr)) {
             conn_ctx.metrics.rx_stream_unknown_track_alias++;
@@ -2177,37 +2175,25 @@ namespace quicr {
             return false;
         }
 
-        rx_ctx.is_new = false;
-
-        rx_ctx.caller_any = std::make_any<std::weak_ptr<SubscribeTrackHandler>>(sub_it->second);
-        if (priority.has_value()) {
-            sub_it->second->SetPriority(*priority);
+        const auto stream_it = conn_ctx.stream_buffers.find(stream_id);
+        if (stream_it == conn_ctx.stream_buffers.end()) {
+            SPDLOG_LOGGER_ERROR(logger_, "Missing expected pending stream buffer");
+            return false;
         }
+        auto initial_buffer = std::move(stream_it->second);
+        conn_ctx.stream_buffers.erase(stream_it);
 
-        sub_it->second->StreamDataRecv(true, stream_id, std::move(data));
+        rx_ctx.is_new = false;
+        rx_ctx.caller_any = std::make_any<std::weak_ptr<SubscribeTrackHandler>>(sub_it->second);
+        sub_it->second->StreamDataRecv(stream_id, std::move(initial_buffer));
         return true;
     }
 
-    bool Session::OnRecvFetch(std::vector<uint8_t>::const_iterator cursor_it,
+    bool Session::OnRecvFetch(std::uint64_t request_id,
                               StreamRxContext& rx_ctx,
                               std::uint64_t stream_id,
-                              ConnectionContext& conn_ctx,
-                              std::shared_ptr<const std::vector<uint8_t>> data) const
+                              ConnectionContext& conn_ctx) const
     {
-        uint64_t request_id = 0;
-
-        try {
-            // Extract Subscribe ID.
-            const std::size_t sub_sz = UintVar::Size(*cursor_it);
-            request_id = static_cast<std::uint64_t>(UintVar({ cursor_it, cursor_it + sub_sz }));
-
-        } catch (std::invalid_argument&) {
-            SPDLOG_LOGGER_WARN(logger_, "Received start of stream without enough bytes to process uintvar");
-            return false;
-        }
-
-        rx_ctx.is_new = false;
-
         const auto fetch_it = conn_ctx.request_handlers.find(request_id);
         if (fetch_it == conn_ctx.request_handlers.end()) {
             // TODO: Metrics.
@@ -2221,8 +2207,17 @@ namespace quicr {
         }
 
         if (auto h = fetch_it->second.Get<SubscribeTrackHandler>()) {
-            h->StreamDataRecv(true, stream_id, std::move(data));
+            const auto stream_it = conn_ctx.stream_buffers.find(stream_id);
+            if (stream_it == conn_ctx.stream_buffers.end()) {
+                SPDLOG_LOGGER_ERROR(logger_, "Missing expected pending stream buffer");
+                return false;
+            }
+            auto initial_buffer = std::move(stream_it->second);
+            conn_ctx.stream_buffers.erase(stream_it);
+
+            rx_ctx.is_new = false;
             rx_ctx.caller_any = std::make_any<std::weak_ptr<SubscribeTrackHandler>>(h);
+            h->StreamDataRecv(stream_id, std::move(initial_buffer));
             return true;
         }
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1970,7 +1970,6 @@ namespace quicr {
                   logger_, "Received stream message type: 0x{:02x} ({})", *initial_stream_type, *initial_stream_type);
 
                 bool parsed_header = false;
-                auto& initial_buffer = conn_ctx.stream_buffers.at(stream_id);
                 switch (GetStreamMessageType(*initial_stream_type)) {
                     case StreamMessageType::kSubgroupHeader: {
                         // Subgroup needs at least track alias decoded before handoff.
@@ -1978,7 +1977,6 @@ namespace quicr {
                         if (!track_alias.has_value()) {
                             continue; // Need more bytes, will try again.
                         }
-                        initial_buffer.InitAny<StreamHeaderSubGroup>(*initial_stream_type);
                         parsed_header = OnRecvSubgroup(*track_alias, *rx_ctx, stream_id, conn_ctx);
                         break;
                     }
@@ -1988,7 +1986,6 @@ namespace quicr {
                         if (!request_id.has_value()) {
                             continue; // Need more bytes, will try again.
                         }
-                        initial_buffer.InitAny<FetchHeader>(*initial_stream_type);
                         parsed_header = OnRecvFetch(*request_id, *rx_ctx, stream_id, conn_ctx);
                         break;
                     }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1907,18 +1907,18 @@ namespace quicr {
 
                 // Parse control messages out of this stream data.
                 while (!stream_buffer.Empty()) {
-                    const auto message_data = stream_buffer.Data();
-                    auto cursor = message_data;
+                    const auto message_view = stream_buffer.Data();
+                    auto cursor = message_view;
 
                     // Type.
-                    const auto message_type = TryDecodeUintV(cursor);
-                    if (!message_type.has_value()) {
+                    const auto decoded_type = TryDecodeUintV(cursor);
+                    if (!decoded_type.has_value()) {
                         i = kReadLoopMaxPerStream - 4;
                         break;
                     }
-                    const auto resolved_msg_type = static_cast<ControlMessageType>(*message_type);
+                    const auto msg_type = static_cast<ControlMessageType>(*decoded_type);
 
-                    // Payload length.
+                    // Length.
                     std::uint16_t payload_len;
                     if (cursor.size() < sizeof(payload_len)) {
                         i = kReadLoopMaxPerStream - 4;
@@ -1935,22 +1935,22 @@ namespace quicr {
                     }
                     const auto payload = cursor.first(payload_len);
                     // Consume completed message.
-                    const auto message_size = message_data.size() - cursor.size() + payload_len;
+                    const auto message_size = message_view.size() - cursor.size() + payload_len;
 
                     bool processed = false;
                     try {
                         if (is_control_stream) {
-                            processed = ProcessCtrlMessage(conn_ctx, resolved_msg_type, payload);
+                            processed = ProcessCtrlMessage(conn_ctx, msg_type, payload);
                         } else if (is_request_stream) {
                             if (!data_ctx_id.has_value()) {
                                 throw std::invalid_argument("Missing data ctx id");
                             }
-                            processed = ProcessRequestMessage(conn_ctx, *data_ctx_id, resolved_msg_type, payload);
+                            processed = ProcessRequestMessage(conn_ctx, *data_ctx_id, msg_type, payload);
                         }
                     } catch (const std::exception& e) {
                         SPDLOG_LOGGER_ERROR(logger_,
                                             "Caught exception trying to process control message. (type={}, error={})",
-                                            static_cast<int>(resolved_msg_type),
+                                            static_cast<int>(msg_type),
                                             e.what());
                         CloseConnection(
                           conn_ctx.connection_id, messages::TerminationReason::kProtocolViolation, e.what());
@@ -1961,10 +1961,10 @@ namespace quicr {
                                         "Control message cannot be parsed");
                     }
 
+                    stream_buffer.Pop(message_size);
                     if (!processed) {
                         conn_ctx.metrics.invalid_ctrl_stream_msg++;
                     }
-                    stream_buffer.Pop(message_size);
                 }
                 continue;
             } // end of control message processing

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1198,7 +1198,7 @@ namespace quicr {
         // Incoming PUBNS requests are not handler based.
         if (std::erase(conn_ctx.recv_publish_namespaces, request_id) > 0) {
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            conn_ctx.stream_buffers.erase(stream_id);
 
             lock.unlock();
 
@@ -1215,7 +1215,7 @@ namespace quicr {
             SPDLOG_LOGGER_DEBUG(
               logger_, "Stream closed for unknown request_id conn_id: {} request_id: {}", connection_id, request_id);
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            conn_ctx.stream_buffers.erase(stream_id);
             return;
         }
 
@@ -1243,7 +1243,7 @@ namespace quicr {
             }
 
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            conn_ctx.stream_buffers.erase(stream_id);
 
             lock.unlock();
             UnsubscribeReceived(connection_id, request_id);
@@ -1255,7 +1255,7 @@ namespace quicr {
 
             ClosePublishTrackLocal(conn_ctx, connection_id, *pub_handler, stream_id, is_reset);
             conn_ctx.request_handlers.erase(handler_it);
-            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            conn_ctx.stream_buffers.erase(stream_id);
 
             lock.unlock();
             UnsubscribeReceived(connection_id, request_id);
@@ -1267,7 +1267,7 @@ namespace quicr {
             RemoveSubscribeNamespace(conn_ctx, *ns_handler, false, false);
             conn_ctx.request_handlers.erase(handler_it);
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            conn_ctx.stream_buffers.erase(stream_id);
             return;
         }
 
@@ -1275,7 +1275,7 @@ namespace quicr {
             pub_ns_handler->SetStatus(PublishNamespaceHandler::Status::kNotPublished);
             conn_ctx.request_handlers.erase(handler_it);
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            conn_ctx.stream_buffers.erase(stream_id);
             return;
         }
 
@@ -1284,13 +1284,13 @@ namespace quicr {
                                               : FetchTrackHandler::Status::kDoneByFin);
             conn_ctx.request_handlers.erase(handler_it);
             conn_ctx.recv_req_id.erase(request_id);
-            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+            conn_ctx.stream_buffers.erase(stream_id);
             return;
         }
 
         conn_ctx.request_handlers.erase(handler_it);
         conn_ctx.recv_req_id.erase(request_id);
-        conn_ctx.ctrl_msg_buffer.erase(stream_id);
+        conn_ctx.stream_buffers.erase(stream_id);
     }
 
     void Session::UnpublishTrack(std::uint64_t conn_id, const std::shared_ptr<PublishTrackHandler>& track_handler)
@@ -1869,8 +1869,8 @@ namespace quicr {
 
             // Control or request handling.
             if (is_control_stream || is_request_stream) {
-                auto& ctrl_msg_buffer = conn_ctx.ctrl_msg_buffer[stream_id];
-                ctrl_msg_buffer.data.insert(ctrl_msg_buffer.data.end(), data.begin(), data.end());
+                auto& stream_buffer = conn_ctx.stream_buffers[stream_id];
+                stream_buffer.Push(data);
 
                 rx_ctx->data_queue.PopFront();
                 rx_ctx->is_new = false;
@@ -1879,47 +1879,50 @@ namespace quicr {
                                     "Transport:ControlMessageReceived conn_id: {} stream_id: {} data size: {}",
                                     conn_id,
                                     stream_id,
-                                    ctrl_msg_buffer.data.size());
+                                    stream_buffer.Size());
 
-                while (ctrl_msg_buffer.data.size() > 0) {
-                    if (ctrl_msg_buffer.data.size() < UintVar::Size(ctrl_msg_buffer.data.front())) {
+                while (!stream_buffer.Empty()) {
+                    auto message_view = stream_buffer.Data();
+
+                    // Type.
+                    const auto size = UintVar::Size(message_view.front());
+                    if (message_view.size() < size) {
                         i = kReadLoopMaxPerStream - 4;
                         break;
                     }
+                    const auto decoded_type = static_cast<std::uint64_t>(UintVar(message_view.first(size)));
+                    const auto msg_type = static_cast<ControlMessageType>(decoded_type);
+                    message_view = message_view.subspan(size);
 
-                    const auto type_sz = UintVar::Size(ctrl_msg_buffer.data.front());
-                    const auto msg_type = static_cast<ControlMessageType>(static_cast<uint64_t>(
-                      UintVar({ ctrl_msg_buffer.data.data(), ctrl_msg_buffer.data.data() + type_sz })));
-
-                    uint16_t payload_len = 0;
-
-                    if (ctrl_msg_buffer.data.size() < type_sz + sizeof(payload_len)) {
+                    // Length.
+                    std::uint16_t payload_len;
+                    if (message_view.size() < sizeof(payload_len)) {
                         i = kReadLoopMaxPerStream - 4;
                         break;
                     }
-
-                    std::memcpy(&payload_len, ctrl_msg_buffer.data.data() + type_sz, sizeof(payload_len));
+                    std::memcpy(&payload_len, message_view.data(), sizeof(payload_len));
                     payload_len = SwapBytes(payload_len);
+                    message_view = message_view.subspan(sizeof(payload_len));
 
-                    const auto message_size = type_sz + sizeof(payload_len) + payload_len;
-                    if (ctrl_msg_buffer.data.size() < message_size) {
+                    // Payload.
+                    if (message_view.size() < payload_len) {
                         i = kReadLoopMaxPerStream - 4;
                         break;
                     }
+                    const auto payload = message_view.first(payload_len);
+                    message_view = message_view.subspan(payload_len);
 
-                    const auto payload_begin = ctrl_msg_buffer.data.begin() + type_sz + sizeof(payload_len);
-                    const auto payload_end = payload_begin + payload_len;
-
+                    // Consume completed message.
+                    const auto message_size = stream_buffer.Size() - message_view.size();
                     bool processed = false;
                     try {
                         if (is_control_stream) {
-                            processed = ProcessCtrlMessage(conn_ctx, msg_type, { payload_begin, payload_end });
+                            processed = ProcessCtrlMessage(conn_ctx, msg_type, payload);
                         } else if (is_request_stream) {
                             if (!data_ctx_id.has_value()) {
                                 throw std::invalid_argument("Missing data ctx id");
                             }
-                            processed =
-                              ProcessRequestMessage(conn_ctx, *data_ctx_id, msg_type, { payload_begin, payload_end });
+                            processed = ProcessRequestMessage(conn_ctx, *data_ctx_id, msg_type, payload);
                         }
                     } catch (const std::exception& e) {
                         SPDLOG_LOGGER_ERROR(logger_,
@@ -1935,13 +1938,9 @@ namespace quicr {
                                         "Control message cannot be parsed");
                     }
 
-                    if (processed) {
-                        ctrl_msg_buffer.data.erase(ctrl_msg_buffer.data.begin(),
-                                                   ctrl_msg_buffer.data.begin() + message_size);
-                    } else {
+                    stream_buffer.Pop(message_size);
+                    if (!processed) {
                         conn_ctx.metrics.invalid_ctrl_stream_msg++;
-                        ctrl_msg_buffer.data.erase(ctrl_msg_buffer.data.begin(),
-                                                   ctrl_msg_buffer.data.begin() + message_size);
                     }
                 }
                 continue;
@@ -2080,7 +2079,7 @@ namespace quicr {
                             CloseConnection(
                               connection_id, TerminationReason::kProtocolViolation, "Primary control stream FIN");
                         } else {
-                            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+                            conn_ctx.stream_buffers.erase(stream_id);
                         }
 
                         break;
@@ -2089,7 +2088,7 @@ namespace quicr {
                             CloseConnection(
                               connection_id, TerminationReason::kProtocolViolation, "Primary control stream RESET");
                         } else {
-                            conn_ctx.ctrl_msg_buffer.erase(stream_id);
+                            conn_ctx.stream_buffers.erase(stream_id);
                         }
                         break;
                 }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1861,7 +1861,7 @@ namespace quicr {
                 initial_cursor = initial_buffer.buffer.Data();
                 initial_stream_type = TryDecodeUintV(initial_cursor);
                 if (!initial_stream_type.has_value()) {
-                    SPDLOG_LOGGER_WARN(
+                    SPDLOG_LOGGER_DEBUG(
                       logger_,
                       "New stream {} bidir: {} does not have enough bytes to process start of stream yet",
                       stream_id,

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -24,44 +24,50 @@ namespace quicr {
     {
     }
 
-    void SubscribeTrackHandler::StreamDataRecv(bool is_start,
-                                               uint64_t stream_id,
-                                               std::shared_ptr<const std::vector<uint8_t>> data)
+    void SubscribeTrackHandler::StreamDataRecv(uint64_t stream_id, StreamBuffer<uint8_t>&& initial_buffer)
     {
-        auto& stream = streams_[stream_id];
-
-        if (is_start) {
-            stream.buffer.Clear();
-
-            stream.buffer.InitAny<messages::StreamHeaderSubGroup>();
-            stream.buffer.Push(*data);
-
-            // Expect that on initial start of stream, there is enough data to process the stream headers
-
-            auto& s_hdr = stream.buffer.GetAny<messages::StreamHeaderSubGroup>();
-            if (not(stream.buffer >> s_hdr)) {
-                SPDLOG_ERROR("Not enough data to process new stream headers, stream is invalid");
-                // TODO: Add metrics to track this
-                return;
-            }
-        } else {
-            stream.buffer.Push(*data);
+        auto [it, inserted] = streams_.try_emplace(stream_id, std::move(initial_buffer));
+        if (!inserted) {
+            SPDLOG_ERROR("StreamDataRecv got new stream for existing Stream ID {}", stream_id);
+            return;
         }
+        TryParseStreamBufferData(it->second);
+    }
 
-        TryParseStreamBufferData(stream);
+    void SubscribeTrackHandler::StreamDataRecv(uint64_t stream_id, std::shared_ptr<const std::vector<uint8_t>> data)
+    {
+        const auto it = streams_.find(stream_id);
+        if (it == streams_.end()) {
+            SPDLOG_ERROR("StreamDataRecv had no stream for expected Stream ID {}", stream_id);
+            return;
+        }
+        it->second.buffer.Push(*data);
+        TryParseStreamBufferData(it->second);
     }
 
     void SubscribeTrackHandler::TryParseStreamBufferData(StreamContext& stream)
     {
         auto& s_hdr = stream.buffer.GetAny<messages::StreamHeaderSubGroup>();
-
-        if (not stream.buffer.AnyHasValueB()) {
-            stream.buffer.InitAnyB<messages::StreamSubGroupObject>();
+        if (not(stream.buffer >> s_hdr)) {
+            return;
         }
 
-        auto& obj = stream.buffer.GetAnyB<messages::StreamSubGroupObject>();
-        obj.properties.emplace(*s_hdr.properties);
-        if (stream.buffer >> obj) {
+        // TODO: This shouldn't override subscriber priority, but keeping existing behaviour.
+        if (s_hdr.priority.has_value()) {
+            SetPriority(*s_hdr.priority);
+        }
+
+        while (not stream.buffer.Empty()) {
+            if (not stream.buffer.AnyHasValueB()) {
+                stream.buffer.InitAnyB<messages::StreamSubGroupObject>();
+            }
+
+            auto& obj = stream.buffer.GetAnyB<messages::StreamSubGroupObject>();
+            obj.properties.emplace(*s_hdr.properties);
+            if (not(stream.buffer >> obj)) {
+                return;
+            }
+
             std::optional<messages::StreamHeaderProperties> stream_properties;
             if (!stream.next_object_id.has_value()) {
                 stream_properties.emplace(*s_hdr.properties);
@@ -122,7 +128,7 @@ namespace quicr {
                 SPDLOG_ERROR("Caught exception trying to receive Subscribe object. (error={})", e.what());
             }
 
-            stream.buffer.ResetAnyB<messages::StreamSubGroupObject>();
+            stream.buffer.ResetAnyB();
         }
     }
 

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -26,7 +26,8 @@ namespace quicr {
 
     void SubscribeTrackHandler::StreamDataRecv(uint64_t stream_id, InitialStreamData&& initial_buffer)
     {
-        auto [it, inserted] = streams_.try_emplace(stream_id, std::move(initial_buffer.buffer));
+        auto [it, inserted] =
+          streams_.try_emplace(stream_id, StreamContext{ .buffer = std::move(initial_buffer.buffer) });
         if (!inserted) {
             SPDLOG_ERROR("StreamDataRecv got new stream for existing Stream ID {}", stream_id);
             return;

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -24,9 +24,9 @@ namespace quicr {
     {
     }
 
-    void SubscribeTrackHandler::StreamDataRecv(uint64_t stream_id, StreamBuffer<uint8_t>&& initial_buffer)
+    void SubscribeTrackHandler::StreamDataRecv(uint64_t stream_id, InitialStreamData&& initial_buffer)
     {
-        auto [it, inserted] = streams_.try_emplace(stream_id, std::move(initial_buffer));
+        auto [it, inserted] = streams_.try_emplace(stream_id, std::move(initial_buffer.buffer));
         if (!inserted) {
             SPDLOG_ERROR("StreamDataRecv got new stream for existing Stream ID {}", stream_id);
             return;

--- a/src/subscribe_track_handler.cpp
+++ b/src/subscribe_track_handler.cpp
@@ -47,6 +47,10 @@ namespace quicr {
 
     void SubscribeTrackHandler::TryParseStreamBufferData(StreamContext& stream)
     {
+        if (not stream.buffer.AnyHasValue()) {
+            stream.buffer.InitAny<messages::StreamHeaderSubGroup>();
+        }
+
         auto& s_hdr = stream.buffer.GetAny<messages::StreamHeaderSubGroup>();
         if (not(stream.buffer >> s_hdr)) {
             return;

--- a/test/integration_test/integration_test.cpp
+++ b/test/integration_test/integration_test.cpp
@@ -1573,6 +1573,42 @@ TEST_CASE("Integration - Subgroup and Stream Testing")
     }
 }
 
+TEST_CASE("Integration - Small data callbacks assemble")
+{
+    // Create with 1 byte window.
+    auto server = MakeTestServer(std::nullopt, 2, 1);
+    auto subscriber = MakeTestClient();
+    auto publisher = MakeTestClient();
+
+    // Pub.
+    const FullTrackName ftn{ TrackNamespace(std::vector<std::string>{ "small", "callbacks" }), { 1 } };
+    auto publish_handler = PublishTrackHandler::Create(ftn, TrackMode::kStream, 3, 5000, { 0, 0 });
+    publisher->PublishTrack(publish_handler);
+    REQUIRE(WaitFor([&publish_handler] { return publish_handler->CanPublish(); }));
+
+    // Sub.
+    auto subscribe_handler = TestSubscribeHandler::Create(ftn, 3, std::nullopt);
+    std::promise<void> received_promise;
+    auto received_future = received_promise.get_future();
+    subscribe_handler->SetObjectCountPromise(1, std::move(received_promise));
+    subscriber->SubscribeTrack(subscribe_handler);
+    REQUIRE(
+      WaitFor([&subscribe_handler] { return subscribe_handler->GetStatus() == SubscribeTrackHandler::Status::kOk; }));
+
+    // Roundtrip.
+    const std::vector<std::uint8_t> payload(64, 0x5a);
+    const ObjectHeaders headers{ .group_id = 0,
+                                 .object_id = 0,
+                                 .subgroup_id = 0,
+                                 .payload_length = payload.size(),
+                                 .status = ObjectStatus::kAvailable,
+                                 .priority = 3,
+                                 .ttl = 5000,
+                                 .track_mode = TrackMode::kStream };
+    REQUIRE_EQ(publish_handler->PublishObject(headers, payload), PublishTrackHandler::PublishObjectStatus::kOk);
+    CHECK(received_future.wait_for(kDefaultTimeout) == std::future_status::ready);
+}
+
 TEST_CASE("Integration - Failed publish does not create subgroup state")
 {
     // Setup a subscriber and publisher.

--- a/test/track_handlers.cpp
+++ b/test/track_handlers.cpp
@@ -69,9 +69,106 @@ class TestSubscribeTrackHandler : public quicr::SubscribeTrackHandler
         status_received_count++;
     }
 
+    void ObjectReceived(const quicr::ObjectHeaders& object_headers,
+                        quicr::BytesSpan data,
+                        std::optional<quicr::messages::StreamHeaderProperties> stream_mode) override
+    {
+        received_objects.push_back({ object_headers.group_id,
+                                     object_headers.object_id,
+                                     quicr::Bytes(data.begin(), data.end()),
+                                     std::move(stream_mode) });
+    }
+
+    struct ReceivedObject
+    {
+        uint64_t group_id;
+        uint64_t object_id;
+        quicr::Bytes payload;
+        std::optional<quicr::messages::StreamHeaderProperties> stream_mode;
+    };
+
     std::optional<ReceivedStatus> last_status;
     int status_received_count{ 0 };
+    std::vector<ReceivedObject> received_objects;
 };
+
+/**
+ * @brief A subgroup header followed by two objects, as it arrives on the wire.
+ */
+static quicr::Bytes
+SerializeSubgroup(const quicr::messages::StreamHeaderProperties& properties)
+{
+    quicr::messages::StreamHeaderSubGroup header;
+    header.properties.emplace(properties);
+    header.track_alias = 0x1234;
+    header.group_id = 7;
+    header.priority = 128;
+
+    quicr::Bytes bytes;
+    bytes << header;
+
+    for (const auto& payload : { quicr::Bytes{ 0x0A, 0x0B }, quicr::Bytes{ 0x0C, 0x0D } }) {
+        quicr::messages::StreamSubGroupObject object;
+        object.properties.emplace(properties);
+        object.object_delta = 0;
+        object.payload = payload;
+        bytes << object;
+    }
+
+    return bytes;
+}
+
+TEST_CASE("Subscribe Track Handler receives every object buffered on a stream")
+{
+    auto handler = TestSubscribeTrackHandler::Create();
+
+    const quicr::messages::StreamHeaderProperties properties{
+        false, quicr::messages::SubgroupIdType::kIsZero, false, false, true
+    };
+
+    // Mirror the session handoff: the stream type stays in the buffer for the handler to parse.
+    quicr::StreamBuffer<uint8_t> buffer;
+    buffer.InitAny<quicr::messages::StreamHeaderSubGroup>(properties.GetType());
+    buffer.Push(SerializeSubgroup(properties));
+    handler->StreamDataRecv(0, std::move(buffer));
+
+    REQUIRE_EQ(handler->received_objects.size(), 2);
+
+    CHECK_EQ(handler->received_objects[0].group_id, 7);
+    CHECK_EQ(handler->received_objects[0].object_id, 0);
+    CHECK_EQ(handler->received_objects[0].payload, quicr::Bytes{ 0x0A, 0x0B });
+    CHECK(handler->received_objects[0].stream_mode.has_value());
+
+    CHECK_EQ(handler->received_objects[1].group_id, 7);
+    CHECK_EQ(handler->received_objects[1].object_id, 1);
+    CHECK_EQ(handler->received_objects[1].payload, quicr::Bytes{ 0x0C, 0x0D });
+    CHECK_FALSE(handler->received_objects[1].stream_mode.has_value());
+}
+
+TEST_CASE("Subscribe Track Handler resumes parsing across single byte chunks")
+{
+    auto handler = TestSubscribeTrackHandler::Create();
+
+    const quicr::messages::StreamHeaderProperties properties{
+        false, quicr::messages::SubgroupIdType::kIsZero, false, false, true
+    };
+    const auto bytes = SerializeSubgroup(properties);
+
+    quicr::StreamBuffer<uint8_t> buffer;
+    buffer.InitAny<quicr::messages::StreamHeaderSubGroup>(properties.GetType());
+    buffer.Push(bytes.front());
+    handler->StreamDataRecv(0, std::move(buffer));
+
+    for (auto it = std::next(bytes.begin()); it != bytes.end(); ++it) {
+        handler->StreamDataRecv(0, std::make_shared<std::vector<uint8_t>>(1, *it));
+    }
+
+    REQUIRE_EQ(handler->received_objects.size(), 2);
+    CHECK_EQ(handler->received_objects[0].object_id, 0);
+    CHECK_EQ(handler->received_objects[0].payload, quicr::Bytes{ 0x0A, 0x0B });
+    CHECK_EQ(handler->received_objects[1].object_id, 1);
+    CHECK_EQ(handler->received_objects[1].payload, quicr::Bytes{ 0x0C, 0x0D });
+}
 
 TEST_CASE("Subscribe Track Handler ObjectStatusReceived - kDoesNotExist")
 {

--- a/test/track_handlers.cpp
+++ b/test/track_handlers.cpp
@@ -129,7 +129,7 @@ TEST_CASE("Subscribe Track Handler receives every object buffered on a stream")
     // Mirror the session handoff: the stream type stays in the buffer for the handler to parse.
     quicr::StreamBuffer<uint8_t> buffer;
     buffer.Push(SerializeSubgroup(properties));
-    handler->StreamDataRecv(0, std::move(buffer));
+    handler->StreamDataRecv(0, { std::move(buffer), {} });
 
     REQUIRE_EQ(handler->received_objects.size(), 2);
 
@@ -155,7 +155,7 @@ TEST_CASE("Subscribe Track Handler resumes parsing across single byte chunks")
 
     quicr::StreamBuffer<uint8_t> buffer;
     buffer.Push(bytes.front());
-    handler->StreamDataRecv(0, std::move(buffer));
+    handler->StreamDataRecv(0, { std::move(buffer), {} });
 
     for (auto it = std::next(bytes.begin()); it != bytes.end(); ++it) {
         handler->StreamDataRecv(0, std::make_shared<std::vector<uint8_t>>(1, *it));

--- a/test/track_handlers.cpp
+++ b/test/track_handlers.cpp
@@ -128,7 +128,6 @@ TEST_CASE("Subscribe Track Handler receives every object buffered on a stream")
 
     // Mirror the session handoff: the stream type stays in the buffer for the handler to parse.
     quicr::StreamBuffer<uint8_t> buffer;
-    buffer.InitAny<quicr::messages::StreamHeaderSubGroup>(properties.GetType());
     buffer.Push(SerializeSubgroup(properties));
     handler->StreamDataRecv(0, std::move(buffer));
 
@@ -155,7 +154,6 @@ TEST_CASE("Subscribe Track Handler resumes parsing across single byte chunks")
     const auto bytes = SerializeSubgroup(properties);
 
     quicr::StreamBuffer<uint8_t> buffer;
-    buffer.InitAny<quicr::messages::StreamHeaderSubGroup>(properties.GetType());
     buffer.Push(bytes.front());
     handler->StreamDataRecv(0, std::move(buffer));
 


### PR DESCRIPTION
Accumulate fragmented stream start up until routable to handlers. For subscribe, this is track alias, for fetch, request ID. 

Pending non-routable bytes accumulate into the stream buffer into session, and are then move'd into the handler to parse. On non-stream start, the existing shared_ptr data path is taken to accumulate into the buffer now owned by the handler. On steam start, the initial event contains both the buffer with the routable bytes, and the original data ptrs, should a consumer (laps) want them for forwarding. libquicr itself doesn't use them, just provides them. 