### PR TITLE
Thread safe connection delegate

### DIFF
--- a/include/quicr/connection.h
+++ b/include/quicr/connection.h
@@ -7,12 +7,14 @@
 #include "quicr/metrics.h"
 #include "quicr/track_name.h"
 #include "quicr/utilities/bytes.h"
+#include "quicr/utilities/thread_safety.h"
 
 #include <atomic>
 #include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 namespace quicr {
@@ -137,8 +139,6 @@ namespace quicr {
       public:
         Connection(std::uint64_t id, API api = API::kNativeQuic);
 
-        Connection(const Connection& other) = default;
-
         virtual ~Connection() = default;
 
         std::uint64_t GetID() const noexcept;
@@ -212,6 +212,8 @@ namespace quicr {
         ConnectionMetrics metrics{};
 
       protected:
+        std::shared_ptr<Delegate> GetDelegate() const;
+
         std::uint64_t id{ 0 };
 
         /// The API the connection uses. Default is Native Quic.
@@ -219,6 +221,7 @@ namespace quicr {
 
         Status status_;
 
-        std::weak_ptr<Delegate> delegate_;
+        mutable std::mutex delegate_mutex_;
+        std::weak_ptr<Delegate> delegate_ QUICR_GUARDED_BY(delegate_mutex_);
     };
 }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -52,7 +52,10 @@ namespace quicr {
 
     void Connection::SetDelegate(const std::shared_ptr<Delegate>& delegate)
     {
-        delegate_ = delegate;
+        {
+            std::lock_guard lock(delegate_mutex_);
+            delegate_ = delegate;
+        }
 
         if (delegate && status_ != Status::kConnecting) {
             // Replay the current status in case transport notifications were delivered
@@ -61,16 +64,22 @@ namespace quicr {
         }
     }
 
+    std::shared_ptr<Connection::Delegate> Connection::GetDelegate() const
+    {
+        std::lock_guard lock(delegate_mutex_);
+        return delegate_.lock();
+    }
+
     void Connection::OnStatusChanged(Status status)
     {
-        if (auto delegate = delegate_.lock()) {
+        if (auto delegate = GetDelegate()) {
             delegate->OnConnectionStatus(status);
         }
     }
 
     void Connection::OnRecvDgram()
     {
-        if (auto delegate = delegate_.lock()) {
+        if (auto delegate = GetDelegate()) {
             delegate->OnRecvDgram();
         }
     }
@@ -80,7 +89,7 @@ namespace quicr {
                                   const std::shared_ptr<Stream>& stream,
                                   bool is_bidir)
     {
-        if (auto delegate = delegate_.lock()) {
+        if (auto delegate = GetDelegate()) {
             delegate->OnRecvStream(stream_id, rx_ctx, stream, is_bidir);
         }
     }
@@ -89,7 +98,7 @@ namespace quicr {
                                     std::shared_ptr<StreamRxContext> rx_ctx,
                                     StreamClosedFlag flag)
     {
-        if (auto delegate = delegate_.lock()) {
+        if (auto delegate = GetDelegate()) {
             delegate->OnStreamClosed(stream_id, std::move(rx_ctx), flag);
         }
     }

--- a/src/picoquic_connection.cpp
+++ b/src/picoquic_connection.cpp
@@ -40,7 +40,7 @@ quicr::PicoQuicConnection::TakeMetricsSample()
 void
 quicr::PicoQuicConnection::ReportMetricsSample(const MetricsTimeStamp& sample_time, const QuicMetricsSample& sample)
 {
-    auto delegate = delegate_.lock();
+    auto delegate = GetDelegate();
     if (!delegate) {
         return;
     }


### PR DESCRIPTION
I think this needs a mutex because the weak_ptr instance *itself* can be unset by an app thread calling `Session::Disconnect` while notifiers are running.

Random aside, seems my mac's clang doesn't seem to have std::atomic<std::weak_ptr>> even though it's in C++20? Shame. 